### PR TITLE
dynamic register recon/ref surfaces for encode

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_fei_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_fei_avc.cpp
@@ -274,6 +274,8 @@ VAStatus DdiEncodeAvcFei::EncodeInCodecHal(uint32_t numSlices)
         encodeParams->pBSBuffer      = m_encodeCtx->pbsBuffer;
         encodeParams->pSlcHeaderData = (void *)m_encodeCtx->pSliceHeaderData;
         encodeParams->pFeiPicParams  = (CodecEncodeAvcFeiPicParams *)(m_encodeCtx->pFeiPicParams);
+        //clear registered recon/ref surface flags
+        DDI_CHK_RET(ClearRefList(&m_encodeCtx->RTtbl, true), "ClearRefList failed!");
     }
 
     status = m_encodeCtx->pCodecHal->Execute(encodeParams);

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_fei_hevc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_fei_hevc.cpp
@@ -120,6 +120,9 @@ VAStatus DdiEncodeHevcFei::EncodeInCodecHal(uint32_t numSlices)
 
     DdiMedia_MediaSurfaceToMosResource(rtTbl->pCurrentReconTarget, &(reconSurface.OsResource));
 
+    //clear registered recon/ref surface flags
+    DDI_CHK_RET(ClearRefList(&m_encodeCtx->RTtbl, true), "ClearRefList failed!");
+
     // Bitstream surface
     MOS_RESOURCE bitstreamSurface;
     MOS_ZeroMemory(&bitstreamSurface, sizeof(bitstreamSurface));

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.cpp
@@ -290,6 +290,9 @@ VAStatus DdiEncodeHevc::EncodeInCodecHal(uint32_t numSlices)
 
     DdiMedia_MediaSurfaceToMosResource(rtTbl->pCurrentReconTarget, &(reconSurface.OsResource));
 
+    //clear registered recon/ref surface flags
+    DDI_CHK_RET(ClearRefList(&m_encodeCtx->RTtbl, true), "ClearRefList failed!");
+
     // Bitstream surface
     MOS_RESOURCE bitstreamSurface;
     MOS_ZeroMemory(&bitstreamSurface, sizeof(bitstreamSurface));
@@ -468,6 +471,11 @@ VAStatus DdiEncodeHevc::ParsePicParams(
 
     PCODEC_HEVC_ENCODE_SEQUENCE_PARAMS hevcSeqParams = (PCODEC_HEVC_ENCODE_SEQUENCE_PARAMS)((uint8_t *)m_encodeCtx->pSeqParams);
 
+    if(picParams->decoded_curr_pic.picture_id != VA_INVALID_SURFACE)
+    {
+        DDI_CHK_RET(RegisterRTSurfaces(&(m_encodeCtx->RTtbl), DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->decoded_curr_pic.picture_id)), "RegisterRTSurfaces failed!");
+    }
+
     // Curr Recon Pic
     SetupCodecPicture(
         mediaCtx,
@@ -495,6 +503,10 @@ VAStatus DdiEncodeHevc::ParsePicParams(
     // RefFrame List
     for (uint32_t i = 0; i < numMaxRefFrame; i++)
     {
+        if(picParams->reference_frames[i].picture_id != VA_INVALID_SURFACE)
+        {
+            DDI_CHK_RET(UpdateRegisteredRTSurfaceFlag(&(m_encodeCtx->RTtbl), DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->reference_frames[i].picture_id)), "RegisterRTSurfaces failed!");
+        }
         SetupCodecPicture(
             mediaCtx,
             &(m_encodeCtx->RTtbl),

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_mpeg2.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_mpeg2.cpp
@@ -260,6 +260,9 @@ VAStatus DdiEncodeMpeg2::EncodeInCodecHal(
     reconSurface.dwOffset = 0;
     DdiMedia_MediaSurfaceToMosResource(rtTbl->pCurrentReconTarget, &(reconSurface.OsResource));
 
+    //clear registered recon/ref surface flags
+    DDI_CHK_RET(ClearRefList(&m_encodeCtx->RTtbl, false), "ClearRefList failed!");
+
     // Bitstream surface
     MOS_RESOURCE bitstreamSurface;
     MOS_ZeroMemory(&bitstreamSurface, sizeof(MOS_RESOURCE));
@@ -571,16 +574,25 @@ VAStatus DdiEncodeMpeg2::ParsePicParams(
         mpeg2PicParams->m_burstAmplitude  = picParams->composite_display.bits.burst_amplitude;
         mpeg2PicParams->m_subCarrierPhase = picParams->composite_display.bits.sub_carrier_phase;
     }
-    mpeg2PicParams->m_currReconstructedPic.FrameIdx = GetRenderTargetID(rtTbl, DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->reconstructed_picture));
+    if ( picParams->reconstructed_picture == VA_INVALID_SURFACE)
+    {
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
+    }
+    auto recon = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->reconstructed_picture);
+    DDI_CHK_RET(RegisterRTSurfaces(&m_encodeCtx->RTtbl, recon),"RegisterRTSurfaces failed!");
+
+    mpeg2PicParams->m_currReconstructedPic.FrameIdx = GetRenderTargetID(rtTbl, recon);
     mpeg2PicParams->m_currReconstructedPic.PicFlags = PICTURE_FRAME;
 
     // be attention , that codec hal use this value to manager the reference list
-    mpeg2PicParams->m_currOriginalPic.FrameIdx = GetRenderTargetID(rtTbl, DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->reconstructed_picture));
+    mpeg2PicParams->m_currOriginalPic.FrameIdx = GetRenderTargetID(rtTbl, recon);
     mpeg2PicParams->m_currOriginalPic.PicFlags = mpeg2PicParams->m_currReconstructedPic.PicFlags;
 
     if (DDI_CODEC_INVALID_FRAME_INDEX != picParams->forward_reference_picture)
     {
-        mpeg2PicParams->m_refFrameList[0].FrameIdx = GetRenderTargetID(rtTbl, DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->forward_reference_picture));
+        auto fwRef = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->forward_reference_picture);
+        UpdateRegisteredRTSurfaceFlag(&m_encodeCtx->RTtbl,fwRef);
+        mpeg2PicParams->m_refFrameList[0].FrameIdx = GetRenderTargetID(rtTbl, fwRef);
         mpeg2PicParams->m_refFrameList[0].PicFlags = PICTURE_FRAME;
     }
     else
