### PR TITLE
Fix the build warning about ‘if’ clause does not guard.

### DIFF
--- a/media_driver/agnostic/common/cm/cm_queue_rt.cpp
+++ b/media_driver/agnostic/common/cm/cm_queue_rt.cpp
@@ -1077,7 +1077,7 @@ finish:
         if(pGPUCopyTask)                    m_pDevice->DestroyTask(pGPUCopyTask);
         if(pBufferUP)                       m_pDevice->DestroyBufferUP(pBufferUP);
         if(pHybridCopyAuxBufferUP)          m_pDevice->DestroyBufferUP(pHybridCopyAuxBufferUP);
-        if(pHybridCopyAuxSysMem)            MOS_AlignedFreeMemory(pHybridCopyAuxSysMem); pHybridCopyAuxSysMem = nullptr;
+        if(pHybridCopyAuxSysMem)            { MOS_AlignedFreeMemory(pHybridCopyAuxSysMem); pHybridCopyAuxSysMem = nullptr; }
     }
 
     return hr;


### PR DESCRIPTION
fix the build warning: this ‘if’ clause does not guard.

Signed-off-by: Jun Zhao <jun.zhao@intel.com>