### PR TITLE
[Encode] Enable max frame size for AVC encoder legacy mode

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_avc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_avc.cpp
@@ -5586,7 +5586,7 @@ MOS_STATUS CodechalEncodeAvcEnc::SetPictureStructs()
         m_numPasses = (CODECHAL_ENCODE_AVC_CQP_NUM_OF_PASSES - 1);
     }
 
-    //add for FEI multiple Pass Pak
+    //add for multiple Pass Pak
     if (CodecHalIsFeiEncode(m_codecFunction))
     {
         CodecEncodeAvcFeiPicParams *feiPicParams;
@@ -5597,6 +5597,10 @@ MOS_STATUS CodechalEncodeAvcEnc::SetPictureStructs()
         {
             m_numPasses = (uint8_t)feiPicParams->dwNumPasses; //-1+1 for additional one IPCM pass
         }
+    }
+    else if (CodecHalUsesPakEngine(m_codecFunction) && picParams->dwMaxFrameSize != 0)
+    {
+        m_numPasses = (uint8_t)picParams->dwNumPasses; //-1+1 for additional one IPCM pass
     }
 
     if (seqParams->RateControlMethod == RATECONTROL_VCM && m_pictureCodingType == B_TYPE)
@@ -8910,6 +8914,11 @@ MOS_STATUS CodechalEncodeAvcEnc::GenericEncodePictureLevel(PCODECHAL_ENCODE_AVC_
         {
             imageStateParams.pDeltaQp = m_avcFeiPicParams->pDeltaQp;
             imageStateParams.dwMaxFrameSize = m_avcFeiPicParams->dwMaxFrameSize;
+        }
+        else if (CodecHalUsesPakEngine(m_codecFunction) && m_avcPicParam->dwMaxFrameSize)
+        {
+            imageStateParams.pDeltaQp = m_avcPicParam->pDeltaQp;
+            imageStateParams.dwMaxFrameSize = m_avcPicParam->dwMaxFrameSize;
         }
         imageStateParams.wPicWidthInMb = m_picWidthInMb;
         imageStateParams.wPicHeightInMb = m_picHeightInMb;

--- a/media_driver/agnostic/common/codec/shared/codec_def_common_encode.h
+++ b/media_driver/agnostic/common/codec/shared/codec_def_common_encode.h
@@ -409,6 +409,10 @@ typedef enum _CODEC_SLICE_STRUCTS
 #define CodecHalUsesVdencEngine(codecFunction)   \
         (codecFunction == CODECHAL_FUNCTION_ENC_VDENC_PAK)
 
+#define CodecHalUsesPakEngine(codecFunction)   \
+    (codecFunction == CODECHAL_FUNCTION_PAK       ||  \
+     codecFunction == CODECHAL_FUNCTION_ENC_PAK)
+
 #define CodecHalIsRateControlBrc(rateControl, standard) (\
     (rateControl == RATECONTROL_CBR)                || \
     (rateControl == RATECONTROL_VBR)                || \

--- a/media_driver/agnostic/common/codec/shared/codec_def_encode_avc.h
+++ b/media_driver/agnostic/common/codec/shared/codec_def_encode_avc.h
@@ -860,6 +860,30 @@ typedef struct _CODEC_AVC_ENCODE_PIC_PARAMS
     */
     bool            bDisableFrameSkip;
 
+    /*! \brief Maximum frame size for all frame types in bytes.
+    *
+    *    Applicable for CQP and multi PAK. If dwMaxFrameSize > 0, driver will do multiple PAK and adjust QP 
+    *    (frame level QP + slice_qp_delta) to make the compressed frame size to be less than this value. 
+    *    If dwMaxFrameSize equals 0, driver will not do multiple PAK and do not adjust QP.
+    */
+    uint32_t        dwMaxFrameSize;
+
+    /*! \brief Total pass number for multiple PAK.
+    *
+    *    Valid range is 0 - 4. If dwNumPasses is set to 0, driver will not do multiple PAK and do not adjust 
+    *    QP (frame level QP + slice_qp_delta), otherwise, driver will do multiple times PAK and in each time 
+    *    the QP will be adjust according deltaQp parameters.
+    */
+    uint32_t        dwNumPasses;
+
+    /*! \brief Delta QP array for each PAK pass.
+    *
+    *    This pointer points to an array of deltaQp, the max array size for AVC encoder is 4. The valid range 
+    *    for each deltaQp is 0 - 51. If the value is out of this valid range, driver will return error. 
+    *    Otherwise, driver will adjust QP (frame level QP + slice_qp_delta) by adding this value in each PAK pass.
+    */
+    uint8_t        *pDeltaQp;
+
 } CODEC_AVC_ENCODE_PIC_PARAMS, *PCODEC_AVC_ENCODE_PIC_PARAMS;
 
 /*! \brief Slice-level parameters of a compressed picture for AVC encoding.

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -40,6 +40,7 @@ static const uint16_t vuiKbps = 1024;
 static const uint8_t sliceTypeP = 0;
 static const uint8_t sliceTypeB = 1;
 static const uint8_t sliceTypeI = 2;
+static const uint8_t maxPassesNum = 4;
 
 //Inter MB partition 16x16 can't be disabled.
 static const uint8_t disMbPartMask      = 0x7E;
@@ -324,6 +325,42 @@ VAStatus DdiEncodeAvc::ParseMiscParamMaxFrameSize(void *data)
 
     // populate MaxFrameSize from DDI
     seqParams->UserMaxFrameSize = vaEncMiscParamMaxFrameSize->max_frame_size >> 3;  // convert to byte
+
+    return VA_STATUS_SUCCESS;
+}
+
+VAStatus DdiEncodeAvc::ParseMiscParamMultiPassFrameSize(void *data)
+{
+    DDI_CHK_NULL(data, "nullptr data", VA_STATUS_ERROR_INVALID_PARAMETER);
+
+    PCODEC_AVC_ENCODE_PIC_PARAMS picParams = (PCODEC_AVC_ENCODE_PIC_PARAMS)(m_encodeCtx->pPicParams) + current_pic_parameter_set_id;
+    VAEncMiscParameterBufferMultiPassFrameSize *vaEncMiscParamMultiPassFrameSize = (VAEncMiscParameterBufferMultiPassFrameSize *)data;
+    DDI_CHK_NULL(picParams, "nullptr picParams", VA_STATUS_ERROR_INVALID_PARAMETER);
+
+    //add for multiple pass pak
+    picParams->dwMaxFrameSize = vaEncMiscParamMultiPassFrameSize->max_frame_size;
+    if (picParams->dwMaxFrameSize)
+    {
+        picParams->dwNumPasses = vaEncMiscParamMultiPassFrameSize->num_passes;
+        if ((picParams->dwNumPasses == 0) || (picParams->dwNumPasses > maxPassesNum))
+        {
+            return VA_STATUS_ERROR_INVALID_PARAMETER;
+        }
+        if (picParams->pDeltaQp != nullptr)
+        {
+            MOS_FreeMemory(picParams->pDeltaQp);
+        }
+        picParams->pDeltaQp = (uint8_t *)MOS_AllocAndZeroMemory(sizeof(uint8_t) * picParams->dwNumPasses);
+        if (!picParams->pDeltaQp)
+        {
+            return VA_STATUS_ERROR_INVALID_PARAMETER;
+        }
+
+        if (MOS_STATUS_SUCCESS != MOS_SecureMemcpy(picParams->pDeltaQp, picParams->dwNumPasses, vaEncMiscParamMultiPassFrameSize->delta_qp, picParams->dwNumPasses))
+        {
+            return VA_STATUS_ERROR_INVALID_PARAMETER;
+        }
+    }
 
     return VA_STATUS_SUCCESS;
 }
@@ -1871,6 +1908,10 @@ VAStatus DdiEncodeAvc::ParseMiscParams(void *ptr)
 
     case VAEncMiscParameterTypeMaxFrameSize:
         status = ParseMiscParamMaxFrameSize((void *)miscParamBuf->data);
+        break;
+
+    case VAEncMiscParameterTypeMultiPassFrameSize:
+        status = ParseMiscParamMultiPassFrameSize((void *)miscParamBuf->data);
         break;
 
     case VAEncMiscParameterTypeQualityLevel:

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.h
@@ -271,6 +271,19 @@ protected:
     VAStatus ParseMiscParamMaxFrameSize(void *data);
 
     //!
+    //! \brief    Parse max frame size setting for multiple pass
+    //! \details  Parse VAEncMiscParameterBufferMultiPassFrameSize
+    //!           to PCODEC_AVC_ENCODE_PIC_PARAMS
+    //!
+    //! \param    [in] data
+    //!           Pointer to buffer VAEncMiscParameterBufferMultiPassFrameSize
+    //!
+    //! \return   VAStatus
+    //!           VA_STATUS_SUCCESS if successful, else fail reason
+    //!
+    VAStatus ParseMiscParamMultiPassFrameSize(void *data);
+
+    //!
     //! \brief    Parse sliceSizeInBytes for enabling VDENC dynamic slice
     //! \details  Parse sliceSizeInBytes for enabling VDENC dynamic slice
     //!


### PR DESCRIPTION
Enable max frame size feature for AVC encoder in legacy mode