### PR TITLE
add SFC flag for decode.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decode_jpeg.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_jpeg.h
@@ -217,8 +217,7 @@ private:
     //!
     bool IsSfcInUse(CodechalSetting * codecHalSettings) override
     {
-        MOS_UNUSED(codecHalSettings);
-        return MEDIA_IS_SKU(m_skuTable, FtrSFCPipe);
+        return (codecHalSettings->sfcEnablingHinted && MEDIA_IS_SKU(m_skuTable, FtrSFCPipe));
     }
 
 protected:

--- a/media_driver/agnostic/common/codec/hal/codechal_setting.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_setting.h
@@ -56,6 +56,8 @@ public:
 
     // Decode Downsampling
     bool                    downsamplingHinted = false;    //!< Applies to decode only, application may request field scaling.
+    // Decode SFC enabling
+    bool                    sfcEnablingHinted = false;     //!< Applies to decode only, application may request field sfc.
 
     //!
     //! \brief    Destructor 

--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_jpeg.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_jpeg.cpp
@@ -864,6 +864,13 @@ VAStatus DdiDecodeJPEG::CodecHalInit(
     m_codechalSettings->mode     = CODECHAL_DECODE_MODE_JPEG;
     m_codechalSettings->standard = CODECHAL_JPEG;
 
+#ifdef _DECODE_PROCESSING_SUPPORTED
+    if (m_decProcessingType == VA_DEC_PROCESSING)
+    {
+        m_codechalSettings->sfcEnablingHinted = true;
+    }
+#endif
+
     m_ddiDecodeCtx->DecodeParams.m_iqMatrixBuffer = MOS_AllocAndZeroMemory(sizeof(CodecJpegQuantMatrix));
     if (m_ddiDecodeCtx->DecodeParams.m_iqMatrixBuffer == nullptr)
     {


### PR DESCRIPTION
we need one VAAPI flag to disable/control SFC in decode. now we using VA_DEC_PROCESSING flag.
maybe we need a new one in the next.

Signed-off-by: Zhang, Owen <owen.zhang@intel.com>