### PR TITLE
bxt fix

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -31,6 +31,8 @@
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <thread>
+#include <chrono>
 
 #ifndef ANDROID
 #include <X11/Xutil.h>
@@ -3338,6 +3340,10 @@ static VAStatus DdiMedia_SyncSurface (
     {
         // Just loop while gem_bo_wait times-out.
     }
+
+    PDDI_MEDIA_CONTEXT mediaDrvCtx = DdiMedia_GetMediaContext(ctx);
+    if(mediaDrvCtx->platform.eRenderCoreFamily <= IGFX_GEN9_CORE)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     uint32_t i = 0;
     PDDI_DECODE_CONTEXT decCtx = (PDDI_DECODE_CONTEXT)surface->pDecCtx;


### PR DESCRIPTION
Hi guys. 
We had few issues regarding to MFX_ERR_NONE != MFX_ERR_GPU_HANG with corrupted streams.
Family: BXT
Platform: u18.04-64
This patch solves this problem. 