@@ -590,7 +602,9 @@ VAStatus DdiEncodeMpeg2::ParsePicParams(
     }
     if (DDI_CODEC_INVALID_FRAME_INDEX != picParams->backward_reference_picture)
     {
-        mpeg2PicParams->m_refFrameList[1].FrameIdx = GetRenderTargetID(rtTbl, DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->backward_reference_picture));
+        auto bwRef = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->backward_reference_picture);
+        UpdateRegisteredRTSurfaceFlag(&m_encodeCtx->RTtbl,bwRef);
+        mpeg2PicParams->m_refFrameList[1].FrameIdx = GetRenderTargetID(rtTbl, bwRef);
         mpeg2PicParams->m_refFrameList[1].PicFlags = PICTURE_FRAME;
     }
     else
@@ -606,7 +620,7 @@ VAStatus DdiEncodeMpeg2::ParsePicParams(
     {
         mpeg2PicParams->m_newGop = false;
     }
-    rtTbl->pCurrentReconTarget = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->reconstructed_picture);
+    rtTbl->pCurrentReconTarget = recon;;
 
     DDI_MEDIA_BUFFER *buf = DdiMedia_GetBufferFromVABufferID(mediaCtx, picParams->coded_buf);
 

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_vp9.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_vp9.cpp
@@ -154,6 +154,9 @@ VAStatus DdiEncodeVp9::EncodeInCodecHal(uint32_t numSlices)
     bitstreamSurface        = m_encodeCtx->resBitstreamBuffer;  // in render picture
     bitstreamSurface.Format = Format_Buffer;
 
+    //clear registered recon/ref surface flags
+    DDI_CHK_RET(ClearRefList(&m_encodeCtx->RTtbl, true), "ClearRefList failed!");
+
     encodeParams.psRawSurface               = &rawSurface;
     encodeParams.psReconSurface             = &reconSurface;
     encodeParams.presBitstreamBuffer        = &bitstreamSurface;
@@ -579,11 +582,13 @@ VAStatus DdiEncodeVp9::ParsePicParams(DDI_MEDIA_CONTEXT *mediaCtx, void *ptr)
  
     DDI_CODEC_RENDER_TARGET_TABLE *rtTbl = &(m_encodeCtx->RTtbl);
 
+    auto recon = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->reconstructed_frame);
+    DDI_CHK_RET(RegisterRTSurfaces(rtTbl, recon),"RegisterRTSurfaces failed!");
+
     SetupCodecPicture(mediaCtx, rtTbl, &vp9PicParam->CurrReconstructedPic,
                                              picParam->reconstructed_frame, false);
-
-    rtTbl->pCurrentReconTarget = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->reconstructed_frame);
-    DDI_CHK_NULL(rtTbl->pCurrentReconTarget, "nullptr rtTbl->pCurrentReconTarget", VA_STATUS_ERROR_INVALID_PARAMETER);
+    rtTbl->pCurrentReconTarget = recon;
+    DDI_CHK_NULL(rtTbl->pCurrentReconTarget, "NULL rtTbl->pCurrentReconTarget", VA_STATUS_ERROR_INVALID_PARAMETER);
 
     // curr orig pic
     vp9PicParam->CurrOriginalPic.FrameIdx = GetRenderTargetID(rtTbl, rtTbl->pCurrentReconTarget);
@@ -593,6 +598,7 @@ VAStatus DdiEncodeVp9::ParsePicParams(DDI_MEDIA_CONTEXT *mediaCtx, void *ptr)
     {
         if (picParam->reference_frames[i] != VA_INVALID_SURFACE)
         {
+            UpdateRegisteredRTSurfaceFlag(rtTbl, DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->reference_frames[i]));
             SetupCodecPicture(mediaCtx, rtTbl, &vp9PicParam->RefFrameList[i],
                                          picParam->reference_frames[i], true);
         }

