### PR TITLE
[ddi] Load libX11.so.6 instead of libX11.so

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -673,7 +673,7 @@ DDI_MEDIA_FORMAT DdiMedia_OsFormatAlphaMaskToMediaFormat(int32_t fourcc, int32_t
 
 #ifndef ANDROID
 
-#define X11_LIB_NAME "libX11.so"
+#define X11_LIB_NAME "libX11.so.6"
 
 /*
  * Close opened libX11.so lib, free related function table.


### PR DESCRIPTION
libX11.so is a linker name so it is not available if the
libX11-dev package is not installed. As a result, attempting to
render to screen with X server will fail (e.g. sample_decode -r)

This fix changes the code to dlopen the actual library name
instead: libX11.so.6

The same patch has been applied to MediaSDK samples:
https://github.com/Intel-Media-SDK/MediaSDK/issues/210

And a similar issue was addressed in media-driver:
https://github.com/intel/media-driver/issues/150