### PR TITLE
Make the vendor string more descriptive

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.h
+++ b/media_driver/linux/common/ddi/media_libva.h
@@ -62,7 +62,7 @@
 #define DDI_CODEC_GEN_MAX_ATTRIBS_TYPE             4    //VAConfigAttribRTFormat,    VAConfigAttribRateControl,    VAConfigAttribDecSliceMode,    VAConfigAttribEncPackedHeaders
 
 #define DDI_CODEC_GEN_MAX_SURFACE_ATTRIBUTES       17   // Use the same value as I965  
-#define DDI_CODEC_GEN_STR_VENDOR                   UFO_VERSION
+#define DDI_CODEC_GEN_STR_VENDOR                   "Intel iHD driver - " UFO_VERSION
 
 #define DDI_CODEC_GET_VTABLE(ctx)                  (ctx->vtable)
 #define DDI_CODEC_GET_VTABLE_VPP(ctx)              (ctx->vtable_vpp)


### PR DESCRIPTION
This adds "Intel iHD driver" so that the driver can be identified from the vendor string.

The i965 driver also includes the platform and more version information (e.g. "Intel i965 driver for Intel(R) Kaby Lake - 2.0.1.pre1 (2.0.0-20-g76d9e59)"), but that is somewhat more involved to obtain and really the driver name is the most important thing.