### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ CNL (Cannonlake)
 | HEVC       |  D  | SKL/CNL     |
 | HEVC       |  E  | SKL         |
 | HEVC 10bit |  D  | CNL         |
+| VP9        |  D  | CNL         |
 | VP9 10bit  |  D  | CNL         |
 
 


### PR DESCRIPTION
CNL also supports VP9 profile 0 (8bit, 4:2:0) HW decode.