### PR TITLE
Use libva-x11.so.2 soname for dlopen

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_putsurface_linux.h
+++ b/media_driver/linux/common/ddi/media_libva_putsurface_linux.h
@@ -31,7 +31,7 @@
 #include <va/va_dricommon.h>
 #include "mos_defs.h"
 
-#define LIBVA_X11_NAME "libva-x11.so"
+#define LIBVA_X11_NAME "libva-x11.so.2"
 typedef struct dri_drawable *(*dri_get_drawable_func)(
     VADriverContextP ctx, XID drawable);
 typedef union dri_buffer *(*dri_get_rendering_buffer_func)(


### PR DESCRIPTION
libva-x11.so is a linker name and is not available in the runtime
environment (if libva-devel package is not installed). Thus, on-screen
rendering with X Server will not work. This patch changes to use
soname instead.

Fixes: #150

Change-Id: I82b9943c10a9d8f0e7d12c824ebcddd9c6b6b0bd
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>