### PR TITLE
fix libva 2.0 render

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -1320,7 +1320,10 @@ VAStatus DdiMedia__Initialize (
     mediaCtx->bIsAtomSOC = IS_ATOMSOC(mediaCtx->iDeviceId);
 
 #ifndef ANDROID
-    output_dri_init(ctx);
+    if (!output_dri_init(ctx))
+    {
+        return VA_STATUS_ERROR_OPERATION_FAILED;
+    }
 #endif
 
     eStatus = Mos_Solo_DdiInitializeDeviceId(

--- a/media_driver/linux/common/ddi/media_libva_putsurface_linux.cpp
+++ b/media_driver/linux/common/ddi/media_libva_putsurface_linux.cpp
@@ -158,11 +158,11 @@ bool output_dri_init(VADriverContextP ctx)
     mediaDrvCtx->dri_output = nullptr;
 
     static const struct dso_symbol symbols[] = {
-        { "dri_get_drawable",
+        { "va_dri_get_drawable",
           offsetof(struct dri_vtable, get_drawable) },
-        { "dri_get_rendering_buffer",
+        { "va_dri_get_rendering_buffer",
           offsetof(struct dri_vtable, get_rendering_buffer) },
-        { "dri_swap_buffer",
+        { "va_dri_swap_buffer",
           offsetof(struct dri_vtable, swap_buffer) },
         { nullptr, }
     };

--- a/media_driver/linux/common/ddi/media_libva_putsurface_linux.h
+++ b/media_driver/linux/common/ddi/media_libva_putsurface_linux.h
@@ -31,7 +31,7 @@
 #include <va/va_dricommon.h>
 #include "mos_defs.h"
 
-#define LIBVA_X11_NAME "libva-x11.so.1"
+#define LIBVA_X11_NAME "libva-x11.so.2"
 typedef struct dri_drawable *(*dri_get_drawable_func)(
     VADriverContextP ctx, XID drawable);
 typedef union dri_buffer *(*dri_get_rendering_buffer_func)(


### PR DESCRIPTION

Fix decoder render failed:
[#60](https://github.com/Intel-Media-SDK/MediaSDK/issues/60)

Since libva change some function names in:
[3da712d668d065476b0fee5fcf5aaf33d63cd2d2](https://github.com/intel/libva/commit/3da712d668d065476b0fee5fcf5aaf33d63cd2d2)
