### PR TITLE
media_libva: fix iHD decoder dump NV12 format UV error issue.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -4297,7 +4297,11 @@ VAStatus DdiMedia_CreateImage(
         pVAImg->format.bits_per_pixel    = format->bits_per_pixel;
         pVAImg->width                    = width;
         pVAImg->height                   = height;
-        pVAImg->data_size                = iPitch * height * 3 / 2;
+#if UFO_GRALLOC_NEW_FORMAT
+        pVAImg->data_size                = iPitch *  MOS_ALIGN_CEIL(height,64) * 3 / 2;
+#else
+        pVAImg->data_size                = iPitch *  MOS_ALIGN_CEIL(height,32) * 3 / 2;
+#endif
         pVAImg->num_planes               = 2;
         pVAImg->pitches[0]               = iPitch;
         pVAImg->pitches[1]               =


### PR DESCRIPTION
iHD decoder dump NV12 U/V date is wrong, root casue is when calc data
size, need tp celing the width with 32 or 64.

Signed-off-by: Jun Zhao <jun.zhao@intel.com>