### PR TITLE
Fix HEVC 10bit encoding on KBL. (GitHub issue #320)

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_hevc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_hevc.cpp
@@ -1428,6 +1428,8 @@ bool CodechalEncHevcState::CheckSupportedFormat(PMOS_SURFACE surface)
     case Format_NV12:
         isColorFormatSupported = IS_Y_MAJOR_TILE_FORMAT(surface->TileType);
         break;
+    case Format_P010:
+        isColorFormatSupported = true;
     case Format_YUY2:
     case Format_YUYV:
     case Format_A8R8G8B8:

--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_hevc_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_hevc_g9.cpp
@@ -4840,7 +4840,7 @@ MOS_STATUS CodechalEncHevcStateG9::InitKernelStateMbEnc()
 
     if(MEDIA_IS_SKU(m_hwInterface->GetSkuTable(), FtrEncodeHEVC10bit) && m_is10BitHevc)
     {
-        m_numMbEncEncKrnStates = CODECHAL_HEVC_MBENC_NUM_KBL;
+        m_numMbEncEncKrnStates = CODECHAL_HEVC_MBENC_NUM_BXT_SKL;
     }
     else if (!m_noMeKernelForPFrame)
     {
@@ -4865,19 +4865,18 @@ MOS_STATUS CodechalEncHevcStateG9::InitKernelStateMbEnc()
         auto kernelSize = m_combinedKernelSize;
         CODECHAL_KERNEL_HEADER currKrnHeader;
 
-        if (krnStateIdx == CODECHAL_HEVC_MBENC_DS_COMBINED &&
-            m_numMbEncEncKrnStates == CODECHAL_HEVC_MBENC_NUM_BXT_SKL)  //Ignore. It isn't used on BXT.
-        {
-            kernelStatePtr++;
-            continue;
-        }
-
         CODECHAL_ENCODE_CHK_STATUS_RETURN(pfnGetKernelHeaderAndSize(
             m_kernelBinary,
             ENC_MBENC,
             krnStateIdx,
             &currKrnHeader,
             &kernelSize));
+
+        if (kernelSize == 0)  //Ignore. It isn't used on current platform.
+        {
+            kernelStatePtr++;
+            continue;
+        }
 
         CODECHAL_ENCODE_CHK_STATUS_RETURN(SetMbEncKernelParams(
             &kernelStatePtr->KernelParams,

--- a/media_driver/agnostic/gen9_bxt/codec/hal/codechal_encode_hevc_g9_bxt.cpp
+++ b/media_driver/agnostic/gen9_bxt/codec/hal/codechal_encode_hevc_g9_bxt.cpp
@@ -160,6 +160,11 @@ MOS_STATUS CodechalEncHevcStateG9Bxt::GetKernelHeaderAndSize(
             currKrnHeader = &kernelHeaderTable->Hevc_LCUEnc_PB_Adv;
             break;
 
+        case CODECHAL_HEVC_MBENC_DS_COMBINED:
+            // Ignore this kernel on BXT.
+            *krnSize = 0;
+            return eStatus;
+
         case CODECHAL_HEVC_MBENC_PENC:
             currKrnHeader = &kernelHeaderTable->HEVC_LCUEnc_P_MB;
             break;

--- a/media_driver/agnostic/gen9_skl/codec/hal/codechal_encode_hevc_g9_skl.cpp
+++ b/media_driver/agnostic/gen9_skl/codec/hal/codechal_encode_hevc_g9_skl.cpp
@@ -148,8 +148,9 @@ MOS_STATUS CodechalEncHevcStateG9Skl::GetKernelHeaderAndSize(
             break;
 
         case CODECHAL_HEVC_MBENC_DS_COMBINED:
-            currKrnHeader = &kernelHeaderTable->Hevc_LCUEnc_DS_Combined;
-            break;
+            // Ignore this kernel on SKL.
+            *krnSize = 0;
+            return eStatus;
 
         case CODECHAL_HEVC_MBENC_PENC:
             currKrnHeader = &kernelHeaderTable->HEVC_LCUEnc_P_MB;


### PR DESCRIPTION
1. Make sure CODECHAL_HEVC_MBENC_PENC kernel state initialized.
2. Add support format for 10bit.
3. Make sure CODECHAL_HEVC_MBENC_DS_COMBINED kernel state initialized.
But need disable it on BXT and SKL. Check kernel size in
CodechalEncHevcStateG9::InitKernelStateMbEnc() instead of hard code.

Fixes #320.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>