### PR TITLE
[VP]Add platform information in DdiMedia_QueryVideoProcPipelineCaps

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -5311,6 +5311,7 @@ DdiMedia_QueryVideoProcPipelineCaps(
 
     if ((context & DDI_MEDIA_MASK_VACONTEXT_TYPE) == DDI_MEDIA_VACONTEXTID_OFFSET_DECODER)
     {
+        //Decode+SFC, go SFC path, the restriction here is the capability of SFC
         pipeline_caps->num_input_pixel_formats    = 1;
         pipeline_caps->input_pixel_format[0]      = VA_FOURCC_NV12;
         pipeline_caps->num_output_pixel_formats   = 1;
@@ -5334,12 +5335,23 @@ DdiMedia_QueryVideoProcPipelineCaps(
     }
     else if ((context & DDI_MEDIA_MASK_VACONTEXT_TYPE) == DDI_MEDIA_VACONTEXTID_OFFSET_VP)
     {
-        pipeline_caps->max_input_width            = VP_MAX_PIC_WIDTH;
-        pipeline_caps->max_input_height           = VP_MAX_PIC_HEIGHT;
+        if(mediaCtx->platform.eRenderCoreFamily <= IGFX_GEN8_CORE)
+        {
+            //Capability of Gen8- platform
+            pipeline_caps->max_input_width            = VP_MAX_PIC_WIDTH_Gen8;
+            pipeline_caps->max_input_height           = VP_MAX_PIC_HEIGHT_Gen8;
+            pipeline_caps->max_output_width           = VP_MAX_PIC_WIDTH_Gen8;
+            pipeline_caps->max_output_height          = VP_MAX_PIC_HEIGHT_Gen8;
+        }else
+        {
+            //Capability of Gen9+ platform
+            pipeline_caps->max_input_width            = VP_MAX_PIC_WIDTH;
+            pipeline_caps->max_input_height           = VP_MAX_PIC_HEIGHT;
+            pipeline_caps->max_output_width           = VP_MAX_PIC_WIDTH;
+            pipeline_caps->max_output_height          = VP_MAX_PIC_HEIGHT;
+        }
         pipeline_caps->min_input_width            = VP_MIN_PIC_WIDTH;
         pipeline_caps->min_input_height           = VP_MIN_PIC_HEIGHT;
-        pipeline_caps->max_output_width           = VP_MAX_PIC_WIDTH;
-        pipeline_caps->max_output_height          = VP_MAX_PIC_HEIGHT;
         pipeline_caps->min_output_width           = VP_MIN_PIC_WIDTH;
         pipeline_caps->min_output_height          = VP_MIN_PIC_WIDTH;
     }

--- a/media_driver/linux/common/vp/ddi/media_libva_vp.h
+++ b/media_driver/linux/common/vp/ddi/media_libva_vp.h
@@ -36,12 +36,17 @@
 #include "mos_os.h"
 
 // Maximum primary surface number in VP
-#define VP_MAX_PRIMARY_SURFS 1
+#define VP_MAX_PRIMARY_SURFS     1
 
-#define VP_MAX_PIC_WIDTH    16384
-#define VP_MAX_PIC_HEIGHT   16384
-#define VP_MIN_PIC_WIDTH    16
-#define VP_MIN_PIC_HEIGHT   16
+//For Gen8, only support max 16k-32
+#define VP_MAX_PIC_WIDTH_Gen8    16352
+#define VP_MAX_PIC_HEIGHT_Gen8   16352
+//For Gen9+ platform, supprot 16k
+#define VP_MAX_PIC_WIDTH         16384
+#define VP_MAX_PIC_HEIGHT        16384
+
+#define VP_MIN_PIC_WIDTH         16
+#define VP_MIN_PIC_HEIGHT        16
 
 // surface flag : 1 secure;  0 clear
 #if (VA_MAJOR_VERSION < 1)


### PR DESCRIPTION
Fix #201, add platform information in DdiMedia_QueryVideoProcPipelineCaps to distinguish Gen8 and Gen9+ max width and height