### PR TITLE
Add performance profiler in media driver

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decoder.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_decoder.cpp
@@ -537,6 +537,14 @@ MOS_STATUS CodechalDecode::Allocate (CodechalSetting * codecHalSettings)
             m_videoContext));
     }
 
+    if (!m_perfProfiler)
+    {
+        m_perfProfiler = MediaPerfProfiler::Instance();
+        CODECHAL_DECODE_CHK_NULL_RETURN(m_perfProfiler);
+
+        CODECHAL_DECODE_CHK_STATUS_RETURN(m_perfProfiler->Initialize((void*)this, m_osInterface));
+    }
+
     return eStatus;
 }
 
@@ -676,6 +684,12 @@ CodechalDecode::~CodechalDecode()
         }
     }
 #endif
+
+    if (m_perfProfiler)
+    {
+        MediaPerfProfiler::Destroy(m_perfProfiler, (void*)this, m_osInterface);
+        m_perfProfiler = nullptr;
+    }
 }
 
 void CodechalDecode::CalcRequestedSpace(
@@ -1273,6 +1287,12 @@ MOS_STATUS CodechalDecode::EndStatusReport(
     CodechalDecodeStatus *decodeStatus = &m_decodeStatusBuf.m_decodeStatus[m_decodeStatusBuf.m_currIndex];
     MOS_ZeroMemory(decodeStatus, sizeof(CodechalDecodeStatus));
 
+    CODECHAL_DECODE_CHK_STATUS_RETURN(m_perfProfiler->AddPerfCollectEndCmd(
+        (void*)this,
+        m_osInterface,
+        m_miInterface,
+        cmdBuffer));
+
     if (!m_osInterface->bEnableKmdMediaFrameTracking && m_osInterface->bInlineCodecStatusUpdate)
     {
         MHW_MI_FLUSH_DW_PARAMS flushDwParams;
@@ -1553,6 +1573,12 @@ MOS_STATUS CodechalDecode::SendPrologWithFrameTracking(
     CODECHAL_DECODE_CHK_STATUS_RETURN(Mhw_SendGenericPrologCmd(
         cmdBuffer,
         &genericPrologParams));
+    
+    CODECHAL_DECODE_CHK_STATUS_RETURN(m_perfProfiler->AddPerfCollectStartCmd(
+        (void*)this,
+        m_osInterface,
+        m_miInterface,
+        cmdBuffer));
 
     // Send predication command
     if (m_decodeParams.m_predicationEnabled)

--- a/media_driver/agnostic/common/codec/hal/codechal_decoder.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_decoder.h
@@ -37,6 +37,7 @@
 #include "codechal_mmc.h"
 #include "codechal_utilities.h"
 #include "cm_wrapper.h"
+#include "media_perf_profiler.h"
 
 class CodechalSecureDecode;
 class CodechalCencDecode;
@@ -1107,6 +1108,9 @@ protected:
     //! \details  Support YUV Luma histogram.
     CodechalDecodeHistogram    *m_decodeHistogram = nullptr;
     PMOS_GPUCTX_CREATOPTIONS   m_gpuCtxCreatOpt = nullptr;
+
+    //! \brief Performance data profiler
+    MediaPerfProfiler          *m_perfProfiler    = nullptr;
 };
 
 //!

--- a/media_driver/agnostic/common/codec/hal/codechal_encoder_base.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encoder_base.cpp
@@ -550,6 +550,14 @@ MOS_STATUS CodechalEncoderState::Allocate(CodechalSetting * codecHalSettings)
             m_renderContext));
     }
 
+    if (!m_perfProfiler)
+    {
+        m_perfProfiler = MediaPerfProfiler::Instance();
+        CODECHAL_ENCODE_CHK_NULL_RETURN(m_perfProfiler);
+
+        CODECHAL_ENCODE_CHK_STATUS_RETURN(m_perfProfiler->Initialize((void*)this, m_osInterface));
+    }
+
     return MOS_STATUS_SUCCESS;
 }
 
@@ -1179,7 +1187,7 @@ MOS_STATUS CodechalEncoderState::CheckResChangeAndCsc()
     }
 #ifndef _FULL_OPEN_SOURCE
     // check recon surface's alignment meet HW requirement
-	CODECHAL_ENCODE_CHK_STATUS_RETURN(m_cscDsState->CheckReconSurfaceAlignment(&m_reconSurface));
+    CODECHAL_ENCODE_CHK_STATUS_RETURN(m_cscDsState->CheckReconSurfaceAlignment(&m_reconSurface));
 
     if (!m_cscDsState->IsEnabled() ||
         CodecHal_PictureIsField(m_currOriginalPic) ||
@@ -1189,7 +1197,7 @@ MOS_STATUS CodechalEncoderState::CheckResChangeAndCsc()
         m_cscDsState->ResetCscFlag();
 
         // check raw surface's alignment meet HW requirement
-		CODECHAL_ENCODE_CHK_STATUS_RETURN(m_cscDsState->CheckRawSurfaceAlignment(m_rawSurfaceToEnc));
+        CODECHAL_ENCODE_CHK_STATUS_RETURN(m_cscDsState->CheckRawSurfaceAlignment(m_rawSurfaceToEnc));
     }
     else
     {
@@ -2926,6 +2934,12 @@ MOS_STATUS CodechalEncoderState::StartStatusReport(
         }
     }
 
+    CODECHAL_ENCODE_CHK_STATUS_RETURN(m_perfProfiler->AddPerfCollectStartCmd(
+        (void*)this,
+        m_osInterface,
+        m_miInterface,
+        cmdBuffer));
+
     return eStatus;
 }
 
@@ -3037,6 +3051,12 @@ MOS_STATUS CodechalEncoderState::EndStatusReport(
             UpdateEncodeStatus(cmdBuffer, true);
         }
     }
+
+    CODECHAL_ENCODE_CHK_STATUS_RETURN(m_perfProfiler->AddPerfCollectEndCmd(
+        (void*)this,
+        m_osInterface,
+        m_miInterface,
+        cmdBuffer));
 
     return eStatus;
 }
