### PR TITLE
Fix transcoding performance issue on BDW.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encoder_base.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encoder_base.cpp
@@ -2509,7 +2509,11 @@ MOS_STATUS CodechalEncoderState::SendGenericKernelCmds(
     stateBaseAddrParams.dwDynamicStateSize = params->pKernelState->m_dshRegion.GetHeapSize();
     stateBaseAddrParams.presInstructionBuffer = ish;
     stateBaseAddrParams.dwInstructionBufferSize = params->pKernelState->m_ishRegion.GetHeapSize();
-    stateBaseAddrParams.mocs4InstructionCache = m_hwInterface->GetCacheabilitySettings()[MOS_CODEC_RESOURCE_USAGE_SURFACE_ELLC_LLC_L3].Value;
+
+    if (m_standard == CODECHAL_HEVC)
+    {
+        stateBaseAddrParams.mocs4InstructionCache = m_hwInterface->GetCacheabilitySettings()[MOS_CODEC_RESOURCE_USAGE_SURFACE_ELLC_LLC_L3].Value;
+    }
 
     CODECHAL_ENCODE_CHK_STATUS_RETURN(m_renderEngineInterface->AddStateBaseAddrCmd(cmdBuffer, &stateBaseAddrParams));
 


### PR DESCRIPTION
This issue was caused by CL722640. CL722640 can improve HEVC VME performance, but it is applied for all codecs. I changed this patch only for HEVC codec.

Signed-off-by: ZhiZhen Tang <zhizhen.tang@intel.com>