### PR TITLE
libva_caps: adjust numAttribs when max num is exceeded

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -1994,18 +1994,18 @@ VAStatus MediaLibvaCaps::QuerySurfaceAttributes(
         return VA_STATUS_ERROR_UNIMPLEMENTED;
     }
 
-    if (i <= *numAttribs)
+    if (i > *numAttribs)
     {
-        MOS_SecureMemcpy(attribList, i * sizeof(*attribs), attribs, i * sizeof(*attribs));
         *numAttribs = i;
         MOS_FreeMemory(attribs);
-        return status;
-
-    }
-    else
-    {
         return VA_STATUS_ERROR_MAX_NUM_EXCEEDED;
     }
+
+    *numAttribs = i;
+    MOS_SecureMemcpy(attribList, i * sizeof(*attribs), attribs, i * sizeof(*attribs));
+
+    MOS_FreeMemory(attribs);
+    return status;
 }
 
 bool MediaLibvaCaps::IsVc1Profile(VAProfile profile)


### PR DESCRIPTION
Per va.h documentation, vaQuerySurfaceAttributes must
adjust numAttribs when VA_STATUS_ERROR_MAX_NUM_EXCEEDED.

Fixes #12

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>