### PR TITLE
Fix timestamp address align issue for perf profiler for Linux

### DIFF
--- a/media_driver/agnostic/common/shared/media_perf_profiler.cpp
+++ b/media_driver/agnostic/common/shared/media_perf_profiler.cpp
@@ -452,12 +452,15 @@ MOS_STATUS MediaPerfProfiler::AddPerfCollectStartCmd(void* context,
         }
     }
 
+    // The address of timestamp must be 8 bytes aligned.
+    uint32_t offset = BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, beginTimeClockValue);
+    offset = MOS_ALIGN_CEIL(offset, 8);
+
     if (rcsEngineUsed)
     {
         CHK_STATUS_RETURN(StoreTSByPipeCtrl(
             miInterface,
             cmdBuffer, 
-            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, beginTimeClockValue)));
     }
     else
     {
@@ -508,19 +511,22 @@ MOS_STATUS MediaPerfProfiler::AddPerfCollectEndCmd(void* context,
         }
     }
 
+    // The address of timestamp must be 8 bytes aligned.
+    offset = MOS_ALIGN_CEIL(offset, 8);
+
     if (rcsEngineUsed)
     {
         CHK_STATUS_RETURN(StoreTSByPipeCtrl(
             miInterface,
             cmdBuffer,
-            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, endTimeClockValue)));
+            offset));
     }
     else
     {
         CHK_STATUS_RETURN(StoreTSByMiFlush(
             miInterface,
             cmdBuffer,
-            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, endTimeClockValue)));
+            offset));
     }
 
     return status;

--- a/media_driver/agnostic/common/shared/media_perf_profiler.cpp
+++ b/media_driver/agnostic/common/shared/media_perf_profiler.cpp
@@ -461,13 +461,14 @@ MOS_STATUS MediaPerfProfiler::AddPerfCollectStartCmd(void* context,
         CHK_STATUS_RETURN(StoreTSByPipeCtrl(
             miInterface,
             cmdBuffer, 
+            offset));
     }
     else
     {
         CHK_STATUS_RETURN(StoreTSByMiFlush(
             miInterface,
             cmdBuffer,
-            BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, beginTimeClockValue)));
+            offset));
     }
     
     return status;
@@ -512,6 +513,7 @@ MOS_STATUS MediaPerfProfiler::AddPerfCollectEndCmd(void* context,
     }
 
     // The address of timestamp must be 8 bytes aligned.
+    uint32_t offset = BASE_OF_NODE(perfDataIndex) + OFFSET_OF(PerfEntry, endTimeClockValue);
     offset = MOS_ALIGN_CEIL(offset, 8);
 
     if (rcsEngineUsed)


### PR DESCRIPTION
Fix timestamp address align issue for perf profiler for Linux
Author: Li, Xiaogang <xiaogang.li@intel.com>