### PR TITLE
fix vp8 decode issue #190, change the first partition size

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
@@ -87,9 +87,8 @@ VAStatus DdiDecodeVP8::ParseSliceParams(
     picParams->uiFirstMbByteOffset = slcParam->slice_data_offset + ((slcParam->macroblock_offset + 8) >> 3);
 
     memcpy_s(picParams->uiPartitionSize, sizeof(picParams->uiPartitionSize), slcParam->partition_size, sizeof(picParams->uiPartitionSize));
-
-    //partition 0 size in command buffer includes the one byte in bool decoder if remaining bits of bool decoder is not zero.
-    picParams->uiPartitionSize[0] += (slcParam->macroblock_offset & 0x7) ? 1 : 0;
+    //partition 0 size in command buffer includes the one byte in bool decoder if remaining bits of bool decoder is zero.
+    picParams->uiPartitionSize[0] -= (slcParam->macroblock_offset & 0x7) ? 0 : 1;
 
     return VA_STATUS_SUCCESS;
 }


### PR DESCRIPTION
when the count in VABoolCoderContextVPX is zero, actually it means there are 8 bit in bool coder

correct first partition_size,when there is 8 bits in bool coder

Signed-off-by: XinfengZhang <carl.zhang@intel.com>