### PR TITLE
Check whether external libs exist before building driver

### DIFF
--- a/media_driver/cmake/media_utils.cmake
+++ b/media_driver/cmake/media_utils.cmake
@@ -59,4 +59,5 @@ macro (MediaAddCommonTargetDefines target)
     endif()
 endmacro()
 
+
 include( ${MEDIA_DRIVER_CMAKE}/ext/media_utils_ext.cmake OPTIONAL)

--- a/media_driver/cmake/media_utils.cmake
+++ b/media_driver/cmake/media_utils.cmake
@@ -17,6 +17,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+include (FindPkgConfig)
 
 # Only can include subdirectory which has a media_srcs.cmake
 # the effect is like include(${CMAKE_CURRENT_LIST_DIR}/<subd>/media_srcs.cmake)
@@ -59,5 +60,15 @@ macro (MediaAddCommonTargetDefines target)
     endif()
 endmacro()
 
+# find external libs, if not found, print an error message and abort cmake
+macro (find_external_libs EXTERNAL_LIBS)
+    string (REPLACE " " ";" EXTERNAL_LIBS_LIST "${EXTERNAL_LIBS}")
+    foreach (LIB ${EXTERNAL_LIBS_LIST})
+        pkg_check_modules (${LIB} REQUIRED)
+        if (NOT ${LIB}_FOUND)
+            message (FATAL_ERROR "cannot find enternal lib: ${LIB}")
+        endif ()
+    endforeach ()
+endmacro ()
 
 include( ${MEDIA_DRIVER_CMAKE}/ext/media_utils_ext.cmake OPTIONAL)

--- a/media_driver/cmake/media_utils.cmake
+++ b/media_driver/cmake/media_utils.cmake
@@ -17,7 +17,6 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-include (FindPkgConfig)
 
 # Only can include subdirectory which has a media_srcs.cmake
 # the effect is like include(${CMAKE_CURRENT_LIST_DIR}/<subd>/media_srcs.cmake)
@@ -59,16 +58,5 @@ macro (MediaAddCommonTargetDefines target)
         )
     endif()
 endmacro()
-
-# find external libs, if not found, print an error message and abort cmake
-macro (find_external_libs EXTERNAL_LIBS)
-    string (REPLACE " " ";" EXTERNAL_LIBS_LIST "${EXTERNAL_LIBS}")
-    foreach (LIB ${EXTERNAL_LIBS_LIST})
-        pkg_check_modules (${LIB} REQUIRED)
-        if (NOT ${LIB}_FOUND)
-            message (FATAL_ERROR "cannot find enternal lib: ${LIB}")
-        endif ()
-    endforeach ()
-endmacro ()
 
 include( ${MEDIA_DRIVER_CMAKE}/ext/media_utils_ext.cmake OPTIONAL)

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -23,6 +23,10 @@ project( media )
 bs_set_if_undefined(LIB_NAME iHD_drv_video)
 set (LIB_NAME_EXTERNAL_LIBS "pciaccess m pthread dl rt")
 
+include (FindPkgConfig)
+# find external libs, if not found, cmake will abort
+pkg_check_modules (${LIB_NAME_EXTERNAL_LIBS} REQUIRED)
+
 option (MEDIA_RUN_TEST_SUITE "run google test module after install" ON) 
 include(${MEDIA_DRIVER_CMAKE}/media_gen_flags.cmake)
 include(${MEDIA_DRIVER_CMAKE}/media_feature_flags.cmake)
@@ -76,7 +80,6 @@ set_target_properties(${LIB_NAME_STATIC} PROPERTIES PREFIX "")
 
 MediaAddCommonTargetDefines(${LIB_NAME_OBJ})
 
