### PR TITLE
cmake: allow fatal warnings to be disabled during build

### DIFF
--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -59,7 +59,11 @@ set_source_files_properties(${SOURCES_} PROPERTIES LANGUAGE "CXX")
 
 add_library( ${LIB_NAME} SHARED ${SOURCES_})
 
-set_target_properties(${LIB_NAME} PROPERTIES COMPILE_FLAGS "-Werror")
+option(MEDIA_BUILD_FATAL_WARNINGS "Turn compiler warnings into fatal errors" ON)
+if(MEDIA_BUILD_FATAL_WARNINGS)
+    set_target_properties(${LIB_NAME} PROPERTIES COMPILE_FLAGS "-Werror")
+endif()
+
 set_target_properties(${LIB_NAME} PROPERTIES LINK_FLAGS "-Wl,--no-as-needed -Wl,--gc-sections -z relro -z now -fstack-protector -fPIC")
 set_target_properties(${LIB_NAME} PROPERTIES PREFIX "")
 


### PR DESCRIPTION
Different compiler versions often generate different
warnings that aren't always addressed (or tested)
immediately.  See #88 for example.

Allow fatal warnings (-Werror) to be turned off if
desired/necessary.  -DMEDIA_BUILD_FATAL_WARNINGS=[ON|OFF]
can be specified during cmake configure to enable/disable
fatal warnings.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>