### PR TITLE
change the resolution check for MPEG2 encode

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -1572,6 +1572,16 @@ VAStatus MediaLibvaCaps::CheckEncodeResolution(
                 return VA_STATUS_ERROR_RESOLUTION_NOT_SUPPORTED;
             }
             break;
+        case VAProfileMPEG2Simple:
+        case VAProfileMPEG2Main:
+            if( width > CODEC_MAX_PIC_WIDTH
+                    || width < m_encMinWidth
+                    || height > CODEC_MAX_PIC_HEIGHT
+                    || height < m_encMinHeight)
+            {
+                return VA_STATUS_ERROR_RESOLUTION_NOT_SUPPORTED;
+            }
+            break; 
         default:
             if (width > m_encMax4kWidth 
                     || width < m_encMinWidth


### PR DESCRIPTION
the resolution check should be same as resolution capability reported by vaQuerySurfaceAttributes
Signed-off-by: XinfengZhang <carl.zhang@intel.com>