### PR TITLE
Fix the uninitialized framerate for AVC when VAEncMiscParameterFrameR…

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -202,6 +202,11 @@ VAStatus DdiEncodeAvc::ParseMiscParamFR(void *data)
     {
         seqParams->FramesPer100Sec = (uint16_t)(numerator/denominator);
     }
+    else
+    {
+        seqParams->FramesPer100Sec = (uint16_t)numerator;
+    }
+
     return VA_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
…ate uses zero denominator

Fix https://github.com/intel/media-driver/issues/36

Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>