### PR TITLE
Jpeg encode full packed header support 

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_jpeg.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_jpeg.cpp
@@ -101,6 +101,7 @@ MOS_STATUS CodechalEncodeJpegState::InitializePicture(const EncoderParams& param
     m_applicationData       = params.pApplicationData;
     m_appDataSize           = params.dwAppDataSize;
     m_jpegQuantMatrixSent   = params.bJpegQuantMatrixSent;
+    m_fullHeaderInAppData   = params.fullHeaderInAppData;
 
     CODECHAL_ENCODE_CHK_NULL_RETURN(m_jpegPicParams);
     CODECHAL_ENCODE_CHK_NULL_RETURN(m_jpegScanParams);
@@ -832,7 +833,6 @@ MOS_STATUS CodechalEncodeJpegState::ExecuteSliceLevel()
         scanObjectParams.pJpegEncodeScanParams  = m_jpegScanParams;
 
         CODECHAL_ENCODE_CHK_STATUS_RETURN(m_mfxInterface->AddMfcJpegScanObjCmd(&cmdBuffer, &scanObjectParams));
-
         // set MFC_JPEG_PAK_INSERT_OBJECT
         MHW_VDBOX_PAK_INSERT_PARAMS pakInsertObjectParams;
         MOS_ZeroMemory(&pakInsertObjectParams, sizeof(pakInsertObjectParams));
@@ -840,17 +840,18 @@ MOS_STATUS CodechalEncodeJpegState::ExecuteSliceLevel()
         // The largest component written through the MFC_JPEG_PAK_INSERT_OBJECT command is Huffman table
         pakInsertObjectParams.pBsBuffer = (BSBuffer *)MOS_AllocAndZeroMemory(sizeof(CodechalEncodeJpegFrameHeader));
         CODECHAL_ENCODE_CHK_NULL_RETURN(pakInsertObjectParams.pBsBuffer);
-
-        // Add SOI (0xFFD8) (only if it was sent by the application)
-        CODECHAL_ENCODE_CHK_STATUS_RETURN(PackSOI(pakInsertObjectParams.pBsBuffer));
-        pakInsertObjectParams.dwOffset                      = 0;
-        pakInsertObjectParams.dwBitSize                     = pakInsertObjectParams.pBsBuffer->BufferSize;
-        pakInsertObjectParams.bLastHeader                   = false;
-        pakInsertObjectParams.bEndOfSlice                   = false;
-        pakInsertObjectParams.bResetBitstreamStartingPos    = 1; // from discussion with HW Architect
-        CODECHAL_ENCODE_CHK_STATUS_RETURN(m_mfxInterface->AddMfxPakInsertObject(&cmdBuffer, nullptr, &pakInsertObjectParams));
-        MOS_FreeMemory(pakInsertObjectParams.pBsBuffer->pBase);
-
+        if(!m_fullHeaderInAppData)
+        {
+            // Add SOI (0xFFD8) (only if it was sent by the application)
+            CODECHAL_ENCODE_CHK_STATUS_RETURN(PackSOI(pakInsertObjectParams.pBsBuffer));
+            pakInsertObjectParams.dwOffset                      = 0;
+            pakInsertObjectParams.dwBitSize                     = pakInsertObjectParams.pBsBuffer->BufferSize;
+            pakInsertObjectParams.bLastHeader                   = false;
+            pakInsertObjectParams.bEndOfSlice                   = false;
+            pakInsertObjectParams.bResetBitstreamStartingPos    = 1; // from discussion with HW Architect
+            CODECHAL_ENCODE_CHK_STATUS_RETURN(m_mfxInterface->AddMfxPakInsertObject(&cmdBuffer, nullptr, &pakInsertObjectParams));
+            MOS_FreeMemory(pakInsertObjectParams.pBsBuffer->pBase);
+        }
         // Add Application data if it was sent by application
         if (m_applicationData != nullptr)
         {
@@ -882,8 +883,17 @@ MOS_STATUS CodechalEncodeJpegState::ExecuteSliceLevel()
                 CODECHAL_ENCODE_CHK_STATUS_RETURN(PackApplicationData(pakInsertObjectParams.pBsBuffer, appDataChunk, appDataChunkSize));
                 pakInsertObjectParams.dwOffset                      = 0;
                 pakInsertObjectParams.dwBitSize                     = pakInsertObjectParams.pBsBuffer->BufferSize;
-                pakInsertObjectParams.bLastHeader                   = false;
-                pakInsertObjectParams.bEndOfSlice                   = false;
+                //if full header is included in application data, it will be the last insert headers
+                if((appDataCmdSizeResidue == 0) && m_fullHeaderInAppData)
+                {
+                    pakInsertObjectParams.bLastHeader                   = true;
+                    pakInsertObjectParams.bEndOfSlice                   = true;
+                }
+                else
+                {
+                    pakInsertObjectParams.bLastHeader                   = false;
+                    pakInsertObjectParams.bEndOfSlice                   = false;
+                }
                 pakInsertObjectParams.bResetBitstreamStartingPos    = 1; // from discussion with HW Architect
                 CODECHAL_ENCODE_CHK_STATUS_RETURN(m_mfxInterface->AddMfxPakInsertObject(&cmdBuffer, nullptr,
                     &pakInsertObjectParams));
@@ -901,8 +911,17 @@ MOS_STATUS CodechalEncodeJpegState::ExecuteSliceLevel()
                 CODECHAL_ENCODE_CHK_STATUS_RETURN(PackApplicationData(pakInsertObjectParams.pBsBuffer, appDataChunk, appDataCmdSizeResidue));
                 pakInsertObjectParams.dwOffset                      = 0;
                 pakInsertObjectParams.dwBitSize                     = pakInsertObjectParams.pBsBuffer->BufferSize;
-                pakInsertObjectParams.bLastHeader                   = false;
-                pakInsertObjectParams.bEndOfSlice                   = false;
+                //if full header is included in application data, it will be the last insert headers
+                if(m_fullHeaderInAppData)
+                {
+                    pakInsertObjectParams.bLastHeader                   = true;
+                    pakInsertObjectParams.bEndOfSlice                   = true;
+                }
+                else
+                {
+                    pakInsertObjectParams.bLastHeader                   = false;
+                    pakInsertObjectParams.bEndOfSlice                   = false;
+                }
                 pakInsertObjectParams.bResetBitstreamStartingPos    = 1; // from discussion with HW Architect
                 CODECHAL_ENCODE_CHK_STATUS_RETURN(m_mfxInterface->AddMfxPakInsertObject(&cmdBuffer, nullptr,
                     &pakInsertObjectParams));
@@ -910,7 +929,8 @@ MOS_STATUS CodechalEncodeJpegState::ExecuteSliceLevel()
 
             MOS_FreeMemory(appDataChunk);
         }
-
+        if(!m_fullHeaderInAppData)
+        {
         // Add Quant Table for Y
         CODECHAL_ENCODE_CHK_STATUS_RETURN(PackQuantTable(pakInsertObjectParams.pBsBuffer, jpegComponentY));
 
@@ -1001,7 +1021,7 @@ MOS_STATUS CodechalEncodeJpegState::ExecuteSliceLevel()
         CODECHAL_ENCODE_CHK_STATUS_RETURN(m_mfxInterface->AddMfxPakInsertObject(&cmdBuffer, nullptr,
             &pakInsertObjectParams));
         MOS_FreeMemory(pakInsertObjectParams.pBsBuffer->pBase);
-
+        }
         MOS_FreeMemory(pakInsertObjectParams.pBsBuffer);
     }
 

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_jpeg.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_jpeg.h
@@ -203,6 +203,7 @@ public:
     // Other
     uint32_t                                    m_appDataSize         = 0;                                     //!< Pointer to Application data size
     bool                                        m_jpegQuantMatrixSent  = false;                                //!< JPEG: bool to tell if quant matrix was sent by the app or not
