### PR TITLE
[Decode] fix the parameter checking issue for vaCreateConfig().

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -1659,7 +1659,8 @@ VAStatus MediaLibvaCaps::CreateDecConfig(
         VAConfigID *configId)
 {
     
-    DDI_CHK_NULL(attribList, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);
+    if (numAttribs)
+        DDI_CHK_NULL(attribList, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);
     DDI_CHK_NULL(configId, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);
 
     VAConfigAttrib decAttributes[3];


### PR DESCRIPTION
For decoding, if vaCreateConfig() is called with  (attrib_list == NULL && num_attribs == 0), it returns INVALID_PARAMETER. This PR fixes the issue.