### PR TITLE
xf86drm_mock: include sys/sysmacros.h for makedev support.

### DIFF
--- a/media_driver/linux/ult/libdrm_mock/xf86drm_mock.c
+++ b/media_driver/linux/ult/libdrm_mock/xf86drm_mock.c
@@ -47,6 +47,7 @@
 #include <signal.h>
 #include <time.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #define stat_t struct stat
 #include <sys/ioctl.h>


### PR DESCRIPTION
commit f0b683b fix the libdrm part, but missing the drm mock test.

Signed-off-by: Jun Zhao <jun.zhao@intel.com>