+    bool                                        m_fullHeaderInAppData  = false;
 
 protected:
     //!

--- a/media_driver/agnostic/common/codec/shared/codec_def_encode.h
+++ b/media_driver/agnostic/common/codec/shared/codec_def_encode.h
@@ -128,6 +128,8 @@ struct EncoderParams
     MOS_SURFACE                     mbQpSurface;
     MOS_SURFACE                     disableSkipMapSurface;          //!< [AVC] MB disable skip map provided by framework
     HANDLE                          gpuAppTaskEvent;                // MSDK event handling
+
+    bool                            fullHeaderInAppData;         //!< [JPEG]
 };
 
 #endif // !__CODEC_DEF_ENCODE_H__

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.cpp
@@ -505,9 +505,16 @@ VAStatus DdiEncodeJpeg::EncodeInCodecHal(uint32_t numSlices)
     encodeParams.ExecCodecFunction = CODECHAL_FUNCTION_PAK;
 
     // Check if Qunt table was sent by application
+    // if it is not sent  by application, driver will use default and scaled by quality setting
+    // if it is sent by application, and it also packed header with scaled qmatrix
+    // scal the qmatrix to change with quality setting
     if (!m_quantSupplied)
     {
         DefaultQmatrix();
+    }
+    else if(m_appDataWholeHeader)
+    {
+        QualityScaleQmatrix();
     }
 
     // Raw Surface