@@ -4474,6 +4494,12 @@ CodechalEncoderState::CodechalEncoderState(
 CodechalEncoderState::~CodechalEncoderState()
 {
     DestroyMDFResources();
+
+    if (m_perfProfiler)
+    {
+        MediaPerfProfiler::Destroy(m_perfProfiler, (void*)this, m_osInterface);
+        m_perfProfiler = nullptr;
+    }
 }
 
 #if USE_CODECHAL_DEBUG_TOOL

--- a/media_driver/agnostic/common/codec/hal/codechal_encoder_base.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_encoder_base.h
@@ -39,6 +39,7 @@
 #include "codechal_mmc.h"
 #include "codechal_utilities.h"
 #include "cm_rt_umd.h"
+#include "media_perf_profiler.h"
 
 //------------------------------------------------------------------------------
 // Macros specific to MOS_CODEC_SUBCOMP_ENCODE sub-comp
@@ -1740,6 +1741,7 @@ public:
     uint32_t                        m_sizeCurrSkipFrame = 0;    //!< size of curr skipped frame for skipflag = 2
     
     MHW_VDBOX_NODE_IND              m_vdboxIndex;               //!< Index of vdbox
+    MediaPerfProfiler               *m_perfProfiler = nullptr;  //!< Performance data profiler
 
 #if (_DEBUG || _RELEASE_INTERNAL)
     bool m_mmcUserFeatureUpdated;  //!< indicate if the user feature is updated with MMC state

--- a/media_driver/agnostic/common/os/mos_utilities.c
+++ b/media_driver/agnostic/common/os/mos_utilities.c
@@ -94,6 +94,105 @@ static MOS_USER_FEATURE_VALUE MOSUserFeatureDescFields[__MOS_USER_FEATURE_KEY_MA
      MOS_USER_FEATURE_VALUE_TYPE_INT32,
      "0",
      "Linux Performance Tag"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_ENABLE_ID,
+     "Perf Profiler Enable",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_BOOL,
+     "0",
+     "Perf Profiler Enable Control Flag"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_OUTPUT_FILE,
+     "Perf Profiler Output File Name",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_STRING,
+     "Perf_DATA_00_00.bin",
+     "Performance Profiler Output File Name"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_BUFFER_SIZE,
+     "Perf Profiler Buffer Size",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "10000000",
+     "Performance Profiler Buffer Size"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_1,
+     "Perf Profiler Register 1",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_2,
+     "Perf Profiler Register 2",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_3,
+     "Perf Profiler Register 3",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_4,
+     "Perf Profiler Register 4",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_5,
+     "Perf Profiler Register 5",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_6,
+     "Perf Profiler Register 6",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_7,
+     "Perf Profiler Register 7",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_8,
+     "Perf Profiler Register 8",
+     __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
+     __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+     "General",
+     MOS_USER_FEATURE_TYPE_USER,
+     MOS_USER_FEATURE_VALUE_TYPE_UINT32,
+     "0",
+     "Performance Profiler Memory Information Register"),
     MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_DISABLE_KMD_WATCHDOG_ID,
      "Disable KMD Watchdog",
      __MEDIA_USER_FEATURE_SUBKEY_PERFORMANCE,
@@ -742,15 +841,15 @@ static MOS_USER_FEATURE_VALUE MOSUserFeatureDescFields[__MOS_USER_FEATURE_KEY_MA
      MOS_USER_FEATURE_VALUE_TYPE_INT32,
      "1",
      "Enables/Disables HEVC Encode."),
-	MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_HEVC_ENCODE_SECURE_INPUT_ID,
-		"Secure HEVC Encode",
-		__MEDIA_USER_FEATURE_SUBKEY_INTERNAL,
-		__MEDIA_USER_FEATURE_SUBKEY_REPORT,
-		"Secure HEVC Encode",
-		MOS_USER_FEATURE_TYPE_USER,
-		MOS_USER_FEATURE_VALUE_TYPE_INT32,
-		"0",
-		"Secure HEVC Encode."),
+    MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_HEVC_ENCODE_SECURE_INPUT_ID,
+        "Secure HEVC Encode",
+        __MEDIA_USER_FEATURE_SUBKEY_INTERNAL,
+        __MEDIA_USER_FEATURE_SUBKEY_REPORT,
+        "Secure HEVC Encode",
+        MOS_USER_FEATURE_TYPE_USER,
+        MOS_USER_FEATURE_VALUE_TYPE_INT32,
+        "0",
+        "Secure HEVC Encode."),
     MOS_DECLARE_UF_KEY_DBGONLY(__MEDIA_USER_FEATURE_VALUE_HEVC_ENCODE_ENABLE_MEDIARESET_TEST_ID,
      "Enable MediaReset Test",
      __MEDIA_USER_FEATURE_SUBKEY_INTERNAL,
@@ -2750,12 +2849,12 @@ MOS_STATUS MOS_AppendFileFromPtr(
 //!
 MOS_FUNC_EXPORT MOS_STATUS MOS_EXPORT_DECL DumpUserFeatureKeyDefinitionsMedia()
 {
-    MOS_STATUS							eStatus = MOS_STATUS_SUCCESS;
+    MOS_STATUS                            eStatus = MOS_STATUS_SUCCESS;
     // Init MOS User Feature Key from mos desc table
     MOS_OS_CHK_STATUS( MOS_DeclareUserFeatureKeysForAllDescFields() );
     MOS_OS_CHK_STATUS( MOS_GenerateUserFeatureKeyXML() );
 finish:
-    return	eStatus;
+    return    eStatus;
 }
 
 #endif
@@ -2994,7 +3093,7 @@ MOS_STATUS MOS_GenerateUserFeatureKeyXML()
         UserFeatureData.StringData.pStringData,
         sOutBuf,
         (uint32_t)strlen(sOutBuf));
-    return	eStatus;
+    return    eStatus;
 }
 
 //!
