### PR TITLE
android: replace deprecated cutils/log.h with log/log.h

### DIFF
--- a/media_driver/linux/common/os/linux_skuwa_debug.h
+++ b/media_driver/linux/common/os/linux_skuwa_debug.h
@@ -28,7 +28,7 @@
 #define __LINUX_SKUWA_DEBUG_H__
 
 #if defined(ANDROID)
-#include <cutils/log.h>
+#include <log/log.h>
 
 #define DEVINFO_ASSERT(expr) ALOG_ASSERT(expr)
 


### PR DESCRIPTION
cutils/log.h deprecated by google on android P