-find_external_libs ("${LIB_NAME_EXTERNAL_LIBS}")
 bs_ufo_link_libraries_noBsymbolic(
     ${LIB_NAME}
     "${INCLUDED_LIBS}"

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -21,13 +21,6 @@
 project( media )
 
 bs_set_if_undefined(LIB_NAME iHD_drv_video)
-set (LIB_NAME_EXTERNAL_LIBS "pciaccess;m;pthread;dl;rt")
-
-include (FindPkgConfig)
-# find external libs, if not found, cmake will abort
-foreach (LIB ${LIB_NAME_EXTERNAL_LIBS})
-    pkg_check_modules (${LIB} REQUIRED)
-endforeach ()
 
 option (MEDIA_RUN_TEST_SUITE "run google test module after install" ON) 
 include(${MEDIA_DRIVER_CMAKE}/media_gen_flags.cmake)
@@ -82,10 +75,18 @@ set_target_properties(${LIB_NAME_STATIC} PROPERTIES PREFIX "")
 
 MediaAddCommonTargetDefines(${LIB_NAME_OBJ})
 
+include (FindPkgConfig)
+# find external libs, if not found, cmake will abort
+pkg_check_modules (pciaccess REQUIRED)
+pkg_check_modules (m REQUIRED)
+pkg_check_modules (pthread REQUIRED)
+pkg_check_modules (dl REQUIRED)
+pkg_check_modules (rt REQUIRED)
+
 bs_ufo_link_libraries_noBsymbolic(
     ${LIB_NAME}
     "${INCLUDED_LIBS}"
-    "${LIB_NAME_EXTERNAL_LIBS}"
+    "pciaccess m pthread dl rt"
 )
 
 if (NOT DEFINED INCLUDED_LIBS OR "${INCLUDED_LIBS}" STREQUAL "")

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -21,11 +21,13 @@
 project( media )
 
 bs_set_if_undefined(LIB_NAME iHD_drv_video)
-set (LIB_NAME_EXTERNAL_LIBS "pciaccess m pthread dl rt")
+set (LIB_NAME_EXTERNAL_LIBS "pciaccess;m;pthread;dl;rt")
 
 include (FindPkgConfig)
 # find external libs, if not found, cmake will abort
-pkg_check_modules (pciaccess REQUIRED)
+foreach (LIB ${LIB_NAME_EXTERNAL_LIBS})
+    pkg_check_modules (${LIB} REQUIRED)
+endforeach ()
 
 option (MEDIA_RUN_TEST_SUITE "run google test module after install" ON) 
 include(${MEDIA_DRIVER_CMAKE}/media_gen_flags.cmake)

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -25,7 +25,7 @@ set (LIB_NAME_EXTERNAL_LIBS "pciaccess m pthread dl rt")
 
 include (FindPkgConfig)
 # find external libs, if not found, cmake will abort
-pkg_check_modules (${LIB_NAME_EXTERNAL_LIBS} REQUIRED)
+pkg_check_modules (pciaccess REQUIRED)
 
 option (MEDIA_RUN_TEST_SUITE "run google test module after install" ON) 
 include(${MEDIA_DRIVER_CMAKE}/media_gen_flags.cmake)

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -21,6 +21,7 @@
 project( media )
 
 bs_set_if_undefined(LIB_NAME iHD_drv_video)
+set (LIB_NAME_EXTERNAL_LIBS "pciaccess m pthread dl rt")
 
 option (MEDIA_RUN_TEST_SUITE "run google test module after install" ON) 
 include(${MEDIA_DRIVER_CMAKE}/media_gen_flags.cmake)
@@ -75,10 +76,11 @@ set_target_properties(${LIB_NAME_STATIC} PROPERTIES PREFIX "")
 
 MediaAddCommonTargetDefines(${LIB_NAME_OBJ})
 
+find_external_libs ("${LIB_NAME_EXTERNAL_LIBS}")
 bs_ufo_link_libraries_noBsymbolic(
     ${LIB_NAME}
     "${INCLUDED_LIBS}"
-    "pciaccess m pthread dl rt"
+    "${LIB_NAME_EXTERNAL_LIBS}"
 )
 
 if (NOT DEFINED INCLUDED_LIBS OR "${INCLUDED_LIBS}" STREQUAL "")


### PR DESCRIPTION
Check whether external libs exist before building driver, if not found, print an error message and abort cmake.