### PR TITLE
Fix compile issue on clang.

### DIFF
--- a/media_driver/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_compile_flags_linux.cmake
@@ -50,7 +50,6 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -msse4
     -mfpmath=sse
     -finline-functions
-    -funswitch-loops
     -fno-short-enums
     -Wa,--noexecstack
     -fno-strict-aliasing
@@ -64,11 +63,9 @@ set(MEDIA_COMPILER_FLAGS_COMMON
 
     # Other common flags
     -fmessage-length=0
-    -fvisibility=hidden
     -fstack-protector
     -fdata-sections
     -ffunction-sections
-    -Wl,--gc-sections
 
     # -m32 or -m64
     -m${ARCH}
@@ -81,6 +78,18 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -DINTEL_NOT_PUBLIC
     -g
 )
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    list(APPEND MEDIA_COMPILER_FLAGS_COMMON
+        #this not a real gcc only option, but with this,
+        #the dll export will failed on clang
+        -fvisibility=hidden
+
+        -funswitch-loops
+        -Wl,--gc-sections
+    )
+endif()
+
 
 if(${UFO_MARCH} STREQUAL "slm")
     set(MEDIA_COMPILER_FLAGS_COMMON
@@ -103,10 +112,16 @@ if(NOT ${PLATFORM} STREQUAL "android")
     set(MEDIA_COMPILER_FLAGS_COMMON
         ${MEDIA_COMPILER_FLAGS_COMMON}
         -D__linux__
-        -fno-tree-pre
         -fPIC
-        -Wl,--no-as-needed
+
     )
+    #for gcc only flag
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        list(APPEND MEDIA_COMPILER_FLAGS_COMMON
+            -fno-tree-pre
+            -Wl,--no-as-needed
+        )
+    endif()
 endif()
 
 set(MEDIA_COMPILER_CXX_FLAGS_COMMON
@@ -143,10 +158,12 @@ endif()
 
 if(NOT ${PLATFORM} STREQUAL "android")
     if(${UFO_VARIANT} STREQUAL "default")
-        set(MEDIA_COMPILER_FLAGS_RELEASE
-            ${MEDIA_COMPILER_FLAGS_RELEASE}
-            -finline-limit=100
-        )
+        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+            set(MEDIA_COMPILER_FLAGS_RELEASE
+                ${MEDIA_COMPILER_FLAGS_RELEASE}
+                -finline-limit=100
+            )
+        endif()
     elseif(${UFO_VARIANT} STREQUAL "nano")
         set(MEDIA_COMPILER_FLAGS_RELEASE
             ${MEDIA_COMPILER_FLAGS_RELEASE}
@@ -165,10 +182,12 @@ set(MEDIA_COMPILER_FLAGS_RELEASEINTERNAL
 )
 
 if(NOT ${PLATFORM} STREQUAL "android")
-    set(MEDIA_COMPILER_FLAGS_RELEASEINTERNAL
-        ${MEDIA_COMPILER_FLAGS_RELEASEINTERNAL}
-        -finline-limit=100
-    )
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        set(MEDIA_COMPILER_FLAGS_RELEASEINTERNAL
+            ${MEDIA_COMPILER_FLAGS_RELEASEINTERNAL}
+            -finline-limit=100
+        )
+    endif()
 endif()
 
 set(MEDIA_COMPILER_FLAGS_DEBUG

--- a/media_driver/linux/common/os/mos_context_specific.cpp
+++ b/media_driver/linux/common/os/mos_context_specific.cpp
@@ -438,10 +438,10 @@ void OsContextSpecific::SetSliceCount(uint32_t *pSliceCount)
         for (int sliceCountShm = m_gtSystemInfo.SliceCount; sliceCountShm > 0; sliceCountShm--)
         {
             uint64_t* pTimestampShm = (uint64_t*)m_sseuShm + sliceCountShm;
-            uint64_t   timestampShm = __atomic_load_8(pTimestampShm, __ATOMIC_SEQ_CST);
+            uint64_t   timestampShm = __atomic_load_n(pTimestampShm, __ATOMIC_SEQ_CST);
             if (sliceNum == sliceCountShm)
             {
-                __atomic_store_8(pTimestampShm, timestamp, __ATOMIC_SEQ_CST);
+                __atomic_store_n(pTimestampShm, timestamp, __ATOMIC_SEQ_CST);
                 break;
             }
             else if (sliceNum < sliceCountShm


### PR DESCRIPTION
After applying this patch, you can use this command to build it using clang.

<pre> CFLAGS="-w" CXXFLAGS="-w" cmake ../media-driver -DCMAKE_INSTALL_PREFIX=/usr -DMEDIA_VERSION="2.0.0" -DBS_DIR_GMMLIB=`pwd`/../gmmlib/Source/GmmLib/ -DBS_DIR_COMMON=`pwd`/../gmmlib/Source/Common/ -DBS_DIR_INC=`pwd`/../gmmlib/Source/inc/ -DBS_DIR_MEDIA=`pwd`/../media-driver -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ </pre>