### PR TITLE
Revert "[Decode] MPEG2 Decoder Fix slice_vertical_position handling i…

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_mpeg2.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_mpeg2.cpp
@@ -103,7 +103,7 @@ VAStatus DdiDecodeMPEG2::ParseSliceParams(
     for (slcCount = 0; slcCount < numSlices; slcCount++)
     {
         codecSlcParams->m_sliceHorizontalPosition = slcParam->slice_horizontal_position;
-        codecSlcParams->m_sliceVerticalPosition   = slcParam->slice_vertical_position;
+        codecSlcParams->m_sliceVerticalPosition   = slcParam->slice_vertical_position / (1 + isField);
 
         codecSlcParams->m_sliceDataSize   = (slcParam->slice_data_size) * 8;
         codecSlcParams->m_sliceDataOffset = slcParam->slice_data_offset + sliceBaseOffset;


### PR DESCRIPTION
…n frames with fields"

This reverts commit 5900867e156d67e3e9d931ae6f6f161392dab8ed.

Reasoning:
1) The commit in question does not seem to fix anything, but in fact
breaks MPEG2 decode, as shown by the MediaSDK testing
2) The affected slice param structure never even leaves the driver
code
3) The commit message seems unrelated to what it actually does.