### PR TITLE
Resolve 'provide a default building configuration'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,15 @@ include(os_release_info.cmake)
 
 get_os_release_info(os_name os_version)
 
+if(NOT DEFINED CMAKE_INSTALL_PREFIX OR CMAKE_INSTALL_PREFIX STREQUAL "")
+    set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "..." FORCE)
+endif()
+message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
+
+if(NOT DEFINED MEDIA_VERSION OR MEDIA_VERSION STREQUAL "")
+    set(MEDIA_VERSION "1.0.0")
+endif()
+
 if("${os_name}" STREQUAL "clear-linux-os")
     # clear-linux-os distribution avoids /etc for distribution defaults.
     # Set this variable explicitly before including GNUInstallDirs.

--- a/README.md
+++ b/README.md
@@ -52,25 +52,7 @@ $ cd <workspace>/build_media
 ```
 5. 
 ```
-$ cmake ../media-driver \
--DCMAKE_INSTALL_PREFIX=/usr \
--DMEDIA_VERSION="2.0.0" \
--DBS_DIR_GMMLIB=`pwd`/../gmmlib/Source/GmmLib/ \
--DBS_DIR_COMMON=`pwd`/../gmmlib/Source/Common/ \
--DBS_DIR_INC=`pwd`/../gmmlib/Source/inc/ \
--DBS_DIR_MEDIA=`pwd`/../media-driver
-```
-Alternatively, copy 
-```
-<workspace>/media-driver/unified_cmake.sh
-```
-into
-```
-<workspace>/build_media
-```
-then run
-```
-$ ./unified_cmake.sh
+$ cmake ../media-driver
 ```
 6. 
 ```

--- a/Tools/bldsys/include/bs_dir_names.cmake
+++ b/Tools/bldsys/include/bs_dir_names.cmake
@@ -41,12 +41,12 @@ endif(NOT DEFINED GFX_DEVELOPMENT_DIR)
 #
 # These will be used later to help with separation of components.
 #
-bs_set_if_undefined(BS_DIR_SOURCE          "${GFX_DEVELOPMENT_DIR}/Source")
+bs_set_if_undefined(BS_DIR_SOURCE          "${CMAKE_SOURCE_DIR}/..")
 
-bs_set_if_undefined(BS_DIR_COMMON          "${BS_DIR_SOURCE}/Common")
-bs_set_if_undefined(BS_DIR_GMMLIB          "${BS_DIR_SOURCE}/GmmLib")
-bs_set_if_undefined(BS_DIR_INC             "${BS_DIR_SOURCE}/inc")
+bs_set_if_undefined(BS_DIR_COMMON          "${BS_DIR_SOURCE}/gmmlib/Source/Common")
+bs_set_if_undefined(BS_DIR_GMMLIB          "${BS_DIR_SOURCE}/gmmlib/Source/GmmLib")
+bs_set_if_undefined(BS_DIR_INC             "${BS_DIR_SOURCE}/gmmlib/Source/inc")
 bs_set_if_undefined(BS_DIR_INSTALL         "${BS_DIR_SOURCE}/install")
-bs_set_if_undefined(BS_DIR_MEDIA           "${BS_DIR_SOURCE}/media")
+bs_set_if_undefined(BS_DIR_MEDIA           "${CMAKE_SOURCE_DIR}")
 
 endif(NOT DEFINED _bs_include_dir_names)

--- a/distro_cmake.sh
+++ b/distro_cmake.sh
@@ -4,13 +4,8 @@
 # Full-open-source means only using open source EU kernels and fixed function hardware.
 
 cmake ../media-driver \
--DMEDIA_VERSION="2.0.0" \
 -DGEN8_Supported="no" \
 -DGEN8_BDW_Supported="no" \
 -DGEN9_Supported="no" \
 -DGEN9_SKL_Supported="no" \
--DFull_Open_Source_Support="yes" \
--DBS_DIR_GMMLIB=`pwd`/../gmmlib/Source/GmmLib/ \
--DBS_DIR_COMMON=`pwd`/../gmmlib/Source/Common/ \
--DBS_DIR_INC=`pwd`/../gmmlib/Source/inc/ \
--DBS_DIR_MEDIA=`pwd`/../media-driver $@
+-DFull_Open_Source_Support="yes" $@

--- a/unified_cmake.sh
+++ b/unified_cmake.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-cmake ../media-driver \
--DCMAKE_INSTALL_PREFIX=/usr \
--DMEDIA_VERSION="2.0.0" \
--DBS_DIR_GMMLIB=`pwd`/../gmmlib/Source/GmmLib/ \
--DBS_DIR_COMMON=`pwd`/../gmmlib/Source/Common/ \
--DBS_DIR_INC=`pwd`/../gmmlib/Source/inc/ \
--DBS_DIR_MEDIA=`pwd`/../media-driver $@
+cmake ../media-driver $@


### PR DESCRIPTION
Fixes: #198  
 - Default CMAKE_INSTALL_PREFIX to '/usr/local' but allow modifications at run-time
 - Default MEDIA_VERSION / UFO_VERSION to 1.0.0
 - Default gmmlib dependency paths until builds shift to dynamic linked
 - Update README.md to reflect simplified build steps
 - Update distro_cmake.sh & unified_cmake.sh scripts

Change-Id: I9250f6ff07c670a6cdf37ea516513b031508cabb