### PR TITLE
xf86drm.c: include sys/sysmacros.h for makedev support

### DIFF
--- a/media_driver/linux/common/os/libdrm/xf86drm.c
+++ b/media_driver/linux/common/os/libdrm/xf86drm.c
@@ -47,6 +47,7 @@
 #include <signal.h>
 #include <time.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #define stat_t struct stat
 #include <sys/ioctl.h>


### PR DESCRIPTION
In newer GNU C Library, makedev is deprecated in sys/types.h
and will be removed soon.  makedev was moved to sys/sysmacros.h
header instead.

Fixes #94

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>