### PR TITLE
Update readme for ICL HEVC/VP9 encode/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ ICL (Ice Lake)
 | VC-1       | D    | D    | D       | D       | D       | D    | D       |
 | JPEG       | D    | D/E2 | D/E2    | D/E2    | D/E2    | D/E2 | D/E2    |
 | VP8        | D    | D    | D       | D       | D       | D/E1 | D/E1    |
-| HEVC       |      | D/E1 | D/E1    | D/E1    | D/E1    | D/E1 |         |
-| HEVC 10bit |      |      | D       | D       | D       | D/E1 |         |
-| VP9        |      |      | D       | D       | D       | D    |         |
-| VP9 10bit  |      |      |         | D       | D       | D    |         |
+| HEVC       |      | D/E1 | D/E1    | D/E1    | D/E1    | D/E1 | D/E1/E2 |
+| HEVC 10bit |      |      | D       | D       | D       | D/E1 | D/E1/E2 |
+| VP9        |      |      | D       | D       | D       | D    | D/E2    |
+| VP9 10bit  |      |      |         | D       | D       | D    | D/E2    |
 
 D  - decoding
 


### PR DESCRIPTION
Now driver could support HEVC/VP9 decode, HEVC VME/Low power encode, and
VP9 VME/low power encode in 8/10 bit.