@@ -628,6 +635,55 @@ VAStatus DdiEncodeJpeg::DefaultQmatrix()
             {
                 quantValue = (defaultChromaQuant[i] * quality + 50) / 100;
             }
+
+            // Clamp the value to range between 1 and 255
+            if (quantValue < 1)
+            {
+                quantValue = 1;
+            }
+            else if (quantValue > 255)
+            {
+                quantValue = 255;
+            }
+
+            quantMatrix->m_quantTable[qMatrixCount].m_qm[i] = (uint16_t)quantValue;
+        }
+    }
+
+    return VA_STATUS_SUCCESS;
+}
+
+VAStatus DdiEncodeJpeg::QualityScaleQmatrix()
+{
+    DDI_CHK_NULL(m_encodeCtx, "nullptr m_encodeCtx", VA_STATUS_ERROR_INVALID_PARAMETER);
+
+    CodecEncodeJpegQuantTable *quantMatrix = (CodecEncodeJpegQuantTable *)m_encodeCtx->pQmatrixParams;
+    DDI_CHK_NULL(quantMatrix, "nullptr quantMatrix", VA_STATUS_ERROR_INVALID_PARAMETER);
+
+    // To get Quality from Pic Params
+    CodecEncodeJpegPictureParams *picParams = (CodecEncodeJpegPictureParams *)m_encodeCtx->pPicParams;
+    DDI_CHK_NULL(picParams, "nullptr picParams", VA_STATUS_ERROR_INVALID_PARAMETER);
+
+    uint32_t quality = 0;
+    if (picParams->m_quality < 50)
+    {
+        quality = 5000 / picParams->m_quality;
+    }
+    else
+    {
+        quality = 200 - (picParams->m_quality * 2);
+    }
+
+    // 2 tables - one for luma and one for chroma
+    for (int32_t qMatrixCount = 0; qMatrixCount < picParams->m_numQuantTable; qMatrixCount++)
+    {
+        quantMatrix->m_quantTable[qMatrixCount].m_precision = 0;
+        quantMatrix->m_quantTable[qMatrixCount].m_tableID   = qMatrixCount;
+
+        for (int32_t i = 0; i < numQuantMatrix; i++)
+        {
+            uint32_t quantValue = 0;
+            quantValue = ( ((uint32_t)(quantMatrix->m_quantTable[qMatrixCount].m_qm[i])) * quality + 50) / 100;
 
             // Clamp the value to range between 1 and 255
             if (quantValue < 1)

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.cpp
@@ -79,6 +79,8 @@ VAStatus DdiEncodeJpeg::ContextInitialize(CodechalSetting *codecHalSettings)
 
     m_quantSupplied                 = false;
     m_appDataSize      = 0;
+    m_appDataTotalSize = 0;
+    m_appDataWholeHeader  = false;
 
     m_encodeCtx->pPicParams = (void *)MOS_AllocAndZeroMemory(sizeof(CodecEncodeJpegPictureParams));
     DDI_CHK_NULL(m_encodeCtx->pPicParams, "nullptr m_encodeCtx->pPicParams.", VA_STATUS_ERROR_ALLOCATION_FAILED);
@@ -160,15 +162,29 @@ VAStatus DdiEncodeJpeg::RenderPicture(
         }
 
         case VAEncPackedHeaderParameterBufferType:
-            if (*((int32_t *)data) != VA_ENC_PACKED_HEADER_MISC)
+            if (*((int32_t *)data) != VAEncPackedHeaderRawData)
             {
                 vaStatus = VA_STATUS_ERROR_INVALID_BUFFER;
+            }
+            else
+            {
+                m_appDataSize = (((VAEncPackedHeaderParameterBuffer *)data)->bit_length + 7) >> 3;
             }
             break;
 
         case VAEncPackedHeaderDataBufferType:
-        case VAEncPackedHeaderRawData:
-            vaStatus = ParseAppData(data, buf->iSize);
+            {
+                uint8_t *tmpAppData = (uint8_t *)data;
+                //by default m_appDataWholeHeader is false, it means it only include headers between 0xFFE0 to 0xFFEF;
+                //follow JPEG spec definition of application segment definition
+                //if the packed header is start with 0xFFD8, a new SOI, it should include whole jpeg headers
+                if((tmpAppData[0] == 0xFF) && (tmpAppData[1] == 0xD8))
+                {
+                    m_appDataWholeHeader = true;
+                }
+                vaStatus = ParseAppData(data, m_appDataSize);
+                m_appDataSize = 0;
+            }
             break;
 
         case VAHuffmanTableBufferType:
@@ -203,6 +219,9 @@ VAStatus DdiEncodeJpeg::ResetAtFrameLevel()
     picParams->m_inputSurfaceFormat = ConvertMediaFormatToInputSurfaceFormat(m_encodeCtx->RTtbl.pCurrentRT->format);
 
     m_appDataSize = 0;
+    m_appDataTotalSize = 0;
+    m_appDataWholeHeader = false;
+    m_quantSupplied = false;
 
     return VA_STATUS_SUCCESS;
 }
@@ -424,7 +443,7 @@ VAStatus DdiEncodeJpeg::ParseAppData(void *ptr, int32_t size)
     DDI_CHK_NULL(m_encodeCtx, "nullptr m_encodeCtx.", VA_STATUS_ERROR_INVALID_PARAMETER);
     DDI_CHK_NULL(ptr, "nullptr ptr.", VA_STATUS_ERROR_INVALID_PARAMETER);
 
-    uint32_t prevAppDataSize = m_appDataSize;
+    uint32_t prevAppDataSize = m_appDataTotalSize;
 
     if (m_appData == nullptr)
     {
@@ -460,7 +479,7 @@ VAStatus DdiEncodeJpeg::ParseAppData(void *ptr, int32_t size)
 
     }
 
-    m_appDataSize += size;
+    m_appDataTotalSize += size;
 
     return VA_STATUS_SUCCESS;
 }
@@ -523,7 +542,8 @@ VAStatus DdiEncodeJpeg::EncodeInCodecHal(uint32_t numSlices)
     // Slice level data
     encodeParams.dwNumSlices      = numSlices;
     encodeParams.dwNumHuffBuffers = picParams->m_numCodingTable;
-    encodeParams.dwAppDataSize    = m_appDataSize;
+    encodeParams.dwAppDataSize    = m_appDataTotalSize;
+    encodeParams.fullHeaderInAppData = m_appDataWholeHeader;
 
     encodeParams.pQuantizationTable = m_encodeCtx->pQmatrixParams;
     encodeParams.pHuffmanTable      = m_huffmanTable;

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.h
@@ -228,7 +228,14 @@ private:
     //!           VA_STATUS_SUCCESS if success, else fail reason
     //!
     VAStatus DefaultQmatrix();
-
+    //!
+    //! \brief    scale Qmatrix buffer to Encode Context,
+    //!           if qmatrix and full jpeg headers are supplied by application
+    //!
+    //! \return   VAStatus
+    //!           VA_STATUS_SUCCESS if success, else fail reason
+    //!
+    VAStatus QualityScaleQmatrix();
     //!
     //! \brief    Convert Media Format To Input Surface Format
     //!

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_jpeg.h
@@ -243,6 +243,8 @@ private:
     CodecEncodeJpegHuffmanDataArray    *m_huffmanTable = nullptr;    //!< Huffman table.
     void                               *m_appData      = nullptr;    //!< Application data.
     bool                               m_quantSupplied = false;      //!< whether Quant table is supplied by the app for JPEG encoder.
-    uint32_t                           m_appDataSize   = 0;          //!< Size of application size.
+    uint32_t                           m_appDataTotalSize   = 0;          //!< Total size of application data.
+    uint32_t                           m_appDataSize   = 0;          //!< Size of application data.
+    uint32_t                           m_appDataWholeHeader = false; //!< whether the app data include whole headers , such as SOI, DQT ...
 };
 #endif /* __MEDIA_LIBVA_ENCODER_JPEG_H__ */

