### PR TITLE
Only fill the uninitialized EUCount/SliceCount/SubSliceCount to fix t…

### DIFF
--- a/media_driver/linux/gen10/ddi/media_sysinfo_g10.cpp
+++ b/media_driver/linux/gen10/ddi/media_sysinfo_g10.cpp
@@ -45,12 +45,18 @@ static bool InitGen10MediaSysInfo(struct GfxDeviceInfo *devInfo, MEDIA_GT_SYSTEM
         return false;
     }
 
-    if (!sysInfo->SliceCount ||
-        !sysInfo->SubSliceCount ||
-        !sysInfo->EUCount)
+    if (!sysInfo->SliceCount)
     {
         sysInfo->SliceCount    = devInfo->SliceCount;
+    }
+
+    if (!sysInfo->SubSliceCount)
+    {
         sysInfo->SubSliceCount = devInfo->SubSliceCount;
+    }
+
+    if (!sysInfo->EUCount)
+    {
         sysInfo->EUCount       = devInfo->EUCount;
     }
 

--- a/media_driver/linux/gen8/ddi/media_sysinfo_g8.cpp
+++ b/media_driver/linux/gen8/ddi/media_sysinfo_g8.cpp
@@ -40,12 +40,18 @@ static bool InitBdwMediaSysInfo(struct GfxDeviceInfo *devInfo, MEDIA_GT_SYSTEM_I
         return false;
     }
 
-    if (!sysInfo->SliceCount ||
-        !sysInfo->SubSliceCount ||
-        !sysInfo->EUCount)
+    if (!sysInfo->SliceCount)
     {
         sysInfo->SliceCount    = devInfo->SliceCount;
+    }
+
+    if (!sysInfo->SubSliceCount)
+    {
         sysInfo->SubSliceCount = devInfo->SubSliceCount;
+    }
+
+    if (!sysInfo->EUCount)
+    {
         sysInfo->EUCount       = devInfo->EUCount;
     }
 

--- a/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
@@ -43,12 +43,18 @@ static bool InitGen9MediaSysInfo(struct GfxDeviceInfo *devInfo, MEDIA_GT_SYSTEM_
         return false;
     }
 
-    if (!sysInfo->SliceCount ||
-        !sysInfo->SubSliceCount ||
-        !sysInfo->EUCount)
+    if (!sysInfo->SliceCount)
     {
         sysInfo->SliceCount    = devInfo->SliceCount;
+    }
+
+    if (!sysInfo->SubSliceCount)
+    {
         sysInfo->SubSliceCount = devInfo->SubSliceCount;
+    }
+
+    if (!sysInfo->EUCount)
+    {
         sysInfo->EUCount       = devInfo->EUCount;
     }
 
@@ -177,12 +183,18 @@ static bool InitLCIAMediaSysInfo(struct GfxDeviceInfo *devInfo, MEDIA_GT_SYSTEM_
         return false;
     }
 
-    if (!sysInfo->SliceCount ||
-        !sysInfo->SubSliceCount ||
-        !sysInfo->EUCount)
+    if (!sysInfo->SliceCount)
     {
         sysInfo->SliceCount    = devInfo->SliceCount;
+    }
+
+    if (!sysInfo->SubSliceCount)
+    {
         sysInfo->SubSliceCount = devInfo->SubSliceCount;
+    }
+
+    if (!sysInfo->EUCount)
+    {
         sysInfo->EUCount       = devInfo->EUCount;
     }
 


### PR DESCRIPTION
…he incorrect EU count

It is mentioned that some particular skus produced may have one EU disabled as
mentioned in
The https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-skl-vol04-configurations.pdf - "

The current code will reintialize EUCount/SliceCount/SubSliceCount even when
only one of them is not initialized.

Fix https://github.com/intel/media-driver/issues/26

Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>