### PR TITLE
remove the alignment check for encode create context

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libva_encoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_encoder.cpp
@@ -322,10 +322,11 @@ VAStatus DdiEncode_CreateContext(
     encCtx->pCodecHal = pCodecHal;
 
     // Setup some initial data
-    encCtx->dwFrameWidth      = picture_width;
-    encCtx->dwFrameHeight     = picture_height;
     encCtx->wPicWidthInMB     = (uint16_t)(DDI_CODEC_NUM_MACROBLOCKS_WIDTH(picture_width));
     encCtx->wPicHeightInMB    = (uint16_t)(DDI_CODEC_NUM_MACROBLOCKS_HEIGHT(picture_height));
+    encCtx->dwFrameWidth      = encCtx->wPicWidthInMB * CODECHAL_MACROBLOCK_WIDTH;
+    encCtx->dwFrameHeight     = encCtx->wPicHeightInMB * CODECHAL_MACROBLOCK_HEIGHT;
+    encCtx->dwFrameHeight     = picture_height;
     //recoder old resolution for dynamic resolution  change
     encCtx->wContextPicWidthInMB  = encCtx->wPicWidthInMB;
     encCtx->wContextPicHeightInMB = encCtx->wPicHeightInMB;

--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -1576,9 +1576,7 @@ VAStatus MediaLibvaCaps::CheckEncodeResolution(
             if (width > m_encMax4kWidth 
                     || width < m_encMinWidth
                     || height > m_encMax4kHeight 
-                    || height < m_encMinHeight
-                    || (width % CODECHAL_MACROBLOCK_WIDTH)
-                    || (height % CODECHAL_MACROBLOCK_HEIGHT))
+                    || height < m_encMinHeight)
             {
                 return VA_STATUS_ERROR_RESOLUTION_NOT_SUPPORTED;
             }


### PR DESCRIPTION
driver should not check resolution alignment , but need to align the resolution

Signed-off-by: XinfengZhang <carl.zhang@intel.com>