--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -491,6 +491,26 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     }
     (*attribList)[attrib.type] = attrib.value;
 
+    attrib.type = VAConfigAttribEncPackedHeaders;
+    attrib.value = VA_ATTRIB_NOT_SUPPORTED;
+    if ((IsAvcProfile(profile))||(IsHevcProfile(profile)))
+    {
+        attrib.value = VA_ENC_PACKED_HEADER_PICTURE    |
+            VA_ENC_PACKED_HEADER_SEQUENCE   |
+            VA_ENC_PACKED_HEADER_SLICE      |
+            VA_ENC_PACKED_HEADER_RAW_DATA   |
+            VA_ENC_PACKED_HEADER_MISC;
+    }
+    else if (IsMpeg2Profile(profile))
+    {
+        attrib.value = VA_ENC_PACKED_HEADER_RAW_DATA;
+    }
+    else if(IsJpegProfile(profile))
+    {
+        attrib.value = VA_ENC_PACKED_HEADER_RAW_DATA;
+    }
+
+    (*attribList)[attrib.type] = attrib.value;
     if(IsJpegProfile(profile))
     {
         return status;
@@ -519,22 +539,6 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     else if(entrypoint == VAEntrypointStats)
     {
         attrib.value = VA_RC_NONE;
-    }
-    (*attribList)[attrib.type] = attrib.value;
-
-    attrib.type = VAConfigAttribEncPackedHeaders;
-    attrib.value = VA_ATTRIB_NOT_SUPPORTED;
-    if ((IsAvcProfile(profile))||(IsHevcProfile(profile)))
-    {
-        attrib.value = VA_ENC_PACKED_HEADER_PICTURE    |
-            VA_ENC_PACKED_HEADER_SEQUENCE   |
-            VA_ENC_PACKED_HEADER_SLICE      |
-            VA_ENC_PACKED_HEADER_RAW_DATA   |
-            VA_ENC_PACKED_HEADER_MISC;
-    }
-    else if (IsMpeg2Profile(profile))
-    {
-        attrib.value = VA_ENC_PACKED_HEADER_NONE;
     }
     (*attribList)[attrib.type] = attrib.value;
 


### PR DESCRIPTION
1. check whether the raw data include all of the headers, and provide different solution
2. when the packed data include all of the headers, scale the qmatrix for quality setting.
fix #111 #232 