### PR TITLE
Fix return value of std:string.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_debug_config_manager.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_debug_config_manager.cpp
@@ -452,7 +452,7 @@ std::string CodechalDebugConfigMgr::GetMediaStateStr(CODECHAL_MEDIA_STATE_TYPE m
         return it->second;
     }
 
-    return nullptr;
+    return "";
 }
 
 bool CodechalDebugConfigMgr::AttrIsEnabled(std::string attrName)


### PR DESCRIPTION
The return type of CodechalDebugConfigMgr::GetMediaStateStr() is
std:string. So it should not be nullptr which will cause segment
fault when dump debugging information.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>