### PR TITLE
media_libva_vp: fix VAProcDeinterlacingNone handle issue.

### DIFF
--- a/media_driver/linux/common/vp/ddi/media_libva_vp.c
+++ b/media_driver/linux/common/vp/ddi/media_libva_vp.c
@@ -1744,6 +1744,7 @@ DdiVp_SetProcFilterDinterlaceParams(
             pSrc->bFieldWeaving = true;;
             return VA_STATUS_SUCCESS;
         case VAProcDeinterlacingNone:
+            return VA_STATUS_SUCCESS;
         case VAProcDeinterlacingMotionCompensated:
         default:
             VP_DDI_ASSERTMESSAGE("Deinterlacing type is unsupported.");


### PR DESCRIPTION
VAProcDeinterlacingNone means bypass the deinterlace module, but now
give a error number and error message, change the logic with do nothing
for this mode.

Signed-off-by: Jun Zhao <jun.zhao@intel.com>