### PR TITLE
CodechalMmcDecodeMpeg2: follow other codec, do not check hwInterface for NULL

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_mmc_decode_mpeg2.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_mmc_decode_mpeg2.cpp
@@ -38,7 +38,7 @@ CodechalMmcDecodeMpeg2::CodechalMmcDecodeMpeg2(
 
     CODECHAL_HW_ASSERT(hwInterface);
     CODECHAL_HW_ASSERT(hwInterface->GetSkuTable());
-    if (hwInterface &&  hwInterface->GetSkuTable() && MEDIA_IS_SKU(hwInterface->GetSkuTable(), FtrMemoryCompression))
+    if (MEDIA_IS_SKU(hwInterface->GetSkuTable(), FtrMemoryCompression))
     {
         MOS_USER_FEATURE_VALUE_DATA userFeatureData;
         MOS_ZeroMemory(&userFeatureData, sizeof(userFeatureData));


### PR DESCRIPTION
No need check the hwInterface  here
if hwInterface  is NULL, CodecHalMmcState::m_hwInterface will be null.
Many fuction calls will crash for release version(CODECHAL_HW_ASSERT is no op in release build)
