### PR TITLE
fix warning for -Wparentheses and -Wparentheses-equality on clang

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_allocator.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_allocator.cpp
@@ -213,7 +213,7 @@ uint32_t CodechalEncodeAllocator::GetResourceSize(uint32_t codec, ResourceName n
     RESOURCE_TAG resTag;
     MOS_ZeroMemory(&resTag, sizeof(resTag));
 
-    if (resTag.tag = GetResourceTag(SetResourceID(codec, name, index), matchLevel1))
+    if ((resTag.tag = GetResourceTag(SetResourceID(codec, name, index), matchLevel1)))
     {
         return resTag.size;
     }

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_avc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_avc.cpp
@@ -3928,7 +3928,7 @@ MOS_STATUS CodechalEncodeAvcEnc::MbEncKernel(bool mbEncIFrameDistInUse)
             m_lastTaskInPhase = false;
         }
     }
-        
+
     CODECHAL_DEBUG_TOOL(CODECHAL_ENCODE_CHK_STATUS_RETURN(m_debugInterface->DumpBuffer(
         &BrcBuffers.sBrcMbQpBuffer.OsResource,
         CodechalDbgAttr::attrInput,
@@ -5567,7 +5567,7 @@ MOS_STATUS CodechalEncodeAvcEnc::SetPictureStructs()
         bBrcRoiEnabled = (seqParams->RateControlMethod != RATECONTROL_CQP) && picParams->NumROI;
 
         // allocated resource for MB-level BRC
-        if (bMbBrcEnabled = (bMbBrcEnabled || bBrcRoiEnabled))
+        if ((bMbBrcEnabled = (bMbBrcEnabled || bBrcRoiEnabled)))
         {
             CODECHAL_ENCODE_CHK_STATUS_RETURN(AllocateResourcesMbBrc());
         }

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_csc_ds.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_csc_ds.cpp
@@ -559,7 +559,7 @@ MOS_STATUS CodechalEncodeCscDs::SetCurbeDS4x()
         curbe.DW4_OutputYBTIBottomField = ds4xDstYPlaneBtmField;
     }
 
-    if (curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled)
+    if ((curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled))
     {
         curbe.DW5_FlatnessThreshold = 128;
         curbe.DW8_FlatnessOutputBTIFrame = ds4xDstFlatness;

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_hevc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_hevc.cpp
@@ -93,7 +93,7 @@ uint32_t CodechalEncHevcState::GetPicHdrSize()
                     numEmuBytes++;   //increment by prevention byte
                 }
 
-                if ((*hdrPtr == 0x00))
+                if (*hdrPtr == 0x00)
                 {
                     zeroCount++;
                 }
@@ -511,7 +511,7 @@ MOS_STATUS CodechalEncHevcState::AddHcpWeightOffsetStateCmd(
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
     CODECHAL_ENCODE_CHK_NULL_RETURN(hevcSlcParams);
-    
+
     if (cmdBuffer == nullptr && batchBuffer == nullptr)
     {
         CODECHAL_ENCODE_ASSERTMESSAGE("There was no valid buffer to add the HW command to.");
@@ -800,7 +800,7 @@ MOS_STATUS CodechalEncHevcState::ReadHcpStatus(PMOS_COMMAND_BUFFER cmdBuffer)
 }
 
 uint8_t CodechalEncHevcState::CalculateROIRatio()
-{   
+{
     uint32_t roiSize = 0;
     for (uint32_t i = 0; i < m_hevcPicParams->NumROI; ++i)
     {
@@ -815,7 +815,7 @@ uint8_t CodechalEncHevcState::CalculateROIRatio()
         roiRatio = 2 * (numMBs * 256 / roiSize - 1);
         roiRatio = MOS_MIN(51, roiRatio);
     }
-    
+
     return (uint8_t)roiRatio;
 }
 

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_tracked_buffer.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_tracked_buffer.cpp
@@ -325,7 +325,7 @@ MOS_STATUS CodechalEncodeTrackedBuffer::AllocateMbCodeResources(uint8_t bufIndex
         "No MbCode buffer is available!");
 
     // early exit if already allocated
-    if (m_trackedBufCurrMbCode = (MOS_RESOURCE*)m_allocator->GetResource(m_standard, mbCodeBuffer, bufIndex))
+    if ((m_trackedBufCurrMbCode = (MOS_RESOURCE*)m_allocator->GetResource(m_standard, mbCodeBuffer, bufIndex)))
     {
         return MOS_STATUS_SUCCESS;
     }
@@ -342,7 +342,7 @@ MOS_STATUS CodechalEncodeTrackedBuffer::AllocateMvDataResources(uint8_t bufIndex
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
     // early exit if already allocated
-    if (m_trackedBufCurrMvData = (MOS_RESOURCE*)m_allocator->GetResource(m_standard, mvDataBuffer, bufIndex))
+    if ((m_trackedBufCurrMvData = (MOS_RESOURCE*)m_allocator->GetResource(m_standard, mvDataBuffer, bufIndex)))
     {
         return MOS_STATUS_SUCCESS;
     }
@@ -365,7 +365,7 @@ MOS_STATUS CodechalEncodeTrackedBuffer::AllocateSurfaceCsc()
     // wait to re-use once # of non-ref slots being used reaches 3
     m_waitCscSurface = (m_cscBufCurrIdx >= CODEC_NUM_REF_BUFFERS && m_cscBufCountNonRef > CODEC_NUM_NON_REF_BUFFERS);
 
-    if (m_trackedBufCurrCsc = (MOS_SURFACE*)m_allocator->GetResource(m_standard, cscSurface, m_cscBufCurrIdx))
+    if ((m_trackedBufCurrCsc = (MOS_SURFACE*)m_allocator->GetResource(m_standard, cscSurface, m_cscBufCurrIdx)))
     {
         return MOS_STATUS_SUCCESS;
     }
@@ -388,7 +388,7 @@ MOS_STATUS CodechalEncodeTrackedBuffer::AllocateSurfaceDS()
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
     // early exit if already allocated
-    if (m_trackedBufCurrDs4x = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds4xSurface, m_trackedBufCurrIdx))
+    if ((m_trackedBufCurrDs4x = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds4xSurface, m_trackedBufCurrIdx)))
     {
         if (m_encoder->m_16xMeSupported)
         {
@@ -496,7 +496,7 @@ MOS_STATUS CodechalEncodeTrackedBuffer::AllocateSurface2xDS()
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
     // early exit if already allocated
-    if (m_trackedBufCurrDs2x = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds2xSurface, m_trackedBufCurrIdx))
+    if ((m_trackedBufCurrDs2x = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds2xSurface, m_trackedBufCurrIdx)))
     {
         return MOS_STATUS_SUCCESS;
     }
@@ -542,7 +542,7 @@ MOS_STATUS CodechalEncodeTrackedBuffer::AllocateDsReconSurfacesVdenc()
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
     // early exit if already allocated
-    if (m_trackedBufCurr4xDsRecon = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds4xRecon, m_trackedBufCurrIdx))
+    if ((m_trackedBufCurr4xDsRecon = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds4xRecon, m_trackedBufCurrIdx)))
     {
         m_trackedBufCurr8xDsRecon = (MOS_SURFACE*)m_allocator->GetResource(m_standard, ds8xRecon, m_trackedBufCurrIdx);
         return MOS_STATUS_SUCCESS;

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_tracked_buffer_hevc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_tracked_buffer_hevc.cpp
@@ -40,7 +40,7 @@ MOS_STATUS CodechalEncodeTrackedBufferHevc::AllocateMvTemporalBuffer()
 {
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-    if (m_trackedBufCurrMvTemporal = (MOS_RESOURCE*)m_allocator->GetResource(m_standard, mvTemporalBuffer, m_trackedBufCurrIdx))
+    if ((m_trackedBufCurrMvTemporal = (MOS_RESOURCE*)m_allocator->GetResource(m_standard, mvTemporalBuffer, m_trackedBufCurrIdx)))
     {
         return MOS_STATUS_SUCCESS;
     }

--- a/media_driver/agnostic/common/codec/hal/codechal_mmc_decode_hevc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_mmc_decode_hevc.cpp
@@ -156,7 +156,7 @@ MOS_STATUS CodechalMmcDecodeHevc::CheckReferenceList(
     {
         for (int i = 0; i < CODEC_MAX_NUM_REF_FRAME_HEVC; i++)
         {
-            if ((m_hevcState->m_hevcPicParams->CurrPic.FrameIdx == m_hevcState->m_hevcPicParams->RefFrameList[i].FrameIdx))
+            if (m_hevcState->m_hevcPicParams->CurrPic.FrameIdx == m_hevcState->m_hevcPicParams->RefFrameList[i].FrameIdx)
             {
                 selfReference = true;
                 break;

--- a/media_driver/agnostic/gen10/codec/hal/codechal_encode_csc_ds_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_encode_csc_ds_g10.cpp
@@ -201,7 +201,7 @@ MOS_STATUS CodechalEncodeCscDsG10::SetCurbeDS4x()
         curbe.DW4_OutputYBTIBottomField = ds4xDstYPlaneBtmField;
     }
 
-    if (curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled)
+    if ((curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled))
     {
         curbe.DW5_FlatnessThreshold = 128;
     }

--- a/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_hevc_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_hevc_g10.cpp
@@ -1716,7 +1716,7 @@ MOS_STATUS CodechalVdencHevcStateG10::SetDmemHuCBrcInitReset()
         hucVdencBrcInitDmem->CuQpCtrl_U8 = 0;  // wPictureCodingType I:0, P:1, B:2
     }
 
-    if (hucVdencBrcInitDmem->LowDelayMode_U8 = (m_hevcSeqParams->FrameSizeTolerance == EFRAMESIZETOL_EXTREMELY_LOW))  // Low Delay BRC
+    if ((hucVdencBrcInitDmem->LowDelayMode_U8 = (m_hevcSeqParams->FrameSizeTolerance == EFRAMESIZETOL_EXTREMELY_LOW)))  // Low Delay BRC
     {
 
         MOS_SecureMemcpy(hucVdencBrcInitDmem->DevThreshPB0_S8, 8 * sizeof(int8_t), (void *)m_lowdelayDevThreshPB, 8 * sizeof(int8_t));
@@ -1822,7 +1822,7 @@ MOS_STATUS CodechalVdencHevcStateG10::SetConstDataHuCBrcUpdate()
         for (int i=0; i < numEstrateThreshlds +1; i++)
         {
             for (int j=0; j < m_numDevThreshlds +1; j++)
-            { 
+            {
                 hucConstData->FrmSzAdjTabI_S8[(numEstrateThreshlds +1)*j+i]= m_lowdelayDeltaFrmszI[j][i];
                 hucConstData->FrmSzAdjTabP_S8[(numEstrateThreshlds +1)*j+i]= m_lowdelayDeltaFrmszP[j][i];
                 hucConstData->FrmSzAdjTabB_S8[(numEstrateThreshlds +1)*j+i]= m_lowdelayDeltaFrmszB[j][i];

--- a/media_driver/agnostic/gen11/codec/hal/codechal_encode_csc_ds_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_encode_csc_ds_g11.cpp
@@ -685,7 +685,7 @@ MOS_STATUS CodechalEncodeCscDsG11::SetCurbeDS4x()
         curbe.DW4_OutputYBTIBottomField = ds4xDstYPlaneBtmField;
     }
 
-    if (curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled)
+    if ((curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled))
     {
         curbe.DW5_FlatnessThreshold = 128;
     }

--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_csc_ds_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_csc_ds_g9.cpp
@@ -200,7 +200,7 @@ MOS_STATUS CodechalEncodeCscDsG9::SetCurbeDS4x()
         curbe.DW4_OutputYBTIBottomField = ds4xDstYPlaneBtmField;
     }
 
-    if (curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled)
+    if ((curbe.DW6_EnableMBFlatnessCheck = m_curbeParams.bFlatnessCheckEnabled))
     {
         curbe.DW5_FlatnessThreshold = 128;
     }

--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_hevc_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_hevc_g9.cpp
@@ -3910,7 +3910,7 @@ MOS_STATUS CodechalEncHevcStateG9::AllocateEncResources()
     {
         CODECHAL_ENCODE_CHK_STATUS_RETURN(m_hmeKernel->AllocateResources());
     }
-  
+
     // BRC Distortion Surface which will be used in ME as the output, too
     // In addition, this surface should also be allocated as BRC resource once ENC is enabled
     width = MOS_ALIGN_CEIL((m_downscaledWidthInMb4x * 8), 64);
@@ -9456,7 +9456,7 @@ MOS_STATUS CodechalEncHevcStateG9::EncodeKernelFunctions()
         }
 
         //Step 1: perform 2:1 down-scaling
-        if ((m_hevcSeqParams->bit_depth_luma_minus8 == 0))  // use this for 8 bit only case.
+        if (m_hevcSeqParams->bit_depth_luma_minus8 == 0)  // use this for 8 bit only case.
         {
             CODECHAL_ENCODE_CHK_STATUS_RETURN(Encode2xScalingKernel());
         }

--- a/media_driver/agnostic/gen9_skl/codec/hal/codechal_fei_hevc_g9_skl.cpp
+++ b/media_driver/agnostic/gen9_skl/codec/hal/codechal_fei_hevc_g9_skl.cpp
@@ -5811,7 +5811,7 @@ MOS_STATUS CodechalFeiHevcStateG9Skl::EncodeKernelFunctions()
     else
     {
         //Step 1: perform 2:1 down-scaling
-        if ((m_hevcSeqParams->bit_depth_luma_minus8 == 0))  // use this for 8 bit only case.
+        if (m_hevcSeqParams->bit_depth_luma_minus8 == 0)  // use this for 8 bit only case.
         {
             CODECHAL_ENCODE_CHK_STATUS_RETURN(Encode2xScalingKernel());
         }


### PR DESCRIPTION
Please ignore first two commits, it will be merged by https://github.com/intel/media-driver/pull/236
Please just review last commit(ef46047)

if you compile current driver like this
<pre>
CFLAGS="-Werror=parentheses -Werror=parentheses-equality -Wno-logical-op-parentheses -w" CXXFLAGS="-Werror=parentheses -Werror=parentheses-equality -Wno-logical-op-parentheses -w" cmake ../media-driver -DCMAKE_INSTALL_PREFIX=/usr -DMEDIA_VERSION="2.0.0" -DBS_DIR_GMMLIB=`pwd`/../gmmlib/Source/GmmLib/ -DBS_DIR_COMMON=`pwd`/../gmmlib/Source/Common/ -DBS_DIR_INC=`pwd`/../gmmlib/Source/inc/ -DBS_DIR_MEDIA=`pwd`/../media-driver -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
</pre>
clang will complain about parentheses  things. 
It's reasonable since parentheses things are error-prone.
Plese consider merging this to fix it
