### PR TITLE
[VP8] Implement frame rate in DDI according to interface

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_debug_config_manager.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_debug_config_manager.cpp
@@ -452,7 +452,7 @@ std::string CodechalDebugConfigMgr::GetMediaStateStr(CODECHAL_MEDIA_STATE_TYPE m
         return it->second;
     }
 
-    return nullptr;
+    return "";
 }
 
 bool CodechalDebugConfigMgr::AttrIsEnabled(std::string attrName)

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_vp8.cpp
@@ -687,13 +687,20 @@ void DdiEncodeVp8::ParseMiscParamVBV(void *data)
 void DdiEncodeVp8::ParseMiscParamFR(void *data)
 {
     VAEncMiscParameterFrameRate *vaFrameRate = (VAEncMiscParameterFrameRate *)data;
-
     CODEC_VP8_ENCODE_SEQUENCE_PARAMS *seqParams = (PCODEC_VP8_ENCODE_SEQUENCE_PARAMS)m_encodeCtx->pSeqParams;
-    uint32_t                          tmpId     = 0;
+
+    uint32_t numerator = (vaFrameRate->framerate & 0xffff) * 100;
+    auto denominator = (vaFrameRate->framerate >> 16)&0xfff;
+    if(denominator == 0)
+    {
+        denominator = 1;
+    }
+
+    uint32_t tmpId = 0;
 #ifdef ANDROID
     tmpId = vaFrameRate->framerate_flags.bits.temporal_id;
 #endif
-    seqParams->FramesPer100Sec[tmpId] = vaFrameRate->framerate;
+    seqParams->FramesPer100Sec[tmpId] = numerator/denominator;
 }
 
 void DdiEncodeVp8::ParseMiscParamRC(void *data)


### PR DESCRIPTION
DDI should parse frame rate buffer according to the definiton
of libva, not pass it directly to low level.