@@ -3802,7 +3901,7 @@ MOS_STATUS MOS_DestroyUserFeatureKeysForAllDescFields()
 static MOS_STATUS MOS_UserFeature_ReadValueInit(
     PMOS_USER_FEATURE_INTERFACE   pOsUserFeatureInterface,
     uint32_t                      uiNumValues,
-    MOS_USER_FEATURE_VALUE_DATA	  Value,
+    MOS_USER_FEATURE_VALUE_DATA   Value,
     const char                    *pValueName,
     MOS_USER_FEATURE_VALUE_TYPE   ValueType)
 {
@@ -4499,7 +4598,7 @@ MOS_STATUS MOS_UserFeature_ReadValue (
     uint32_t                                ui;
     void                                    *UFKey = nullptr;
     PMOS_USER_FEATURE_VALUE                 pSettingsValue = nullptr;
-    MOS_USER_FEATURE_VALUE_DATA	            UserFeatureData;
+    MOS_USER_FEATURE_VALUE_DATA             UserFeatureData;
     MOS_USER_FEATURE_VALUE_ID               ValueID = __MOS_USER_FEATURE_KEY_INVALID_ID;
     PMOS_USER_FEATURE_VALUE                 pUserFeatureValue=NULL;
     PMOS_USER_FEATURE_VALUE_STRING          pSrcString = nullptr;

--- a/media_driver/agnostic/common/os/mos_utilities.h
+++ b/media_driver/agnostic/common/os/mos_utilities.h
@@ -119,6 +119,17 @@ typedef enum _MOS_USER_FEATURE_VALUE_ID
     __MEDIA_USER_FEATURE_VALUE_SIM_IN_USE_ID,
     __MEDIA_USER_FEATURE_VALUE_FORCE_VDBOX_ID,
     __MEDIA_USER_FEATURE_VALUE_LINUX_PERFORMANCETAG_ENABLE_ID,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_ENABLE_ID,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_OUTPUT_FILE,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_BUFFER_SIZE,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_1,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_2,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_3,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_4,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_5,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_6,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_7,
+    __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_8,
     __MEDIA_USER_FEATURE_VALUE_DISABLE_KMD_WATCHDOG_ID,
     __MEDIA_USER_FEATURE_VALUE_SINGLE_TASK_PHASE_ENABLE_ID,
     __MEDIA_USER_FEATURE_VALUE_MFE_MBENC_ENABLE_ID,
@@ -629,14 +640,14 @@ typedef struct
 //template<class _Ty, class... _Types> inline
 //std::shared_ptr<_Ty> MOS_MakeShared(_Types&&... _Args)
 //{
-//	try
-//	{
-//		return std::make_shared<_Ty>(std::forward<_Types>(_Args)...);
-//	}
-//	catch (const std::bad_alloc&)
-//	{
-//		return nullptr;
-//	}
+//    try
+//    {
+//        return std::make_shared<_Ty>(std::forward<_Types>(_Args)...);
+//    }
+//    catch (const std::bad_alloc&)
+//    {
+//        return nullptr;
+//    }
 //}
 
 #if MOS_MESSAGES_ENABLED
@@ -925,7 +936,7 @@ void MOS_FreeMemory(
 #define MOS_FreeMemAndSetNull(ptr)  \
 do{                                 \
     MOS_FreeMemory(ptr);            \
-    ptr = nullptr;                     \
+    ptr = nullptr;                  \
 } while (0)
 
 //!
@@ -1243,7 +1254,7 @@ MOS_STATUS MOS_GenerateUserFeatureKeyXML();
 //!
 //! \brief    Get the User Feature Value from Table
 //! \details  Get the related User Feature Value item according to Filter rules , and pass the item
-//! 		   into return callback function
+//!            into return callback function
 //! \param    [in] descTable
 //!           The user feature key description table
 //! \param    [in] numOfItems
@@ -1282,7 +1293,7 @@ MOS_STATUS MOS_GetItemFromMOSUserFeatureDescField(
 //!           else MOS_STATUS_SUCCESS
 //!
 MOS_STATUS MOS_UserFeature_SetDefaultValues(
-    PMOS_USER_FEATURE_INTERFACE	            pOsUserFeatureInterface,
+    PMOS_USER_FEATURE_INTERFACE                pOsUserFeatureInterface,
     PMOS_USER_FEATURE_VALUE_WRITE_DATA      pWriteValues,
     uint32_t                                uiNumOfValues);
 
@@ -1366,9 +1377,9 @@ MOS_STATUS MOS_DestroyUserFeatureKeysForAllDescFields();
 //!           else MOS_STATUS_SUCCESS
 //!
 MOS_STATUS MOS_CopyUserFeatureValueData(
-	PMOS_USER_FEATURE_VALUE_DATA pSrcData,
-	PMOS_USER_FEATURE_VALUE_DATA pDstData,
-	MOS_USER_FEATURE_VALUE_TYPE ValueType
+    PMOS_USER_FEATURE_VALUE_DATA pSrcData,
+    PMOS_USER_FEATURE_VALUE_DATA pDstData,
+    MOS_USER_FEATURE_VALUE_TYPE ValueType
 );
 
 //!
@@ -1383,8 +1394,8 @@ MOS_STATUS MOS_CopyUserFeatureValueData(
 //!           else MOS_STATUS_SUCCESS
 //!
 MOS_STATUS MOS_DestroyUserFeatureData(
-	PMOS_USER_FEATURE_VALUE_DATA pData,
-	MOS_USER_FEATURE_VALUE_TYPE  ValueType);
+    PMOS_USER_FEATURE_VALUE_DATA pData,
+    MOS_USER_FEATURE_VALUE_TYPE  ValueType);
 
 #ifdef  __MOS_USER_FEATURE_WA_
 MOS_STATUS MOS_UserFeature_ReadValue (

--- a/media_driver/agnostic/common/shared/media_perf_profiler.cpp
+++ b/media_driver/agnostic/common/shared/media_perf_profiler.cpp
@@ -1,0 +1,576 @@
+/*
+* Copyright (c) 2017, Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*/
+//!
+//! \file     media_perf_profiler.cpp
+//! \brief    Defines data structures and interfaces for media performance profiler.
+//! \details  
+//!
+
+#include "media_perf_profiler.h"
+
+#define UMD_PERF_LOG            8
+#define NAME_LEN                60
+#define LOCAL_STRING_SIZE       64
+#define OFFSET_OF(TYPE, MEMBER) ((size_t) & ((TYPE *)0)->MEMBER )
+
+typedef enum _UMD_PERF_MODE
+{
+    UMD_PERF_MODE_TIMING_ONLY      = 0,
+    UMD_PERF_MODE_WITH_MEMORY_INFO = 4
+} UMD_PERF_MODE;
+
+#pragma pack(push)
+#pragma pack(8)
+struct PerfEntry 
+{
+    uint32_t    nodeIndex;                  //!< Perf node index
+    uint32_t    processId;                  //!< Process Id
+    uint32_t    instanceId;                 //!< Instance Id
+    uint32_t    engineTag;                  //!< Engine tag
+    uint32_t    perfTag;                    //!< Performance tag
+    uint32_t    timeStampBase;              //!< HW timestamp base
+    uint32_t    beginRegisterValue[8];      //!< Begin register value
+    uint32_t    endRegisterValue[8];        //!< End register value
+    uint32_t    reserved[16];               //!< Reserved[16]
+    uint64_t    beginTimeClockValue;        //!< Begin timestamp
+    uint64_t    endTimeClockValue;          //!< End timestamp
+};
+#pragma pack(pop)
+
+struct NodeHeader 
+{
+    uint32_t osPlatform  : 3;
+    uint32_t genPlatform : 3; 
+    uint32_t eventType   : 4;
+    uint32_t perfMode    : 3;
+    uint32_t genAndroid  : 4;
+    uint32_t reserved    : 15;
+};
+
+#define BASE_OF_NODE(perfDataIndex) (sizeof(NodeHeader) + (sizeof(PerfEntry) * perfDataIndex))
+
+#define CHK_STATUS_RETURN(_stmt)                   \
+{                                                  \
+    MOS_STATUS stmtStatus = (MOS_STATUS)(_stmt);   \
+    if (stmtStatus != MOS_STATUS_SUCCESS)          \
+    {                                              \
+        return stmtStatus;                         \
+    }                                              \
+}
+
+#define CHK_NULL_RETURN(_ptr)                      \
+{                                                  \
+    if ((_ptr) == nullptr)                         \
+    {                                              \
+        return MOS_STATUS_NULL_POINTER;            \
+    }                                              \
+}
+
+#define CHK_STATUS_UNLOCK_MUTEX_RETURN(_stmt)      \
+{                                                  \
+    MOS_STATUS stmtStatus = (MOS_STATUS)(_stmt);   \
+    if (stmtStatus != MOS_STATUS_SUCCESS)          \
+    {                                              \
+        MOS_UnlockMutex(m_mutex);                  \
+        return stmtStatus;                         \
+    }                                              \
+}
+
+#define CHK_NULL_UNLOCK_MUTEX_RETURN(_ptr)         \
+{                                                  \
+    if ((_ptr) == nullptr)                         \
+    {                                              \
+        MOS_UnlockMutex(m_mutex);                  \
+        return MOS_STATUS_NULL_POINTER;            \
+    }                                              \
+}
+
+#define IS_PERF_MODE_WITH_MEM_INFO(_reg)           \
+({                                                 \
+    int8_t regIndex = 0;                           \
+    bool   ret = false;                            \
+    for (regIndex = 0; regIndex < 8; regIndex++)   \
+    {                                              \
+        if (_reg[regIndex] != 0)                   \
+        {                                          \
+            ret = true;                            \
+            break;                                 \
+        }                                          \
+    }                                              \
+    ret;                                           \
+})
+
+MediaPerfProfiler::MediaPerfProfiler()
+{
+    m_perfDataIndex = 0;
+    m_ref           = 0;
+    m_initialized   = false;
+
+    m_mutex         = MOS_CreateMutex();
+}
+
+MediaPerfProfiler::~MediaPerfProfiler()
+{
+    MOS_DestroyMutex(m_mutex);
+    m_mutex = nullptr;
+}
+
+MediaPerfProfiler* MediaPerfProfiler::Instance()
+{
+    static MediaPerfProfiler instance;
+
+    MOS_LockMutex(instance.m_mutex);
+    instance.m_ref++;
+    MOS_UnlockMutex(instance.m_mutex);
+
+    return &instance;
+}
+
+void MediaPerfProfiler::Destroy(MediaPerfProfiler* profiler, void* context, MOS_INTERFACE *osInterface)
+{
+    if (profiler->m_initialized == false)
+    {
+        return;
+    }
+
+    MOS_LockMutex(profiler->m_mutex);
+    profiler->m_ref--;
+
+    profiler->m_contextIndexMap.erase(context);
+
+    if (profiler->m_ref == 0)
+    {
+        profiler->SavePerfData(osInterface);
+
+        osInterface->pfnFreeResource(
+            osInterface,
+            &profiler->m_perfStoreBuffer);
+
+        profiler->m_initialized = false;
+    }
+
+    MOS_UnlockMutex(profiler->m_mutex);
+}
+
+MOS_STATUS MediaPerfProfiler::Initialize(void* context, MOS_INTERFACE *osInterface)
+{
+    MOS_STATUS                      status = MOS_STATUS_SUCCESS;
+
+    CHK_NULL_RETURN(osInterface);
+    CHK_NULL_RETURN(m_mutex);
+
+    MOS_LockMutex(m_mutex);
+
+    m_contextIndexMap[context] = 0;
+
+    if (m_initialized == true)
+    {
+        MOS_UnlockMutex(m_mutex);
+        return status;
+    }
+
+    MOS_ZeroMemory(&m_perfStoreBuffer, sizeof(MOS_RESOURCE));
+
+    MOS_USER_FEATURE_VALUE_DATA     userFeatureData;
+    int32_t                         profilerEnabled = 0;
+
+    // Check whether profiler is enabled
+    MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));
+    MOS_UserFeature_ReadValue_ID(
+        nullptr,
+        __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_ENABLE_ID,
+        &userFeatureData);
+    profilerEnabled = userFeatureData.bData;
+
+    if (profilerEnabled == 0)
+    {
+        MOS_UnlockMutex(m_mutex);
+        return status;
+    }
+
+    // Read output file name from registry
+    MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));
+    userFeatureData.StringData.pStringData = m_outputFileName;
+    MOS_UserFeature_ReadValue_ID(
+        NULL,
+        __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_OUTPUT_FILE,
+        &userFeatureData);
+
+    if (userFeatureData.StringData.uSize == MOS_MAX_PATH_LENGTH + 1)
+    {
+        userFeatureData.StringData.uSize = 0;
+    }
+
+    if (userFeatureData.StringData.uSize > 0)
+    {
+        userFeatureData.StringData.pStringData[userFeatureData.StringData.uSize] = '\0';
+        userFeatureData.StringData.uSize++;
+    }
+
+    // Read buffer size from registry
+    MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));
+    MOS_UserFeature_ReadValue_ID(
+        nullptr,
+        __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_BUFFER_SIZE,
+        &userFeatureData);
+    m_bufferSize = userFeatureData.u32Data;
+
+    // Read Memory information register from registry
+    int8_t regIndex = 0;
+    for (regIndex = 0; regIndex < 8; regIndex++)
+    {
+        MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));
+        MOS_UserFeature_ReadValue_ID(                                   
+            nullptr,                                                    
+            __MEDIA_USER_FEATURE_VALUE_PERF_PROFILER_REGISTER_1 + regIndex,
+            &userFeatureData);                                          
+        m_registers[regIndex] = userFeatureData.u32Data;
+    }
+
+    // Allocate the buffer which store the performance data
+    MOS_ALLOC_GFXRES_PARAMS allocParams;
+    MOS_ZeroMemory(&allocParams, sizeof(MOS_ALLOC_GFXRES_PARAMS));
+    allocParams.Type        = MOS_GFXRES_BUFFER;
+    allocParams.TileType    = MOS_TILE_LINEAR;
+    allocParams.Format      = Format_Buffer;
+    allocParams.dwBytes     = m_bufferSize;
+    allocParams.pBufName    = "PerfStoreBuffer";
+
+    status = osInterface->pfnAllocateResource(
+                                        osInterface,
+                                        &allocParams,
+                                        &m_perfStoreBuffer);
+
+    CHK_STATUS_UNLOCK_MUTEX_RETURN(status);
+
+    PLATFORM platform = { IGFX_UNKNOWN };
+    osInterface->pfnGetPlatform(osInterface, &platform);
+
+    MOS_LOCK_PARAMS lockFlags;
+    MOS_ZeroMemory(&lockFlags, sizeof(MOS_LOCK_PARAMS));
+    lockFlags.WriteOnly   = 1;
+
+    NodeHeader* header = (NodeHeader*)osInterface->pfnLockResource(
+            osInterface,
+            &m_perfStoreBuffer,
+            &lockFlags);
+    
+    CHK_NULL_UNLOCK_MUTEX_RETURN(header);
+
+    // Append the header info
+    MOS_ZeroMemory(header, m_bufferSize);
+    header->eventType   = UMD_PERF_LOG;
+    header->genPlatform = GFX_GET_CURRENT_RENDERCORE(platform) - 8;
+    
+    if (IS_PERF_MODE_WITH_MEM_INFO(m_registers))
+    {
+        header->perfMode    = UMD_PERF_MODE_WITH_MEMORY_INFO;
+    }
+    else
+    {
+        header->perfMode    = UMD_PERF_MODE_TIMING_ONLY;
+    }
+
+    osInterface->pfnUnlockResource(
+            osInterface,
+            &m_perfStoreBuffer);
+
+    m_initialized = true;
+
+    MOS_UnlockMutex(m_mutex);
+
+    return MOS_STATUS_SUCCESS;
+}
+
+MOS_STATUS MediaPerfProfiler::StoreData(
+    MhwMiInterface *miInterface, 
+    PMOS_COMMAND_BUFFER cmdBuffer,
+    uint32_t offset,
+    uint32_t value)
+{
+    MHW_MI_STORE_DATA_PARAMS storeDataParams;
+    MOS_ZeroMemory(&storeDataParams, sizeof(storeDataParams));
+
+    storeDataParams.pOsResource         = &m_perfStoreBuffer;
+    storeDataParams.dwResourceOffset    = offset;
+    storeDataParams.dwValue             = value;
+
+    return miInterface->AddMiStoreDataImmCmd(cmdBuffer, &storeDataParams);
+}
+
+MOS_STATUS MediaPerfProfiler::StoreRegister(
+    MhwMiInterface *miInterface, 
+    PMOS_COMMAND_BUFFER cmdBuffer,
+    uint32_t offset,
+    uint32_t reg)
+{
+    MHW_MI_STORE_REGISTER_MEM_PARAMS storeRegMemParams;
+    MOS_ZeroMemory(&storeRegMemParams, sizeof(storeRegMemParams));
+
+    storeRegMemParams.presStoreBuffer = &m_perfStoreBuffer;
+    storeRegMemParams.dwOffset        = offset;
+    storeRegMemParams.dwRegister      = reg;
+    return miInterface->AddMiStoreRegisterMemCmd(cmdBuffer, &storeRegMemParams);
+}
+
+MOS_STATUS MediaPerfProfiler::StoreTSByPipeCtrl(
+    MhwMiInterface *miInterface,
+    PMOS_COMMAND_BUFFER cmdBuffer,
+    uint32_t offset)
+{
+    MHW_PIPE_CONTROL_PARAMS PipeControlParams;
+
+    MOS_ZeroMemory(&PipeControlParams, sizeof(PipeControlParams));
+    PipeControlParams.dwResourceOffset = offset;
+    PipeControlParams.dwPostSyncOp     = MHW_FLUSH_WRITE_TIMESTAMP_REG;
+    PipeControlParams.dwFlushMode      = MHW_FLUSH_READ_CACHE;
+    PipeControlParams.presDest         = &m_perfStoreBuffer;
+
+    CHK_STATUS_RETURN(miInterface->AddPipeControl(
+        cmdBuffer,
+        NULL,
+        &PipeControlParams));
+
+    return MOS_STATUS_SUCCESS;
+}
+
+MOS_STATUS MediaPerfProfiler::StoreTSByMiFlush(
+    MhwMiInterface *miInterface,
+    PMOS_COMMAND_BUFFER cmdBuffer,
+    uint32_t offset)
+{
+    MHW_MI_FLUSH_DW_PARAMS FlushDwParams;
+
+    MOS_ZeroMemory(&FlushDwParams, sizeof(FlushDwParams));
+    FlushDwParams.postSyncOperation             = MHW_FLUSH_WRITE_TIMESTAMP_REG;
+    FlushDwParams.dwResourceOffset              = offset;
+    FlushDwParams.pOsResource                   = &m_perfStoreBuffer;
+
+    CHK_STATUS_RETURN(miInterface->AddMiFlushDwCmd(
+        cmdBuffer,
+        &FlushDwParams));
+
+    return MOS_STATUS_SUCCESS;
+}
+
+MOS_STATUS MediaPerfProfiler::AddPerfCollectStartCmd(void* context, 
+    MOS_INTERFACE *osInterface,
+    MhwMiInterface *miInterface,
+    MOS_COMMAND_BUFFER *cmdBuffer)
+{
+    MOS_STATUS       status        = MOS_STATUS_SUCCESS;
+
+    if (m_initialized == false)
+    {
+        return status;
+    }
+
+    CHK_NULL_RETURN(osInterface);
+    CHK_NULL_RETURN(miInterface);
+    CHK_NULL_RETURN(cmdBuffer);
+    CHK_NULL_RETURN(m_mutex);
+
+    uint32_t         perfDataIndex = 0;
+
+    MOS_LockMutex(m_mutex);
+
+    perfDataIndex = m_perfDataIndex;
+    m_perfDataIndex++;
+
+    MOS_UnlockMutex(m_mutex);
+
+    m_contextIndexMap[context] = perfDataIndex;
+
+    bool             rcsEngineUsed = false;
+    MOS_GPU_CONTEXT  gpuContext;
+
+    gpuContext     = osInterface->pfnGetGpuContext(osInterface);
+    rcsEngineUsed = MOS_RCS_ENGINE_USED(gpuContext);
+
+    CHK_STATUS_RETURN(StoreData(
+        miInterface,
+        cmdBuffer, 
+        BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, perfTag),
+        osInterface->pfnGetPerfTag(osInterface)));
+
+    CHK_STATUS_RETURN(StoreData(
+        miInterface,
+        cmdBuffer, 
+        BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, engineTag),
+        GpuContextToGpuNode(gpuContext)));
+
+    int8_t regIndex = 0;
+    for (regIndex = 0; regIndex < 8; regIndex++)
+    {
+        if (m_registers[regIndex] != 0)
+        {
+            CHK_STATUS_RETURN(StoreRegister(
+                miInterface,
+                cmdBuffer, 
+                BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, beginRegisterValue[regIndex]),
+                m_registers[regIndex]));
+        }
+    }
+
+    if (rcsEngineUsed)
+    {
+        CHK_STATUS_RETURN(StoreTSByPipeCtrl(
+            miInterface,
+            cmdBuffer, 
+            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, beginTimeClockValue)));
+    }
+    else
+    {
+        CHK_STATUS_RETURN(StoreTSByMiFlush(
+            miInterface,
+            cmdBuffer,
+            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, beginTimeClockValue)));
+    }
+    
+    return status;
+}
+
+MOS_STATUS MediaPerfProfiler::AddPerfCollectEndCmd(void* context,
+    MOS_INTERFACE *osInterface,
+    MhwMiInterface *miInterface,
+    MOS_COMMAND_BUFFER *cmdBuffer)
+{
+    MOS_STATUS       status        = MOS_STATUS_SUCCESS;
+
+    if (m_initialized == false)
+    {
+        return status;
+    }
+
+    CHK_NULL_RETURN(osInterface);
+    CHK_NULL_RETURN(miInterface);
+    CHK_NULL_RETURN(cmdBuffer);
+
+    MOS_GPU_CONTEXT  gpuContext;
+    bool             rcsEngineUsed = false;
+    UINT             perfDataIndex = 0;
+
+    gpuContext     = osInterface->pfnGetGpuContext(osInterface);
+    rcsEngineUsed = MOS_RCS_ENGINE_USED(gpuContext);
+
+    perfDataIndex = m_contextIndexMap[context];
+
+    int8_t regIndex = 0;
+    for (regIndex = 0; regIndex < 8; regIndex++)
+    {
+        if (m_registers[regIndex] != 0)
+        {
+            CHK_STATUS_RETURN(StoreRegister(
+                miInterface,
+                cmdBuffer, 
+                BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, endRegisterValue[regIndex]),
+                m_registers[regIndex]));
+        }
+    }
+
+    if (rcsEngineUsed)
+    {
+        CHK_STATUS_RETURN(StoreTSByPipeCtrl(
+            miInterface,
+            cmdBuffer,
+            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, endTimeClockValue)));
+    }
+    else
+    {
+        CHK_STATUS_RETURN(StoreTSByMiFlush(
+            miInterface,
+            cmdBuffer,
+            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, endTimeClockValue)));
+    }
+
+    return status;
+}
+
+MOS_STATUS MediaPerfProfiler::SavePerfData(MOS_INTERFACE *osInterface)
+{
+    MOS_STATUS status = MOS_STATUS_SUCCESS;
+
+    CHK_NULL_RETURN(osInterface);
+    
+    if (m_perfDataIndex > 0)
+    {
+        MOS_LOCK_PARAMS     LockFlagsNoOverWrite;
+        MOS_ZeroMemory(&LockFlagsNoOverWrite, sizeof(MOS_LOCK_PARAMS));
+
+        LockFlagsNoOverWrite.WriteOnly   = 1;
+        LockFlagsNoOverWrite.NoOverWrite = 1;
+
+        uint8_t* pData = (uint8_t*)osInterface->pfnLockResource(
+            osInterface,
+            &m_perfStoreBuffer,
+            &LockFlagsNoOverWrite);
+
+        CHK_NULL_RETURN(pData);
+
+        MOS_WriteFileFromPtr(m_outputFileName, pData, BASE_OF_NODE(m_perfDataIndex));
+
+        osInterface->pfnUnlockResource(
+            osInterface,
+            &m_perfStoreBuffer);
+    }
+
+    return status;
+}
+
+MOS_GPU_NODE MediaPerfProfiler::GpuContextToGpuNode(MOS_GPU_CONTEXT context)
+{
+    MOS_GPU_NODE node = MOS_GPU_NODE_MAX;
+
+    switch (context)
+    {
+        case MOS_GPU_CONTEXT_RENDER:
+        case MOS_GPU_CONTEXT_RENDER2:
+        case MOS_GPU_CONTEXT_RENDER3:
+        case MOS_GPU_CONTEXT_RENDER4:
+        case MOS_GPU_OVERLAY_CONTEXT:
+            node = MOS_GPU_NODE_3D;
+            break;
+        case MOS_GPU_CONTEXT_COMPUTE:
+        case MOS_GPU_CONTEXT_CM_COMPUTE:
+            node = MOS_GPU_NODE_3D;    // Todo: MOS_GPU_NODE_COMPUTE?
+            break;
+        case MOS_GPU_CONTEXT_VIDEO:
+        case MOS_GPU_CONTEXT_VIDEO2:
+        case MOS_GPU_CONTEXT_VIDEO3:
+        case MOS_GPU_CONTEXT_VIDEO4:
+            node = MOS_GPU_NODE_VIDEO;
+            break;
+        case MOS_GPU_CONTEXT_VDBOX2_VIDEO:
+        case MOS_GPU_CONTEXT_VDBOX2_VIDEO2:
+        case MOS_GPU_CONTEXT_VDBOX2_VIDEO3:
+            node = MOS_GPU_NODE_VIDEO2;
+            break;
+        case MOS_GPU_CONTEXT_VEBOX:
+        case MOS_GPU_CONTEXT_VEBOX2:
+            node = MOS_GPU_NODE_VE;
+            break;
+        default:
+            break;
+    }
+
+    return node;
+}

