### PR TITLE
remove the minimum resolution attribute for decode

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -2103,26 +2103,6 @@ VAStatus MediaLibvaCaps::QuerySurfaceAttributes(
         attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE;
         attribs[i].value.value.i = maxHeight;
         i++;
-
-        attribs[i].type = VASurfaceAttribMinWidth;
-        attribs[i].value.type = VAGenericValueTypeInteger;
-        attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE;
-        attribs[i].value.value.i = m_encMinWidth;
-        if(profile == VAProfileJPEGBaseline)
-        {
-            attribs[i].value.value.i = m_encJpegMinWidth;
-        }
-        i++;
-
-        attribs[i].type = VASurfaceAttribMinHeight;
-        attribs[i].value.type = VAGenericValueTypeInteger;
-        attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE;
-        attribs[i].value.value.i = m_encMinHeight;
-        if(profile == VAProfileJPEGBaseline)
-        {
-            attribs[i].value.value.i = m_encJpegMinHeight;
-        }
-        i++;
     }
     else if(entrypoint == VAEntrypointEncSlice)
     {


### PR DESCRIPTION
to pass the libva-utils test. the resolution check in vaCreateContext should be same as the vaQuerySurfaceAttributes consistent.  
Signed-off-by: XinfengZhang <carl.zhang@intel.com>