--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -103,39 +103,6 @@ VAStatus DdiDecode_CreateBuffer(
 
 }
 
-VAStatus DdiDecode_UnRegisterRTSurfaces(
-    VADriverContextP    ctx,
-    PDDI_MEDIA_SURFACE surface)
-{
-    DDI_CHK_NULL(ctx,"nullptr context!", VA_STATUS_ERROR_INVALID_CONTEXT);
-    PDDI_MEDIA_CONTEXT mediaCtx   = DdiMedia_GetMediaContext(ctx);
-    DDI_CHK_NULL(mediaCtx,"nullptr mediaCtx!", VA_STATUS_ERROR_INVALID_CONTEXT);
-    DDI_CHK_NULL(surface, "nullptr surface!", VA_STATUS_ERROR_INVALID_PARAMETER);
-    
-    //Look through all decode contexts to unregister the surface in each decode context's RTtable.
-    if (mediaCtx->pDecoderCtxHeap != nullptr)
-    {
-        PDDI_MEDIA_VACONTEXT_HEAP_ELEMENT decVACtxHeapBase;
-
-        DdiMediaUtil_LockMutex(&mediaCtx->DecoderMutex);
-        decVACtxHeapBase  = (PDDI_MEDIA_VACONTEXT_HEAP_ELEMENT)mediaCtx->pDecoderCtxHeap->pHeapBase;
-        for (int32_t j = 0; j < mediaCtx->pDecoderCtxHeap->uiAllocatedHeapElements; j++)
-        {
-            if (decVACtxHeapBase[j].pVaContext != nullptr)
-            {
-                PDDI_DECODE_CONTEXT  decCtx = (PDDI_DECODE_CONTEXT)decVACtxHeapBase[j].pVaContext;
-                if (decCtx && decCtx->m_ddiDecode)
-                {
-                    //not check the return value since the surface may not be registered in the context. pay attention to LOGW.
-                    decCtx->m_ddiDecode->UnRegisterRTSurfaces(&decCtx->RTtbl, surface);
-                }
-            }
-        }
-        DdiMediaUtil_UnLockMutex(&mediaCtx->DecoderMutex);
-    }
-    return VA_STATUS_SUCCESS;
-}
-
 VAStatus DdiDecode_BeginPicture (
     VADriverContextP    ctx,
     VAContextID         context,

--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.h
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.h
@@ -118,21 +118,6 @@ VAStatus DdiDecode_CreateBuffer(
 );
 
 //!
-//! \brief  Unregister RT surfaces
-//!
-//! \param  [in] ctx
-//!     Pointer to VA driver context
-//! \param  [in] surface
-//!     Pointer to ddi media surface
-//!     
-//! \return     VAStatus
-//!     VA_STATUS_SUCCESS if success, else fail reason
-//!
-VAStatus DdiDecode_UnRegisterRTSurfaces(
-    VADriverContextP    ctx,
-    PDDI_MEDIA_SURFACE surface);
-
-//!
 //! \brief  Begin picture
 //!
 //! \param  [in] ctx

--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -1770,7 +1770,7 @@ static VAStatus DdiMedia_DestroySurfaces (
             surface->pReferenceFrameSemaphore = nullptr;
         }
 
-        DdiDecode_UnRegisterRTSurfaces(ctx, surface);
+        DdiMediaUtil_UnRegisterRTSurfaces(ctx, surface);
 
         DdiMediaUtil_FreeSurface(surface);
         MOS_FreeMemory(surface);

--- a/media_driver/linux/common/ddi/media_libva_util.h
+++ b/media_driver/linux/common/ddi/media_libva_util.h
@@ -322,6 +322,19 @@ void     DdiMediaUtil_UnRefBufObjInMediaBuffer(PDDI_MEDIA_BUFFER buf);
 //!
 int32_t  DdiMediaUtil_OpenGraphicsAdaptor(char *devName);
 
+//!
+//! \brief  Unregister RT surfaces
+//!
+//! \param  [in] ctx
+//!     Pointer to VA driver context
+//! \param  [in] surface
+//!     Pointer to ddi media surface
+//!     
+//! \return     VAStatus
+//!     VA_STATUS_SUCCESS if success, else fail reason
+//!
+VAStatus DdiMediaUtil_UnRegisterRTSurfaces(VADriverContextP    ctx,PDDI_MEDIA_SURFACE surface);
+
 //------------------------------------------------------------------------------
 // Macros for debug messages, Assert, Null check and condition check within ddi files
 //------------------------------------------------------------------------------


### PR DESCRIPTION
with this fix, application can set the context tied surface with vaCreateSurface
also it can register the recon & ref into context tied surface by vaRenderPicture
fix issue #25 

Signed-off-by: XinfengZhang <carl.zhang@intel.com>