--- a/media_driver/agnostic/common/shared/media_perf_profiler.cpp
+++ b/media_driver/agnostic/common/shared/media_perf_profiler.cpp
@@ -207,7 +207,7 @@ MOS_STATUS MediaPerfProfiler::Initialize(void* context, MOS_INTERFACE *osInterfa
         return status;
     }
 
-    // Read output file name from registry
+    // Read output file name
     MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));
     userFeatureData.StringData.pStringData = m_outputFileName;
     MOS_UserFeature_ReadValue_ID(
@@ -226,7 +226,7 @@ MOS_STATUS MediaPerfProfiler::Initialize(void* context, MOS_INTERFACE *osInterfa
         userFeatureData.StringData.uSize++;
     }
 
-    // Read buffer size from registry
+    // Read buffer size
     MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));
     MOS_UserFeature_ReadValue_ID(
         nullptr,
@@ -234,7 +234,7 @@ MOS_STATUS MediaPerfProfiler::Initialize(void* context, MOS_INTERFACE *osInterfa
         &userFeatureData);
     m_bufferSize = userFeatureData.u32Data;
 
-    // Read Memory information register from registry
+    // Read Memory information register
     int8_t regIndex = 0;
     for (regIndex = 0; regIndex < 8; regIndex++)
     {
@@ -467,7 +467,7 @@ MOS_STATUS MediaPerfProfiler::AddPerfCollectEndCmd(void* context,
 
     MOS_GPU_CONTEXT  gpuContext;
     bool             rcsEngineUsed = false;
-    UINT             perfDataIndex = 0;
+    uint32_t         perfDataIndex = 0;
 
     gpuContext     = osInterface->pfnGetGpuContext(osInterface);
     rcsEngineUsed = MOS_RCS_ENGINE_USED(gpuContext);
@@ -551,7 +551,7 @@ MOS_GPU_NODE MediaPerfProfiler::GpuContextToGpuNode(MOS_GPU_CONTEXT context)
             break;
         case MOS_GPU_CONTEXT_COMPUTE:
         case MOS_GPU_CONTEXT_CM_COMPUTE:
-            node = MOS_GPU_NODE_3D;    // Todo: MOS_GPU_NODE_COMPUTE?
+            node = MOS_GPU_NODE_3D;
             break;
         case MOS_GPU_CONTEXT_VIDEO:
         case MOS_GPU_CONTEXT_VIDEO2:

--- a/media_driver/agnostic/common/shared/media_perf_profiler.h
+++ b/media_driver/agnostic/common/shared/media_perf_profiler.h
@@ -1,0 +1,232 @@
+/*
+* Copyright (c) 2017, Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*/
+//!
+//! \file     media_perf_profiler.h
+//! \brief    Defines data structures and interfaces for media performance profiler.
+
+#ifndef __MEDIA_PERF_PROFILER_H__
+#define __MEDIA_PERF_PROFILER_H__
+
+#include <map>
+#include "mos_os.h"
+#include "mhw_mi.h"
+
+using Map = std::map<void*, uint32_t>;
+
+class MediaPerfProfiler
+{
+public:
+    //!
+    //! \brief    Get the instance of the profiler
+    //!
+    //! \return   pointer of profiler
+    //!
+    static MediaPerfProfiler *Instance();
+
+    //!
+    //! \brief    Destroy the resurces of profiler
+    //!
+    //! \param    [in] profiler
+    //!           Pointer of profiler
+    //! \param    [in] context
+    //!           Pointer of Codechal/VPHal
+    //! \param    [in] osInterface
+    //!           Pointer of OS interface
+    //!
+    //! \return   void
+    //!
+    static void Destroy(MediaPerfProfiler* profiler, void* context, MOS_INTERFACE *osInterface);
+
+    //!
+    //! \brief    Initialize profiler and allcoate resources
+    //!
+    //! \param    [in] context
+    //!           Pointer of Codechal/VPHal
+    //! \param    [in] osInterface
+    //!           Pointer of OS interface
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS Initialize(void* context, MOS_INTERFACE *osInterface);
+
+    //!
+    //! \brief    Insert start command of storing performance data
+    //!
+    //! \param    [in] context
+    //!           Pointer of Codechal/VPHal
+    //! \param    [in] osInterface
+    //!           Pointer of OS interface
+    //! \param    [in] miInterface
+    //!           pointer of MI interface
+    //! \param    [in] cmdBuffer
+    //!           Pointer of OS command buffer
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS AddPerfCollectStartCmd(void* context,
+        MOS_INTERFACE *osInterface,
+        MhwMiInterface *miInterface,
+        MOS_COMMAND_BUFFER *cmdBuffer);
+
+    //!
+    //! \brief    Insert end command of storing performance data
+    //!
+   //! \param    [in] context
+    //!           Pointer of Codechal/VPHal
+    //! \param    [in] osInterface
+    //!           Pointer of OS interface
+    //! \param    [in] miInterface
+    //!           pointer of MI interface
+    //! \param    [in] cmdBuffer
+    //!           Pointer of OS command buffer
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS AddPerfCollectEndCmd(void* context,
+        MOS_INTERFACE *osInterface,
+        MhwMiInterface *miInterface,
+        MOS_COMMAND_BUFFER *cmdBuffer);
+
+private:
+    //!
+    //! \brief    Constructor
+    //!
+    MediaPerfProfiler();
+
+    //!
+    //! \brief    Deconstructor
+    //!
+    virtual ~MediaPerfProfiler();
+
+    //!
+    //! \brief    Save data to the buffer which store the performance data 
+    //!
+    //! \param    [in] miInterface 
+    //!           Pointer of MI interface
+    //! \param    [in] cmdBuffer
+    //!           Pointer of OS command buffer
+    //! \param    [in] offset
+    //!           Offset in the buffer
+    //! \param    [in] value       
+    //!           Value of data
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS StoreData(MhwMiInterface *miInterface, 
+                         PMOS_COMMAND_BUFFER cmdBuffer,
+                         uint32_t offset,
+                         uint32_t value);
+
+    //!
+    //! \brief    Save register value to the buffer which store the performance data 
+    //!
+    //! \param    [in] miInterface 
+    //!           Pointer of MI interface
+    //! \param    [in] cmdBuffer
+    //!           Pointer of OS command buffer
+    //! \param    [in] offset
+    //!           Offset in the buffer
+    //! \param    [in] reg
+    //!           Address of register
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS StoreRegister(MhwMiInterface *miInterface, 
+                         PMOS_COMMAND_BUFFER cmdBuffer,
+                         uint32_t offset,
+                         uint32_t reg);
+    
+    //!
+    //! \brief    Save timestamp to the buffer by Pipe control command 
+    //!
+    //! \param    [in] miInterface 
+    //!           Pointer of MI interface
+    //! \param    [in] cmdBuffer
+    //!           Pointer of OS command buffer
+    //! \param    [in] offset
+    //!           Offset in the buffer
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS StoreTSByPipeCtrl(MhwMiInterface *miInterface,
+                         PMOS_COMMAND_BUFFER cmdBuffer,
+                         uint32_t offset);
+
+    //!
+    //! \brief    Save timestamp to the buffer by MI command 
+    //!
+    //! \param    [in] miInterface 
+    //!           Pointer of MI interface
+    //! \param    [in] cmdBuffer
+    //!           Pointer of OS command buffer
+    //! \param    [in] offset
+    //!           Offset in the buffer
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS StoreTSByMiFlush(MhwMiInterface *miInterface,
+                         PMOS_COMMAND_BUFFER cmdBuffer,
+                         uint32_t offset);
+
+    //!
+    //! \brief    Save performance data in to a file 
+    //!
+    //! \param    [in] osInterface
+    //!           Pointer of OS interface
+    //!
+    //! \return   MOS_STATUS
+    //!           MOS_STATUS_SUCCESS if success, else fail reason
+    //!
+    MOS_STATUS SavePerfData(MOS_INTERFACE *osInterface);
+
+    //!
+    //! \brief    Convert GPU context to GPU node 
+    //!
+    //! \param    [in] context
+    //!           GPU context
+    //!
+    //! \return   MOS_GPU_NODE
+    //!
+    MOS_GPU_NODE GpuContextToGpuNode(MOS_GPU_CONTEXT context);
+
+protected:
+    MOS_RESOURCE               m_perfStoreBuffer;       //!< Buffer for perf data collection
+    Map                        m_contextIndexMap;       //!< Map between CodecHal/VPHal and PerfDataContext
+    PMOS_MUTEX                 m_mutex;                 //!< Mutex for protecting data of profiler when refereced multi times
+
+    uint32_t                   m_perfDataIndex = 0;     //!< The index of performance data node in buffer
+    uint32_t                   m_ref = 0;               //!< The number of refereces
+    uint32_t                   m_bufferSize = 10000000; //!< The size of perf data buffer
+    uint32_t                   m_registers[8] = { 0 };  //!< registers of Memory information
+
+    bool                       m_initialized = false;   //!< Indicate whether profiler was initialized
+    char                       m_outputFileName[MOS_MAX_PATH_LENGTH + 1];  //!< Name of output file
+};
+
+#endif // __MEDIA_PERF_PROFILER_H__

--- a/media_driver/agnostic/common/shared/media_srcs.cmake
+++ b/media_driver/agnostic/common/shared/media_srcs.cmake
@@ -20,10 +20,12 @@
 
 set(TMP_SOURCES_
     ${CMAKE_CURRENT_LIST_DIR}/mediamemdecomp.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/media_perf_profiler.cpp
 )
 
 set(TMP_HEADERS_
     ${CMAKE_CURRENT_LIST_DIR}/mediamemdecomp.h
+    ${CMAKE_CURRENT_LIST_DIR}/media_perf_profiler.h
 )
 
 set(SOURCES_

--- a/media_driver/linux/common/os/mos_os_specific.c
+++ b/media_driver/linux/common/os/mos_os_specific.c
@@ -142,7 +142,7 @@ int32_t Linux_GetCommandBuffer(
     int32_t                 iSize)
 {
     int32_t                bResult  = false;
-    MOS_LINUX_BO    	   *cmd_bo = nullptr;
+    MOS_LINUX_BO           *cmd_bo = nullptr;
 
     if ( pOsContext == nullptr ||
          pCmdBuffer == nullptr)
@@ -1481,7 +1481,7 @@ MOS_STATUS Mos_Specific_AllocateResource(
     int32_t                 iPitch;
     unsigned long           ulPitch;
     MOS_STATUS              eStatus;
-    MOS_LINUX_BO	    *bo;
+    MOS_LINUX_BO            *bo;
     MOS_TILE_TYPE           tileformat;
     uint32_t                tileformat_linux;
     int32_t                 iHeight;
@@ -2523,7 +2523,7 @@ void Mos_Specific_ResetResourceAllocationIndex (
 MOS_STATUS Mos_Specific_GetCommandBuffer(
     PMOS_INTERFACE          pOsInterface,
     PMOS_COMMAND_BUFFER     pCmdBuffer,
-	uint32_t                dwFlags)
+    uint32_t                dwFlags)
 {
 
     PMOS_OS_CONTEXT         pOsContext;
@@ -2715,7 +2715,7 @@ MOS_STATUS Mos_Specific_GetIndirectStatePointer(
 void Mos_Specific_ReturnCommandBuffer(
     PMOS_INTERFACE          pOsInterface,
     PMOS_COMMAND_BUFFER     pCmdBuffer,
-	uint32_t                dwFlags)
+    uint32_t                dwFlags)
 {
     PMOS_OS_CONTEXT         pOsContext;
     int32_t                 bResult;
@@ -2813,7 +2813,7 @@ MOS_LINUX_BO * Mos_GetBadCommandBuffer_Linux(
     // 31:29 = 0
     // 28:23 = 0x1c
     // ---> 31:24 = 0x0e, 23=0x0
-    // 22:22 = 0x1	(GTT, must be secure batch)
+    // 22:22 = 0x1    (GTT, must be secure batch)
     // 21:16 = 0x0
     // ---> 23:20 = 0x4, 19:16=0x0
     // 15:15 = 0x1 (polling mode)
@@ -3066,8 +3066,8 @@ MOS_STATUS Mos_Specific_SubmitCommandBuffer(
     
     //dwComponentTag 3: decode,5: vpp,6: encode
     //dwCallType     8: PAK(CODECHAL_ENCODE_PERFTAG_CALL_PAK_ENGINE)
-    //		     34: PREENC
-    //		     5: VPP
+    //             34: PREENC
+    //             5: VPP
     dwComponentTag = (PerfData & 0xF000) >> 12;
     dwCallType     = (PerfData & 0xFC) >> 2;
 
@@ -3145,7 +3145,7 @@ MOS_STATUS Mos_Specific_SubmitCommandBuffer(
      }
      else
      {
-       	ret = mos_bo_mrb_exec(cmd_bo,
+           ret = mos_bo_mrb_exec(cmd_bo,
                                        pOsGpuContext->uiCommandBufferSize,
                                        cliprects,
                                        num_cliprects,
@@ -3534,11 +3534,15 @@ void Mos_Specific_IncPerfFrameID(
 uint32_t Mos_Specific_GetPerfTag(
     PMOS_INTERFACE pOsInterface)
 {
-    uint32_t                dwPerfTag;
-    MOS_UNUSED(pOsInterface);
-    dwPerfTag = 0;
+    PMOS_CONTEXT osContext = (pOsInterface) ? (PMOS_CONTEXT)pOsInterface->pOsContext : nullptr;
 
-    return dwPerfTag;
+    if (osContext == nullptr || !osContext->uEnablePerfTag)
+    {
+        return 0;
+    }
+
+    perfTag = *(uint32_t *)(osContext->pPerfData);
+    return perfTag;
 }
 
 //!
@@ -4696,7 +4700,7 @@ MOS_STATUS Mos_Specific_SetMemoryCompressionHint(
 finish:
     return eStatus;
 }
-		
+        
 #ifdef ANDROID
 //!
 //! \brief    Create GPU node association.
@@ -5342,15 +5346,15 @@ MOS_STATUS Mos_Specific_InitInterface(
     Mos_Solo_Initialize(pOsInterface);
 #endif // MOS_MEDIASOLO_SUPPORTED
 
-	// read the "Disable KMD Watchdog" user feature key
+    // read the "Disable KMD Watchdog" user feature key
     MOS_ZeroMemory(&UserFeatureData, sizeof(UserFeatureData));
     MOS_UserFeature_ReadValue_ID(
         nullptr,
         __MEDIA_USER_FEATURE_VALUE_DISABLE_KMD_WATCHDOG_ID,
         &UserFeatureData);
-    pOsContext->bDisableKmdWatchdog = (UserFeatureData.i32Data) ? true : false;	
-	
-	// read "Linux PerformanceTag Enable" user feature key
+    pOsContext->bDisableKmdWatchdog = (UserFeatureData.i32Data) ? true : false;    
+    
+    // read "Linux PerformanceTag Enable" user feature key
     MOS_ZeroMemory(&UserFeatureData, sizeof(UserFeatureData));
     MOS_UserFeature_ReadValue_ID(
         nullptr,


### PR DESCRIPTION
This profiler can collect GT timing and memory bandwidth information into a bin file, which help us to debug performance issues.