### PR TITLE
[vaCreateBuffer] one fixing for issue in vaCreateBuffer().

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_base.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_base.cpp
@@ -548,17 +548,18 @@ VAStatus DdiMediaDecode::AllocBsBuffer(
         buf->uiOffset                           = 0;
         bufMgr->pSliceData[index].bIsUseExtBuf  = true;
         bufMgr->pSliceData[index].pSliceBuf     = sliceBuf;
+        buf->bCFlushReq                         = false;
     }
     else
     {
         buf->pData                              = (uint8_t*)(bufMgr->pBitStreamBase[bufMgr->dwBitstreamIndex]);
         bufMgr->pSliceData[index].bIsUseExtBuf  = false;
         bufMgr->pSliceData[index].pSliceBuf     = nullptr;
+        buf->bCFlushReq                         = true;
     }
 
     bufMgr->dwNumSliceData ++;
     buf->bo                            = bufMgr->pBitStreamBuffObject[bufMgr->dwBitstreamIndex]->bo;
-    buf->bCFlushReq                    = true;
 
     return VA_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Here is the case, when vaCreateBuffer() is called with source data
pointer provided, and there are multiple slices in the frame, buf->pData
is assigned a different buffer for the second or following slices if
bIsSliceOverSize is true, but the calling of mos_bo_subdata() for
the second slices would copy the data to the buffer of the first slice.