### PR TITLE
Follow the upper-setting of transform hiearchy Intra/Inter depth to f…

### DIFF
--- a/media_driver/agnostic/gen9/hw/vdbox/mhw_vdbox_hcp_g9_X.h
+++ b/media_driver/agnostic/gen9/hw/vdbox/mhw_vdbox_hcp_g9_X.h
@@ -1434,8 +1434,8 @@ protected:
     
         cmd.DW5.PicCbQpOffset                                           = hevcPicParams->pps_cb_qp_offset & 0x1f;
         cmd.DW5.PicCrQpOffset                                           = hevcPicParams->pps_cr_qp_offset & 0x1f;
-        cmd.DW5.MaxTransformHierarchyDepthIntraOrNamedAsTuMaxDepthIntra = 2;
-        cmd.DW5.MaxTransformHierarchyDepthInterOrNamedAsTuMaxDepthInter = 2;
+        cmd.DW5.MaxTransformHierarchyDepthIntraOrNamedAsTuMaxDepthIntra = hevcSeqParams->max_transform_hierarchy_depth_intra;
+        cmd.DW5.MaxTransformHierarchyDepthInterOrNamedAsTuMaxDepthInter = hevcSeqParams->max_transform_hierarchy_depth_inter;
         cmd.DW5.PcmSampleBitDepthChromaMinus1   = 7;
         cmd.DW5.PcmSampleBitDepthLumaMinus1     = 7;
     


### PR DESCRIPTION
…ix HEVC enc corruption on SKL

Now the TransformHieraryDepthIntra/Inter is hardcoded to 2 on SKL. This is incorrect.
The upper-setting should be followed.

Fix https://github.com/intel/media-driver/issues/50

Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Tested-by:     Zhao, Jun  <jun.zhao@intel.com>