### PR TITLE
vp8dec: fix the last/gold/alt referenc frame check in key frame.

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
@@ -149,17 +149,23 @@ VAStatus DdiDecodeVP8::ParsePicParams(
     DDI_MEDIA_CONTEXT           *mediaCtx,
     VAPictureParameterBufferVP8 *picParam)
 {
+    PDDI_MEDIA_SURFACE lastRefSurface   = nullptr;
+    PDDI_MEDIA_SURFACE goldenRefSurface = nullptr;
+    PDDI_MEDIA_SURFACE altRefSurface    = nullptr;
+
     PCODEC_VP8_PIC_PARAMS codecPicParams = (PCODEC_VP8_PIC_PARAMS)(m_ddiDecodeCtx->DecodeParams.m_picParams);
 
     PDDI_MEDIA_SURFACE *vp8Surfaces = m_ddiDecodeCtx->BufMgr.Codec_Param.Codec_Param_VP8.pReferenceFrames;
 
     PDDI_MEDIA_SURFACE currentSurface = m_ddiDecodeCtx->RTtbl.pCurrentRT;
 
-    PDDI_MEDIA_SURFACE lastRefSurface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->last_ref_frame);
-
-    PDDI_MEDIA_SURFACE goldenRefSurface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->golden_ref_frame);
-
-    PDDI_MEDIA_SURFACE altRefSurface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->alt_ref_frame);
+    // only no-keyframe have last/gold/alt reference frame
+    if (picParam->pic_fields.bits.key_frame)
+    {
+        lastRefSurface   = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->last_ref_frame);
+        goldenRefSurface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->golden_ref_frame);
+        altRefSurface    = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->alt_ref_frame);
+    }
 
     int32_t frameIdx;
     frameIdx = GetRenderTargetID(&m_ddiDecodeCtx->RTtbl, currentSurface);


### PR DESCRIPTION
Only no-key frame have last/gold/alt reference frame, add more
check for this case.

Fix #48 

Signed-off-by: Jun Zhao <jun.zhao@intel.com>