### PR TITLE
VeboxSendVeboxCmd: do not goto finish if caller pass NULl for pRender

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
@@ -2022,7 +2022,10 @@ MOS_STATUS VPHAL_VEBOX_STATE::VeboxSendVeboxCmd()
     iRemaining              = 0;
     pVeboxInterface         = pVeboxState->m_pVeboxInterface;
 
-    VPHAL_RENDER_CHK_NULL(pRenderData);
+    if (!pRenderData) {
+        VPHAL_RENDER_ASSERTMESSAGE("pRenderData is NULL");
+        return MOS_STATUS_NULL_POINTER;
+    }
 
     VPHAL_RENDER_CHK_STATUS(VeboxSendVeboxCmd_Prepare(
         CmdBuffer,


### PR DESCRIPTION
 goto finish will use CmdBuffer, it will init later by VeboxSendVeboxCmd_Prepare