### PR TITLE
Add YUY2 and UYVY surface format for VAProfileHEVCMain on ICL platform.

### DIFF
--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -34,6 +34,13 @@
 #include "media_ddi_decode_const_g11.h"
 #include "media_libva_vp.h"
 
+const uint32_t MediaLibvaCapsG11::m_hevcMainEncSurfaceAttr[m_numHevcMainEncSurfaceAttr] =
+{
+    VA_FOURCC_NV12,
+    VA_FOURCC_YUY2,
+    VA_FOURCC_UYVY
+};
+
 CODECHAL_MODE MediaLibvaCapsG11::GetEncodeCodecMode(VAProfile profile, VAEntrypoint entrypoint)
 {
     if (entrypoint == VAEntrypointStats)
@@ -914,6 +921,17 @@ VAStatus MediaLibvaCapsG11::QuerySurfaceAttributes(
                 attribs[i].value.type = VAGenericValueTypeInteger;
                 attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
                 attribs[i].value.value.i = m_jpegEncSurfaceAttr[j];
+                i++;
+            }
+        }
+        else if (profile == VAProfileHEVCMain)
+        {
+            for (int32_t j = 0; j < m_numHevcMainEncSurfaceAttr; j++)
+            {
+                attribs[i].type = VASurfaceAttribPixelFormat;
+                attribs[i].value.type = VAGenericValueTypeInteger;
+                attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+                attribs[i].value.value.i = m_hevcMainEncSurfaceAttr[j];
                 i++;
             }
         }

--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.h
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.h
@@ -141,6 +141,8 @@ protected:
         CODEC_8K_MAX_PIC_WIDTH; //!< maxinum width for VP9 encode
     static const uint32_t m_maxVp9EncHeight =
         CODEC_8K_MAX_PIC_HEIGHT; //!< maxinum height for VP9 encode
+    static const uint32_t m_numHevcMainEncSurfaceAttr = 3; //!< Number of HEVC Main encode surface attributes
+    static const uint32_t m_hevcMainEncSurfaceAttr[m_numHevcMainEncSurfaceAttr]; //!< Store the HEVC Main encode surface attributes
 
     virtual VAStatus GetPlatformSpecificAttrib(VAProfile profile,
             VAEntrypoint entrypoint,


### PR DESCRIPTION
Fixes #322.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>