### PR TITLE
Refactor build options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,26 @@ script:
       cmake  --build . -- -j 8
   - ccache -s
   - ccache -z
+  - sudo rm -rf ${TRAVIS_BUILD_DIR}/../build && mkdir ${TRAVIS_BUILD_DIR}/../build
+  - >
+      docker run
+      -v $HOME/.ccache:/opt/ccache
+      -v ${TRAVIS_BUILD_DIR}/../:/opt/src
+      -w /opt/src/build
+      -e CCACHE_DIR=/opt/ccache
+      intelmediadriver/media-driver-docker
+      cmake
+      -DMEDIA_VERSION="0.1.0"
+      -DFREE_KERNELS=ON
+      -DBUILD_TYPE=Release
+      ../media-driver
+  - >
+      docker run
+      -v $HOME/.ccache:/opt/ccache
+      -v ${TRAVIS_BUILD_DIR}/..:/opt/src
+      -w /opt/src/build
+      -e CCACHE_DIR=/opt/ccache
+      intelmediadriver/media-driver-docker
+      cmake  --build . -- -j 8
+  - ccache -s
+  - ccache -z

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,16 @@ if("${os_name}" STREQUAL "clear-linux-os")
     set(CMAKE_INSTALL_SYSCONFDIR "usr/share/defaults/etc")
 endif()
 
+include(CMakeDependentOption)
+
 option (ENABLE_KERNELS "Build driver with shaders (kernels) support" ON)
+# FREE_KERNELS option means using only open source EU shaders (kernels) and
+# fixed function hardware. The opposite is a full-feature build which permits
+# usage of shaders (kernels) in binary form.
+cmake_dependent_option( FREE_KERNELS
+    "Use only shaders (kernels) with available sources" OFF
+    "ENABLE_KERNELS" OFF)
+
 option (BUILD_CMRTLIB "Build and Install cmrtlib together with media driver" ON)
 
 include(GNUInstallDirs)

--- a/distro_cmake.sh
+++ b/distro_cmake.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Full_Open_Source_Support flag is to control full-open-source build.
-# Full-open-source means only using open source EU kernels and fixed function hardware.
-
 cmake ../media-driver \
 -DGEN8_Supported="no" \
 -DGEN8_BDW_Supported="no" \
@@ -12,4 +9,4 @@ cmake ../media-driver \
 -DGEN9_CFL_Supported="no" \
 -DGEN9_GLK_Supported="no" \
 -DGEN9_KBL_Supported="no" \
--DFull_Open_Source_Support="yes" $@
+-DFREE_KERNELS=ON $@

--- a/distro_cmake.sh
+++ b/distro_cmake.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
 cmake ../media-driver \
--DGEN8_Supported="no" \
--DGEN8_BDW_Supported="no" \
--DGEN9_Supported="no" \
--DGEN9_BXT_Supported="no" \
--DGEN9_SKL_Supported="no" \
--DGEN9_CFL_Supported="no" \
--DGEN9_GLK_Supported="no" \
--DGEN9_KBL_Supported="no" \
+-DGEN8=OFF \
+-DGEN9=OFF \
 -DFREE_KERNELS=ON $@

--- a/media_driver/agnostic/common/shared/dummykrn.c
+++ b/media_driver/agnostic/common/shared/dummykrn.c
@@ -25,29 +25,6 @@ const unsigned int IGCDUMMYKRN_SIZE = 0;
 const unsigned int IGCDUMMYKRN[] = {
 };
 
-//gen9 dummy kernel
-extern const unsigned int IGCODECKRN_G9_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGCODECKRN_G9;
-const unsigned int* IGCODECKRN_G9 =IGCDUMMYKRN;
-
-extern const unsigned int IGVPKRN_G9_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGVPKRN_G9;
-const unsigned int* IGVPKRN_G9 = IGCDUMMYKRN;
-
-extern const unsigned int IGVP_HVS_DENOISE_G900_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGVP_HVS_DENOISE_G900;
-const unsigned int* IGVP_HVS_DENOISE_G900 = IGCDUMMYKRN;
-
-//gen9 bxt dummy kernel
-extern const unsigned int IGCODECKRN_G9_BXT_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGCODECKRN_G9_BXT;
-const unsigned int* IGCODECKRN_G9_BXT = IGCDUMMYKRN;
-
-//gen9 kbl dummy kernel
-extern const unsigned int IGCODECKRN_G9_KBL_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGCODECKRN_G9_KBL;
-const unsigned int* IGCODECKRN_G9_KBL = IGCDUMMYKRN;
-
 //gen10 dummy kernel
 extern const unsigned int IGCODECKRN_G10_SIZE = IGCDUMMYKRN_SIZE;
 extern const unsigned int* IGCODECKRN_G10;

--- a/media_driver/agnostic/common/shared/dummykrn.c
+++ b/media_driver/agnostic/common/shared/dummykrn.c
@@ -25,15 +25,6 @@ const unsigned int IGCDUMMYKRN_SIZE = 0;
 const unsigned int IGCDUMMYKRN[] = {
 };
 
-//gen10 dummy kernel
-extern const unsigned int IGCODECKRN_G10_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGCODECKRN_G10;
-const unsigned int* IGCODECKRN_G10 = IGCDUMMYKRN;
-
-extern const unsigned int IGVPKRN_G10_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGVPKRN_G10;
-const unsigned int* IGVPKRN_G10 = IGCDUMMYKRN;
-
 //gen11 dummy kernel
 extern const unsigned int IGCODECKRN_G11_SIZE = IGCDUMMYKRN_SIZE;
 extern const unsigned int* IGCODECKRN_G11;

--- a/media_driver/agnostic/common/shared/dummykrn.c
+++ b/media_driver/agnostic/common/shared/dummykrn.c
@@ -25,15 +25,6 @@ const unsigned int IGCDUMMYKRN_SIZE = 0;
 const unsigned int IGCDUMMYKRN[] = {
 };
 
-//gen8 dummy kernel
-extern const unsigned int IGCODECKRN_G8_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGCODECKRN_G8;
-const unsigned int* IGCODECKRN_G8 = IGCDUMMYKRN;
-
-extern const unsigned int IGVPKRN_G8_SIZE = IGCDUMMYKRN_SIZE;
-extern const unsigned int* IGVPKRN_G8;
-const unsigned int* IGVPKRN_G8 = IGCDUMMYKRN;
-
 //gen9 dummy kernel
 extern const unsigned int IGCODECKRN_G9_SIZE = IGCDUMMYKRN_SIZE;
 extern const unsigned int* IGCODECKRN_G9;

--- a/media_driver/agnostic/common/shared/media_srcs.cmake
+++ b/media_driver/agnostic/common/shared/media_srcs.cmake
@@ -18,14 +18,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(NOT ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/dummykrn.c
-    )
-endif()
-
 set(TMP_SOURCES_
-    ${TMP_SOURCES_}
     ${CMAKE_CURRENT_LIST_DIR}/mediamemdecomp.cpp
     ${CMAKE_CURRENT_LIST_DIR}/media_perf_profiler.cpp
 )

--- a/media_driver/agnostic/gen10/codec/hal/codechal_decode_downsampling_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_decode_downsampling_g10.cpp
@@ -25,7 +25,7 @@
 //!
 #include "codechal_decoder.h"
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #endif
 
@@ -35,10 +35,8 @@ FieldScalingInterfaceG10::FieldScalingInterfaceG10(CodechalHwInterface *hwInterf
     FieldScalingInterface(hwInterface)
 {
     CODECHAL_DECODE_FUNCTION_ENTER;
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G10;
-#else
-    m_kernelBase = nullptr;
 #endif
 
     InitInterfaceStateHeapSetting(hwInterface);

--- a/media_driver/agnostic/gen10/codec/hal/codechal_encode_csc_ds_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_encode_csc_ds_g10.cpp
@@ -28,7 +28,7 @@
 #include "codechal_encode_csc_ds_g10.h"
 #include "codeckrnheader.h"
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #endif
 
@@ -244,9 +244,7 @@ CodechalEncodeCscDsG10::CodechalEncodeCscDsG10(CodechalEncoderState* encoder)
 {
     m_cscKernelUID = IDR_CODEC_Downscale_Copy;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t *)IGCODECKRN_G10;
-#else
-    m_kernelBase = nullptr;
 #endif
 }

--- a/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_avc_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_avc_g10.cpp
@@ -27,7 +27,7 @@
 
 #include "codechal_vdenc_avc_g10.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #endif
 #if USE_CODECHAL_DEBUG_TOOL
@@ -413,10 +413,8 @@ CodechalVdencAvcStateG10::CodechalVdencAvcStateG10(
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
     m_kuid = IDR_CODEC_AllAVCEnc;
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G10;
-#else
-    m_kernelBase = nullptr;
 #endif
     AddIshSize(m_kuid, m_kernelBase);
 

--- a/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_hevc_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_hevc_g10.cpp
@@ -26,7 +26,7 @@
 
 #include "codechal_vdenc_hevc_g10.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #endif
 #include "codechal_huc_cmd_initializer.h"
@@ -714,7 +714,7 @@ MOS_STATUS CodechalVdencHevcStateG10::InitKernelState()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     CODECHAL_ENCODE_CHK_STATUS_RETURN(InitKernelStateMe());
     CODECHAL_ENCODE_CHK_STATUS_RETURN(InitKernelStateStreamIn());
 #endif
@@ -728,7 +728,7 @@ uint32_t CodechalVdencHevcStateG10::GetMaxBtCount()
 
     uint32_t maxBtCount = 0;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     auto btIdxAlignment = m_stateHeapInterface->pStateHeapInterface->GetBtIdxAlignment();
 
     // 4x, 16x DS, 4x ME, 16x ME
@@ -1482,7 +1482,7 @@ MOS_STATUS CodechalVdencHevcStateG10::EncodeKernelFunctions()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     if (m_pictureCodingType == P_TYPE)
     {
         CODECHAL_ENCODE_ASSERTMESSAGE("GEN10 HEVC VDENC does not support P slice");
@@ -2539,10 +2539,8 @@ CodechalVdencHevcStateG10::CodechalVdencHevcStateG10(
     m_brcRoiBufferSize             = m_roiStreamInBufferSize;
     m_deltaQpRoiBufferSize         = m_deltaQpBufferSize;
     m_maxNumSlicesSupported        = CODECHAL_VDENC_HEVC_MAX_SLICE_NUM;
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase                   = (uint8_t*)IGCODECKRN_G10;
-#else
-    m_kernelBase                   = nullptr;
 #endif
 
     m_hwInterface->GetStateHeapSettings()->dwNumSyncTags = CODECHAL_ENCODE_HEVC_NUM_SYNC_TAGS;

--- a/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_vp9_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_vdenc_vp9_g10.cpp
@@ -37,7 +37,7 @@
 
 #include "codechal_vdenc_vp9_g10.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #endif
 #include "mhw_vdbox_vdenc_hwcmd_g10_X.h"
@@ -51,10 +51,8 @@ CodechalVdencVp9StateG10::CodechalVdencVp9StateG10(
     m_hwInterface->GetStateHeapSettings()->dwNumSyncTags = CODECHAL_ENCODE_VP9_NUM_SYNC_TAGS;
     m_hwInterface->GetStateHeapSettings()->dwDshSize = CODECHAL_ENCODE_VP9_INIT_DSH_SIZE;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G10;
-#else
-    m_kernelBase = nullptr;
 #endif
 
     m_kuid = IDR_CODEC_VDENC_HME;
@@ -494,7 +492,7 @@ MOS_STATUS CodechalVdencVp9StateG10::InitKernelStates()
 {
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     // DYS
     CODECHAL_ENCODE_CHK_STATUS_RETURN(InitKernelStateDys());
     // VDEnc SHME (16x)
@@ -514,7 +512,7 @@ uint32_t CodechalVdencVp9StateG10::GetMaxBtCount()
 
     m_maxBtCount = 0;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     uint16_t btIdxAlignment = m_stateHeapInterface->pStateHeapInterface->GetBtIdxAlignment();
 
     if (m_hmeSupported)
@@ -589,7 +587,7 @@ MOS_STATUS CodechalVdencVp9StateG10::Initialize(CodechalSetting * settings)
 
     m_dysVdencMultiPassEnabled = true;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     if (m_cscDsState)
     {
         m_cscDsState->EnableColor();
@@ -894,7 +892,7 @@ MOS_STATUS CodechalVdencVp9StateG10::ExecuteKernelFunctions()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     uint32_t dumpFormat = 0;
     CODECHAL_DEBUG_TOOL(
     //    CodecHal_DbgMapSurfaceFormatToDumpFormat(m_rawSurfaceToEnc->Format, &dumpFormat);

--- a/media_driver/agnostic/gen10/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/codec/kernel/media_srcs.cmake
@@ -19,15 +19,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g10.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g10.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g10.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g10.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen10/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/codec/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()
 media_include_subdirectory(share)

--- a/media_driver/agnostic/gen10/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/codec/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT "${Full_Open_Source_Support}" STREQUAL "yes")
+if(NOT FREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()
 media_include_subdirectory(share)

--- a/media_driver/agnostic/gen10/vp/hal/vphal_renderer_g10.cpp
+++ b/media_driver/agnostic/gen10/vp/hal/vphal_renderer_g10.cpp
@@ -25,7 +25,7 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g10.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igvpkrn_g10.h"
 #endif
 #include "vphal_render_vebox_g10_base.h"
@@ -171,7 +171,7 @@ MOS_STATUS VphalRendererG10::InitKdllParam()
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
     // Set KDLL parameters (Platform dependent)
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     pKernelDllRules         = g_KdllRuleTable_g10;
     pcKernelBin             = (const void*)IGVPKRN_G10;
     dwKernelBinSize         = IGVPKRN_G10_SIZE;

--- a/media_driver/agnostic/gen10/vp/hal/vphal_renderer_g10.cpp
+++ b/media_driver/agnostic/gen10/vp/hal/vphal_renderer_g10.cpp
@@ -25,7 +25,9 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g10.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igvpkrn_g10.h"
+#endif
 #include "vphal_render_vebox_g10_base.h"
 #include "vphal_render_composite_g10.h"
 
@@ -169,10 +171,11 @@ MOS_STATUS VphalRendererG10::InitKdllParam()
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
     // Set KDLL parameters (Platform dependent)
+#ifndef _FULL_OPEN_SOURCE
     pKernelDllRules         = g_KdllRuleTable_g10;
     pcKernelBin             = (const void*)IGVPKRN_G10;
     dwKernelBinSize         = IGVPKRN_G10_SIZE;
-
+#endif
     return eStatus;
 }
 

--- a/media_driver/agnostic/gen10/vp/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/vp/kernel/media_srcs.cmake
@@ -18,16 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g10.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g10.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g10.h
-    )
-endif()
-
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g10.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen10/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/vp/media_srcs.cmake
@@ -19,5 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kdll)
-media_include_subdirectory(kernel)
+if(NOT FREE_KERNELS)
+    media_include_subdirectory(kdll)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen10/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/vp/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
     media_include_subdirectory(kdll)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen10_cnl/media_interfaces/media_interfaces_g10_cnl.cpp
+++ b/media_driver/agnostic/gen10_cnl/media_interfaces/media_interfaces_g10_cnl.cpp
@@ -27,7 +27,7 @@
 #include "media_interfaces_g10_cnl.h"
 #include "codechal_encoder_base.h"
 #include "codechal_vdenc_hevc_g10.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #endif
 
@@ -418,10 +418,8 @@ MOS_STATUS CodechalInterfacesG10Cnl::Initialize(
             {
                 m_codechalDevice = encoder;
             }
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
             encoder->m_kernelBase = (uint8_t*)IGCODECKRN_G10;
-#else
-            encoder->m_kernelBase = nullptr;
 #endif
         }
         else
@@ -451,10 +449,8 @@ MOS_STATUS CodechalInterfacesG10Cnl::Initialize(
             {
                 m_codechalDevice = encoder;
             }
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
             encoder->m_kernelBase = (uint8_t*)IGCODECKRN_G10;
-#else
-            encoder->m_kernelBase = nullptr;
 #endif
         }
         else
@@ -480,7 +476,7 @@ MOS_STATUS CodechalInterfacesG10Cnl::Initialize(
             CODECHAL_PUBLIC_ASSERTMESSAGE("Unsupported encode function requested.");
             return MOS_STATUS_INVALID_PARAMETER;
         }
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
         if (info->Mode != CODECHAL_ENCODE_MODE_JPEG)
         {
             // Create CSC and Downscaling interface

--- a/media_driver/agnostic/gen11/codec/hal/codechal_encode_csc_ds_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_encode_csc_ds_g11.cpp
@@ -29,7 +29,7 @@
 #include "codechal_encode_csc_ds_g11.h"
 #include "codechal_kernel_header_g11.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g11.h"
 #endif
 #if USE_CODECHAL_DEBUG_TOOL
@@ -743,10 +743,8 @@ CodechalEncodeCscDsG11::CodechalEncodeCscDsG11(CodechalEncoderState* encoder)
 {
     m_cscKernelUID = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G11;
-#else
-    m_kernelBase = nullptr;
 #endif
 }
 

--- a/media_driver/agnostic/gen11/codec/hal/codechal_vdenc_avc_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_vdenc_avc_g11.cpp
@@ -31,7 +31,9 @@
 #include "mhw_vdbox_vdenc_g11_X.h"
 #include "mhw_vdbox_g11_X.h"
 #include "mos_util_user_interface.h"
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g11.h"
+#endif
 #if USE_CODECHAL_DEBUG_TOOL
 #include "codechal_debug_encode_par_g11.h"
 #include "mhw_vdbox_mfx_hwcmd_g11_X.h"
@@ -674,10 +676,8 @@ CodechalVdencAvcStateG11::CodechalVdencAvcStateG11(
 
     CODECHAL_ENCODE_ASSERT(m_osInterface);
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G11;
-#else
-    m_kernelBase = nullptr;
 #endif
     m_cmKernelEnable = true;
     m_mbStatsSupported = true; //Starting from GEN9
@@ -1075,7 +1075,7 @@ MOS_STATUS CodechalVdencAvcStateG11::ExecuteSliceLevel()
             &flushDwParams));
     }
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     // On-demand sync for VDEnc StreamIn surface and CSC surface
     if (m_currPass == 0)
     {

--- a/media_driver/agnostic/gen11/codec/hal/codechal_vdenc_hevc_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_vdenc_hevc_g11.cpp
@@ -28,7 +28,7 @@
 #include "codechal_vdenc_hevc_g11.h"
 #include "codechal_kernel_header_g11.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g11.h"
 #endif
 #include "mhw_vdbox_g11_X.h"
@@ -229,7 +229,7 @@ uint32_t CodechalVdencHevcStateG11::GetMaxBtCount()
 
     uint32_t maxBtCount = 0;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     auto btIdxAlignment = m_stateHeapInterface->pStateHeapInterface->GetBtIdxAlignment();
 
     // DsConversion kernel
@@ -333,7 +333,7 @@ MOS_STATUS CodechalVdencHevcStateG11::InitKernelState()
 
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     CODECHAL_ENCODE_CHK_STATUS_RETURN(InitKernelStateMe());
     CODECHAL_ENCODE_CHK_STATUS_RETURN(InitKernelStateStreamIn());
 #endif
@@ -1579,7 +1579,7 @@ MOS_STATUS CodechalVdencHevcStateG11::EncodeKernelFunctions()
 
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     CODECHAL_DEBUG_TOOL(CODECHAL_ENCODE_CHK_STATUS_RETURN(m_debugInterface->DumpYUVSurface(
         m_rawSurfaceToEnc,
         CodechalDbgAttr::attrEncodeRawInputSurface,
@@ -4534,10 +4534,8 @@ CodechalVdencHevcStateG11::CodechalVdencHevcStateG11(
     m_useCommonKernel = true;
     pfnGetKernelHeaderAndSize = GetKernelHeaderAndSize;
     m_useHwScoreboard = false;
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G11;
-#else
-    m_kernelBase = nullptr;
 #endif
     m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
     m_hucPakStitchEnabled = true;
@@ -4575,10 +4573,8 @@ CodechalVdencHevcStateG11::CodechalVdencHevcStateG11(
 
     m_hwInterface->GetStateHeapSettings()->dwNumSyncTags = CODECHAL_ENCODE_HEVC_NUM_SYNC_TAGS;
     m_hwInterface->GetStateHeapSettings()->dwDshSize = CODECHAL_INIT_DSH_SIZE_HEVC_ENC;
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G11;
-#else
-    m_kernelBase = nullptr;
 #endif
 
     MOS_STATUS eStatus = CodecHalGetKernelBinaryAndSize(

--- a/media_driver/agnostic/gen11/codec/hal/codechal_vdenc_vp9_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_vdenc_vp9_g11.cpp
@@ -37,7 +37,7 @@
 #include "codechal_vdenc_vp9_g11.h"
 #include "codechal_kernel_header_g11.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g10.h"
 #include "igcodeckrn_g11.h"
 #endif
@@ -84,7 +84,7 @@ CodechalVdencVp9StateG11::CodechalVdencVp9StateG11(
     m_useCommonKernel = true;
     m_isTilingSupported      = true;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t *)IGCODECKRN_G11;
 #endif
 
@@ -107,7 +107,7 @@ CodechalVdencVp9StateG11::CodechalVdencVp9StateG11(
     {
         m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
         eStatus = CodecHalGetKernelBinaryAndSize(
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
             (uint8_t*)IGCODECKRN_G11,
 #else
             nullptr,
@@ -326,7 +326,7 @@ MOS_STATUS CodechalVdencVp9StateG11::InitKernelStateMe()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     CODECHAL_ENCODE_CHK_NULL_RETURN(m_renderEngineInterface->GetHwCaps());
 
     uint32_t combinedKernelSize = 0;
@@ -409,7 +409,7 @@ MOS_STATUS CodechalVdencVp9StateG11::InitKernelStates()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     // DYS
     CODECHAL_ENCODE_CHK_STATUS_RETURN(InitKernelStateDys());
 
@@ -427,7 +427,7 @@ uint32_t CodechalVdencVp9StateG11::GetMaxBtCount()
     CODECHAL_ENCODE_FUNCTION_ENTER;
     uint32_t maxBtCount = 0;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     if (m_hmeSupported)
     {
         uint32_t scalingBtCount = 0;
@@ -468,7 +468,7 @@ MOS_STATUS CodechalVdencVp9StateG11::InitKernelStateDys()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     uint32_t combinedKernelSize = 0;
     uint8_t* binary = nullptr;
     CODECHAL_ENCODE_CHK_STATUS_RETURN(CodecHalGetKernelBinaryAndSize(
@@ -1535,7 +1535,7 @@ MOS_STATUS CodechalVdencVp9StateG11::ExecuteKernelFunctions()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     uint32_t dumpFormat = 0;
     CODECHAL_DEBUG_TOOL(
      //   CodecHal_DbgMapSurfaceFormatToDumpFormat(m_rawSurfaceToEnc->Format, &dumpFormat);

--- a/media_driver/agnostic/gen11/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen11/codec/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen11/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen11/codec/media_srcs.cmake
@@ -19,5 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()
 media_include_subdirectory(share)

--- a/media_driver/agnostic/gen11/vp/hal/vphal_render_hdr_g11.cpp
+++ b/media_driver/agnostic/gen11/vp/hal/vphal_render_hdr_g11.cpp
@@ -27,7 +27,9 @@
 #if !EMUL
 
 #include "vphal_render_hdr_g11.h"
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igvpkrn_isa_g11_icllp.h"
+#endif
 #include "renderhal.h"
 
 static const std::string DumpRoot("C:\\temp\\");
@@ -218,7 +220,9 @@ Hdr3DLutCmRender::Hdr3DLutCmRender() :
     m_cmKernel(nullptr),
     m_cmPayload(nullptr)
 {
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_cmProgram = LoadProgram(IGVP3DLUT_GENERATION_G11_ICLLP, IGVP3DLUT_GENERATION_G11_ICLLP_SIZE);
+#endif
     if (!m_cmProgram)
     {
         VPHAL_RENDER_ASSERTMESSAGE("Hdr3DLutCmRender [%s]: CM LoadProgram error %d\n");

--- a/media_driver/agnostic/gen11/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen11/vp/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kdll)
+if(ENABLE_KERNELS)
+    media_include_subdirectory(kdll)
+endif()

--- a/media_driver/agnostic/gen11_icllp/media_interfaces/media_interfaces_g11_icllp.cpp
+++ b/media_driver/agnostic/gen11_icllp/media_interfaces/media_interfaces_g11_icllp.cpp
@@ -26,7 +26,9 @@
 
 #include "media_interfaces_g11_icllp.h"
 #include "codechal_encoder_base.h"
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g11.h"
+#endif
 
 extern template class MediaInterfacesFactory<MhwInterfaces>;
 extern template class MediaInterfacesFactory<MmdDevice>;
@@ -445,7 +447,9 @@ MOS_STATUS CodechalInterfacesG11Icllp::Initialize(
                 m_codechalDevice = encoder;
             }
 
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
             encoder->m_kernelBase = (uint8_t*)IGCODECKRN_G11;
+#endif
         }
         else
 #endif

--- a/media_driver/agnostic/gen11_icllp/vp/hal/vphal_renderer_g11_icllp.cpp
+++ b/media_driver/agnostic/gen11_icllp/vp/hal/vphal_renderer_g11_icllp.cpp
@@ -25,7 +25,9 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g11_icllp.h"
+#if defined(ENABLE_KERNELS)
 #include "igvpkrn_g11_icllp.h"
+#endif
 
 extern const Kdll_RuleEntry         g_KdllRuleTable_g11[];
 
@@ -34,9 +36,11 @@ MOS_STATUS VphalRendererG11Icllp::InitKdllParam()
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
     // Set KDLL parameters (Platform dependent)
+#if defined(ENABLE_KERNELS)
     pKernelDllRules     = g_KdllRuleTable_g11;
     pcKernelBin         = (const void*)IGVPKRN_G11_ICLLP;
     dwKernelBinSize     = IGVPKRN_G11_ICLLP_SIZE;
+#endif
 
     return eStatus;
 }

--- a/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
@@ -18,17 +18,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g11_icllp.c
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g11_icllp.c
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g11_icllp.h
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g11_icllp.h
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen11_icllp/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen11_icllp/vp/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
+if(ENABLE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen8/codec/hal/codechal_encode_csc_ds_g8.cpp
+++ b/media_driver/agnostic/gen8/codec/hal/codechal_encode_csc_ds_g8.cpp
@@ -27,7 +27,7 @@
 #include "codechal_encoder_base.h"
 #include "codechal_encode_csc_ds_g8.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g8.h"
 #endif
 
@@ -37,7 +37,7 @@ CodechalEncodeCscDsG8::CodechalEncodeCscDsG8(CodechalEncoderState* encoder)
     m_rawSurfAlignment = 16;  // on Gen8 raw surface has to be 16-aligned
     m_cscKernelUID = IDR_CODEC_Downscale_Copy;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G8;
 #endif
 }

--- a/media_driver/agnostic/gen8/codec/hal/codechal_encode_csc_ds_g8.cpp
+++ b/media_driver/agnostic/gen8/codec/hal/codechal_encode_csc_ds_g8.cpp
@@ -27,7 +27,9 @@
 #include "codechal_encoder_base.h"
 #include "codechal_encode_csc_ds_g8.h"
 #include "codeckrnheader.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g8.h"
+#endif
 
 CodechalEncodeCscDsG8::CodechalEncodeCscDsG8(CodechalEncoderState* encoder)
     : CodechalEncodeCscDs(encoder)
@@ -35,5 +37,7 @@ CodechalEncodeCscDsG8::CodechalEncodeCscDsG8(CodechalEncoderState* encoder)
     m_rawSurfAlignment = 16;  // on Gen8 raw surface has to be 16-aligned
     m_cscKernelUID = IDR_CODEC_Downscale_Copy;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
+#ifndef _FULL_OPEN_SOURCE
     m_kernelBase = (uint8_t*)IGCODECKRN_G8;
+#endif
 }

--- a/media_driver/agnostic/gen8/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/codec/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g8.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g8.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g8.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g8.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen8/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/codec/media_srcs.cmake
@@ -19,5 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
-
+if(NOT FREE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen8/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/codec/media_srcs.cmake
@@ -19,6 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.cpp
+++ b/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.cpp
@@ -25,7 +25,7 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g8.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igvpkrn_g8.h"
 #endif
 #include "vphal_render_vebox_g8_base.h"
@@ -177,7 +177,7 @@ MOS_STATUS VphalRendererG8::InitKdllParam()
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
     // Set KDLL parameters (Platform dependent)
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     pKernelDllRules         = g_KdllRuleTable_g8;
     pcKernelBin             = (const void*)IGVPKRN_G8;
     dwKernelBinSize         = IGVPKRN_G8_SIZE;

--- a/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.cpp
+++ b/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.cpp
@@ -25,7 +25,9 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g8.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igvpkrn_g8.h"
+#endif
 #include "vphal_render_vebox_g8_base.h"
 #include "vphal_render_composite_g8.h"
 #include "renderhal_g8.h"
@@ -175,9 +177,11 @@ MOS_STATUS VphalRendererG8::InitKdllParam()
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
     // Set KDLL parameters (Platform dependent)
+#ifndef _FULL_OPEN_SOURCE
     pKernelDllRules         = g_KdllRuleTable_g8;
     pcKernelBin             = (const void*)IGVPKRN_G8;
     dwKernelBinSize         = IGVPKRN_G8_SIZE;
+#endif
 
     return eStatus;
 }

--- a/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.h
+++ b/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.h
@@ -63,7 +63,7 @@ public:
     {
         // Set SSEUTable
         pRenderHal->sseuTable           = VpHalDefaultSSEUTableG8;
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
         m_modifyKdllFunctionPointers    = KernelDll_ModifyFunctionPointers_g8;
 #endif
     }

--- a/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.h
+++ b/media_driver/agnostic/gen8/vp/hal/vphal_renderer_g8.h
@@ -63,9 +63,9 @@ public:
     {
         // Set SSEUTable
         pRenderHal->sseuTable           = VpHalDefaultSSEUTableG8;
-
+#ifndef _FULL_OPEN_SOURCE
         m_modifyKdllFunctionPointers    = KernelDll_ModifyFunctionPointers_g8;
-
+#endif
     }
 
     //!

--- a/media_driver/agnostic/gen8/vp/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/vp/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g8.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g8.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g8.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g8.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen8/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/vp/media_srcs.cmake
@@ -19,5 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kdll)
-media_include_subdirectory(kernel)
+if(NOT FREE_KERNELS)
+    media_include_subdirectory(kdll)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen8/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/vp/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
     media_include_subdirectory(kdll)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen8_bdw/media_interfaces/media_interfaces_g8_bdw.cpp
+++ b/media_driver/agnostic/gen8_bdw/media_interfaces/media_interfaces_g8_bdw.cpp
@@ -25,7 +25,9 @@
 //!
 
 #include "media_interfaces_g8_bdw.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g8.h"
+#endif
 
 #ifdef _HYBRID_HEVC_DECODE_SUPPORTED
 #include "codechal_decode_hybrid_hevc.h"

--- a/media_driver/agnostic/gen8_bdw/media_interfaces/media_interfaces_g8_bdw.cpp
+++ b/media_driver/agnostic/gen8_bdw/media_interfaces/media_interfaces_g8_bdw.cpp
@@ -25,7 +25,7 @@
 //!
 
 #include "media_interfaces_g8_bdw.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g8.h"
 #endif
 

--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_csc_ds_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_csc_ds_g9.cpp
@@ -27,7 +27,9 @@
 #include "codechal_encoder_base.h"
 #include "codechal_encode_csc_ds_g9.h"
 #include "codeckrnheader.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g9.h"
+#endif
 #if USE_CODECHAL_DEBUG_TOOL
 #include "codechal_debug_encode_par_g9.h"
 #endif
@@ -240,5 +242,7 @@ CodechalEncodeCscDsG9::CodechalEncodeCscDsG9(CodechalEncoderState* encoder)
 {
     m_cscKernelUID = IDR_CODEC_Downscale_Copy;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
+#ifndef _FULL_OPEN_SOURCE
     m_kernelBase = (uint8_t*)IGCODECKRN_G9;
+#endif
 }

--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_csc_ds_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_csc_ds_g9.cpp
@@ -27,7 +27,7 @@
 #include "codechal_encoder_base.h"
 #include "codechal_encode_csc_ds_g9.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g9.h"
 #endif
 #if USE_CODECHAL_DEBUG_TOOL
@@ -242,7 +242,7 @@ CodechalEncodeCscDsG9::CodechalEncodeCscDsG9(CodechalEncoderState* encoder)
 {
     m_cscKernelUID = IDR_CODEC_Downscale_Copy;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G9;
 #endif
 }

--- a/media_driver/agnostic/gen9/codec/hal/codechal_vdenc_avc_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_vdenc_avc_g9.cpp
@@ -27,7 +27,9 @@
 
 #include "codechal_vdenc_avc_g9.h"
 #include "codeckrnheader.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g9.h"
+#endif
 #if USE_CODECHAL_DEBUG_TOOL
 #include "codechal_debug_encode_par_g9.h"
 #endif
@@ -37,7 +39,9 @@ CodechalVdencAvcStateG9::CodechalVdencAvcStateG9(
         CodechalDebugInterface *debugInterface,
         PCODECHAL_STANDARD_INFO standardInfo) : CodechalVdencAvcState(hwInterface, debugInterface, standardInfo)
 {
+#ifndef _FULL_OPEN_SOURCE
     m_kernelBase = (uint8_t*)IGCODECKRN_G9;
+#endif
     m_kuid = IDR_CODEC_AllAVCEnc;
     AddIshSize(m_kuid, m_kernelBase);
 

--- a/media_driver/agnostic/gen9/codec/hal/codechal_vdenc_avc_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_vdenc_avc_g9.cpp
@@ -27,7 +27,7 @@
 
 #include "codechal_vdenc_avc_g9.h"
 #include "codeckrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g9.h"
 #endif
 #if USE_CODECHAL_DEBUG_TOOL
@@ -39,7 +39,7 @@ CodechalVdencAvcStateG9::CodechalVdencAvcStateG9(
         CodechalDebugInterface *debugInterface,
         PCODECHAL_STANDARD_INFO standardInfo) : CodechalVdencAvcState(hwInterface, debugInterface, standardInfo)
 {
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G9;
 #endif
     m_kuid = IDR_CODEC_AllAVCEnc;

--- a/media_driver/agnostic/gen9/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/codec/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen9/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/codec/media_srcs.cmake
@@ -19,6 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen9/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/codec/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
+if(NOT FREE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen9/vp/hal/vphal_render_vebox_g9_base.cpp
+++ b/media_driver/agnostic/gen9/vp/hal/vphal_render_vebox_g9_base.cpp
@@ -30,7 +30,9 @@
 #include "vphal_render_sfc_g9_base.h"
 #include "vphal_render_vebox_util_base.h"
 #include "vpkrnheader.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igvpkrn_isa_g9.h"
+#endif
 
 #define MAX_INPUT_PREC_BITS         16
 #define DOWNSHIFT_WITH_ROUND(x, n)  (((x) + (((n) > 0) ? (1 << ((n) - 1)) : 0)) >> (n))
@@ -2224,7 +2226,9 @@ VPHAL_VEBOX_STATE_G9_BASE::VPHAL_VEBOX_STATE_G9_BASE(
     pKernelParamTable                   = (PRENDERHAL_KERNEL_PARAM)g_Vebox_KernelParam_g9;
     iNumFFDISurfaces                    = 2;  // PE on: 4 used. PE off: 2 used
 
+#ifndef _FULL_OPEN_SOURCE
     m_hvsKernelBinary                   = (uint8_t *)IGVP_HVS_DENOISE_G900;
     m_hvsKernelBinarySize               = IGVP_HVS_DENOISE_G900_SIZE;
+#endif
 }
 

--- a/media_driver/agnostic/gen9/vp/hal/vphal_render_vebox_g9_base.cpp
+++ b/media_driver/agnostic/gen9/vp/hal/vphal_render_vebox_g9_base.cpp
@@ -30,7 +30,7 @@
 #include "vphal_render_sfc_g9_base.h"
 #include "vphal_render_vebox_util_base.h"
 #include "vpkrnheader.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igvpkrn_isa_g9.h"
 #endif
 
@@ -2226,7 +2226,7 @@ VPHAL_VEBOX_STATE_G9_BASE::VPHAL_VEBOX_STATE_G9_BASE(
     pKernelParamTable                   = (PRENDERHAL_KERNEL_PARAM)g_Vebox_KernelParam_g9;
     iNumFFDISurfaces                    = 2;  // PE on: 4 used. PE off: 2 used
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_hvsKernelBinary                   = (uint8_t *)IGVP_HVS_DENOISE_G900;
     m_hvsKernelBinarySize               = IGVP_HVS_DENOISE_G900_SIZE;
 #endif

--- a/media_driver/agnostic/gen9/vp/hal/vphal_renderer_g9.cpp
+++ b/media_driver/agnostic/gen9/vp/hal/vphal_renderer_g9.cpp
@@ -25,7 +25,9 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g9.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igvpkrn_g9.h"
+#endif
 #include "vphal_render_vebox_g9_base.h"
 #include "vphal_render_composite_g9.h"
 
@@ -167,9 +169,11 @@ MOS_STATUS VphalRendererG9::InitKdllParam()
 {
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
+#ifndef _FULL_OPEN_SOURCE
     pKernelDllRules     = g_KdllRuleTable_g9;
     pcKernelBin         = (const void*)IGVPKRN_G9;
     dwKernelBinSize     = IGVPKRN_G9_SIZE;
+#endif
 
     return eStatus;
 }

--- a/media_driver/agnostic/gen9/vp/hal/vphal_renderer_g9.cpp
+++ b/media_driver/agnostic/gen9/vp/hal/vphal_renderer_g9.cpp
@@ -25,7 +25,7 @@
 //! \details  The top renderer is responsible for coordinating the sequence of calls to low level renderers, e.g. DNDI or Comp
 //!
 #include "vphal_renderer_g9.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igvpkrn_g9.h"
 #endif
 #include "vphal_render_vebox_g9_base.h"
@@ -169,7 +169,7 @@ MOS_STATUS VphalRendererG9::InitKdllParam()
 {
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     pKernelDllRules     = g_KdllRuleTable_g9;
     pcKernelBin         = (const void*)IGVPKRN_G9;
     dwKernelBinSize     = IGVPKRN_G9_SIZE;

--- a/media_driver/agnostic/gen9/vp/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/vp/kernel/media_srcs.cmake
@@ -18,17 +18,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g9.c
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g9.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g9.c
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g9.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g9.h
-        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g9.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g9.h
+    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g9.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen9/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/vp/media_srcs.cmake
@@ -19,5 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kdll)
-media_include_subdirectory(kernel)
+if(NOT FREE_KERNELS)
+    media_include_subdirectory(kdll)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen9/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/vp/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND NOT FREE_KERNELS)
     media_include_subdirectory(kdll)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen9_bxt/media_interfaces/media_interfaces_g9_bxt.cpp
+++ b/media_driver/agnostic/gen9_bxt/media_interfaces/media_interfaces_g9_bxt.cpp
@@ -25,7 +25,7 @@
 //!
 
 #include "media_interfaces_g9_bxt.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g9.h"
 #endif
 

--- a/media_driver/agnostic/gen9_bxt/media_interfaces/media_interfaces_g9_bxt.cpp
+++ b/media_driver/agnostic/gen9_bxt/media_interfaces/media_interfaces_g9_bxt.cpp
@@ -25,7 +25,9 @@
 //!
 
 #include "media_interfaces_g9_bxt.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g9.h"
+#endif
 
 extern template class MediaInterfacesFactory<MhwInterfaces>;
 extern template class MediaInterfacesFactory<MmdDevice>;

--- a/media_driver/agnostic/gen9_glk/media_interfaces/media_interfaces_g9_glk.cpp
+++ b/media_driver/agnostic/gen9_glk/media_interfaces/media_interfaces_g9_glk.cpp
@@ -26,7 +26,9 @@
 
 #include "media_interfaces_g9_kbl.h"
 #include "media_interfaces_g9_glk.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g9.h"
+#endif
 
 extern template class MediaInterfacesFactory<MhwInterfaces>;
 extern template class MediaInterfacesFactory<MmdDevice>;

--- a/media_driver/agnostic/gen9_glk/media_interfaces/media_interfaces_g9_glk.cpp
+++ b/media_driver/agnostic/gen9_glk/media_interfaces/media_interfaces_g9_glk.cpp
@@ -26,7 +26,7 @@
 
 #include "media_interfaces_g9_kbl.h"
 #include "media_interfaces_g9_glk.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g9.h"
 #endif
 

--- a/media_driver/agnostic/gen9_kbl/media_interfaces/media_interfaces_g9_kbl.cpp
+++ b/media_driver/agnostic/gen9_kbl/media_interfaces/media_interfaces_g9_kbl.cpp
@@ -25,7 +25,9 @@
 //!
 
 #include "media_interfaces_g9_kbl.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g9.h"
+#endif
 
 extern template class MediaInterfacesFactory<MhwInterfaces>;
 extern template class MediaInterfacesFactory<MmdDevice>;

--- a/media_driver/agnostic/gen9_kbl/media_interfaces/media_interfaces_g9_kbl.cpp
+++ b/media_driver/agnostic/gen9_kbl/media_interfaces/media_interfaces_g9_kbl.cpp
@@ -25,7 +25,7 @@
 //!
 
 #include "media_interfaces_g9_kbl.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g9.h"
 #endif
 

--- a/media_driver/agnostic/gen9_skl/media_interfaces/media_interfaces_g9_skl.cpp
+++ b/media_driver/agnostic/gen9_skl/media_interfaces/media_interfaces_g9_skl.cpp
@@ -25,7 +25,9 @@
 //!
 
 #include "media_interfaces_g9_skl.h"
+#ifndef _FULL_OPEN_SOURCE
 #include "igcodeckrn_g9.h"
+#endif
 
 #ifdef _HYBRID_HEVC_DECODE_SUPPORTED
 #include "codechal_decode_hybrid_hevc.h"

--- a/media_driver/agnostic/gen9_skl/media_interfaces/media_interfaces_g9_skl.cpp
+++ b/media_driver/agnostic/gen9_skl/media_interfaces/media_interfaces_g9_skl.cpp
@@ -25,7 +25,7 @@
 //!
 
 #include "media_interfaces_g9_skl.h"
-#ifndef _FULL_OPEN_SOURCE
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g9.h"
 #endif
 

--- a/media_driver/agnostic/media_srcs.cmake
+++ b/media_driver/agnostic/media_srcs.cmake
@@ -20,51 +20,51 @@
 
 media_include_subdirectory(common)
 
-if(${GEN8_Supported} STREQUAL "yes")
+if(GEN8)
     media_include_subdirectory(gen8)
 endif()
 
-if(${GEN8_BDW_Supported} STREQUAL "yes")
+if(GEN8_BDW)
     media_include_subdirectory(gen8_bdw)
 endif()
 
-if(${GEN9_Supported} STREQUAL "yes")
+if(GEN9)
     media_include_subdirectory(gen9)
 endif()
 
-if(${GEN9_BXT_Supported} STREQUAL "yes")
+if(GEN9_BXT)
     media_include_subdirectory(gen9_bxt)
 endif()
 
-if(${GEN9_SKL_Supported} STREQUAL "yes")
+if(GEN9_SKL)
     media_include_subdirectory(gen9_skl)
 endif()
 
-if(${GEN9_CFL_Supported} STREQUAL "yes")
+if(GEN9_CFL)
     media_include_subdirectory(gen9_cfl)
 endif()
 
-if(${GEN9_GLK_Supported} STREQUAL "yes")
+if(GEN9_GLK)
     media_include_subdirectory(gen9_glk)
 endif()
 
-if(${GEN9_KBL_Supported} STREQUAL "yes")
+if(GEN9_KBL)
     media_include_subdirectory(gen9_kbl)
 endif()
 
-if(${GEN10_Supported} STREQUAL "yes")
+if(GEN10)
     media_include_subdirectory(gen10)
 endif()
 
-if(${GEN10_CNL_Supported} STREQUAL "yes")
+if(GEN10_CNL)
     media_include_subdirectory(gen10_cnl)
 endif()
 
-if(${GEN11_Supported} STREQUAL "yes")
+if(GEN11)
     media_include_subdirectory(gen11)
 endif()
 
-if(${GEN11_ICLLP_Supported} STREQUAL "yes")
+if(GEN11_ICLLP)
     media_include_subdirectory(gen11_icllp)
 endif()
 

--- a/media_driver/cmake/linux/media_feature_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_feature_flags_linux.cmake
@@ -23,13 +23,7 @@ bs_set_if_undefined(Encode_VME_Supported "yes")
 # global flag for encode AVC_VDENC/HEVC_VDENC/VP9_VDENC/JPEG
 bs_set_if_undefined(Encode_VDEnc_Supported "yes")
 
-# Full-open-source means only using open source EU kernels and fixed function hardware
-# which is controlled by Full_Open_Source_Support flag.
-# The opposite is full-feature which permits some features only have binaries.
-# The default build is full-feature build so set Full_Open_Source_Support as "no".
-bs_set_if_undefined(Full_Open_Source_Support "no")
-
-if(${Full_Open_Source_Support} STREQUAL "yes")
+if(FREE_KERNELS)
     # full-open-source
     bs_set_if_undefined(AVC_Encode_VME_Supported "no")
     bs_set_if_undefined(HEVC_Encode_VME_Supported "no")
@@ -158,12 +152,12 @@ else()
     add_definitions(-D__VPHAL_SFC_SUPPORTED=0)
 endif()
 
-if(${Full_Open_Source_Support} STREQUAL "yes")
-    add_definitions(-D_FULL_OPEN_SOURCE)
-endif()
-
 if(ENABLE_KERNELS)
     add_definitions(-DENABLE_KERNELS)
+endif()
+
+if(FREE_KERNELS)
+    add_definitions(-D_FULL_OPEN_SOURCE)
 endif()
 
 include(${MEDIA_DRIVER_CMAKE}/ext/linux/media_feature_flags_linux_ext.cmake OPTIONAL)

--- a/media_driver/cmake/linux/media_feature_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_feature_flags_linux.cmake
@@ -23,7 +23,13 @@ bs_set_if_undefined(Encode_VME_Supported "yes")
 # global flag for encode AVC_VDENC/HEVC_VDENC/VP9_VDENC/JPEG
 bs_set_if_undefined(Encode_VDEnc_Supported "yes")
 
-if(FREE_KERNELS)
+# Some features can't be supported if shaders (kernels) are not
+# available. So, we switch such features off explicitly. That's
+# possible either if user requested a build entirely without
+# shaders or a build with free only shaders. The list of switched
+# off features correspnds to the free kernels case, but we can
+# reuse the full list for enable kernels as well.
+if(NOT ENABLE_KERNELS OR FREE_KERNELS)
     # full-open-source
     bs_set_if_undefined(AVC_Encode_VME_Supported "no")
     bs_set_if_undefined(HEVC_Encode_VME_Supported "no")

--- a/media_driver/cmake/linux/media_gen_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_gen_flags_linux.cmake
@@ -18,65 +18,83 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-bs_set_if_undefined(GEN8_Supported "yes")
-bs_set_if_undefined(GEN8_BDW_Supported "yes")
-bs_set_if_undefined(GEN9_Supported "yes")
-bs_set_if_undefined(GEN9_BXT_Supported "yes")
-bs_set_if_undefined(GEN9_SKL_Supported "yes")
-bs_set_if_undefined(GEN9_CFL_Supported "yes")
-bs_set_if_undefined(GEN9_GLK_Supported "yes")
-bs_set_if_undefined(GEN9_KBL_Supported "yes")
-bs_set_if_undefined(GEN10_Supported "yes")
-bs_set_if_undefined(GEN10_CNL_Supported "yes")
-bs_set_if_undefined(GEN11_Supported "yes")
-bs_set_if_undefined(GEN11_ICLLP_Supported "yes")
+option(GEN8 "Enable Gen8 support" ON)
+cmake_dependent_option(GEN8_BDW
+    "Enabled BDW support (Gen8)" ON
+    "GEN8" OFF)
 
+option(GEN9 "Enable Gen9 support" ON)
+cmake_dependent_option(GEN9_BXT
+    "Enabled BXT support (Gen9)" ON
+    "GEN9" OFF)
+cmake_dependent_option(GEN9_CFL
+    "Enabled CFL support (Gen9)" ON
+    "GEN9" OFF)
+cmake_dependent_option(GEN9_GLK
+    "Enabled GLK support (Gen9)" ON
+    "GEN9" OFF)
+cmake_dependent_option(GEN9_KBL
+    "Enabled KBL support (Gen9)" ON
+    "GEN9" OFF)
+cmake_dependent_option(GEN9_SKL
+    "Enabled SKL support (Gen9)" ON
+    "GEN9" OFF)
 
-if(${GEN8_Supported} STREQUAL "yes")
+option(GEN10 "Enable Gen10 support" ON)
+cmake_dependent_option(GEN10_CNL
+    "Enabled CNL support (Gen10)" ON
+    "GEN10" OFF)
+
+option(GEN11 "Enable Gen11 support" ON)
+cmake_dependent_option(GEN11_ICLLP
+    "Enabled ICLLP support (Gen11)" ON
+    "GEN11" OFF)
+
+if(GEN8)
     add_definitions(-DIGFX_GEN8_SUPPORTED)
 endif()
 
-if(${GEN8_BDW_Supported} STREQUAL "yes")
+if(GEN8_BDW)
     add_definitions(-DIGFX_GEN8_BDW_SUPPORTED)
 endif()
 
-if(${GEN9_Supported} STREQUAL "yes")
+if(GEN9)
     add_definitions(-DIGFX_GEN9_SUPPORTED)
 endif()
 
-if(${GEN9_BXT_Supported} STREQUAL "yes")
+if(GEN9_BXT)
     add_definitions(-DIGFX_GEN9_BXT_SUPPORTED)
 endif()
 
-if(${GEN9_SKL_Supported} STREQUAL "yes")
+if(GEN9_SKL)
     add_definitions(-DIGFX_GEN9_SKL_SUPPORTED)
 endif()
 
-if(${GEN9_CFL_Supported} STREQUAL "yes")
+if(GEN9_CFL)
     add_definitions(-DIGFX_GEN9_CFL_SUPPORTED)
 endif()
 
-if(${GEN9_GLK_Supported} STREQUAL "yes")
+if(GEN9_GLK)
     add_definitions(-DIGFX_GEN9_GLK_SUPPORTED)
 endif()
 
-if(${GEN9_KBL_Supported} STREQUAL "yes")
+if(GEN9_KBL)
     add_definitions(-DIGFX_GEN9_KBL_SUPPORTED)
 endif()
 
-if(${GEN10_Supported} STREQUAL "yes")
+if(GEN10)
     add_definitions(-DIGFX_GEN10_SUPPORTED)
 endif()
 
-if(${GEN10_CNL_Supported} STREQUAL "yes")
+if(GEN10_CNL)
     add_definitions(-DIGFX_GEN10_CNL_SUPPORTED)
 endif()
 
-if(${GEN11_Supported} STREQUAL "yes")
+if(GEN11)
     add_definitions(-DIGFX_GEN11_SUPPORTED)
 endif()
 
-if(${GEN11_ICLLP_Supported} STREQUAL "yes")
+if(GEN11_ICLLP)
     add_definitions(-DIGFX_GEN11_ICLLP_SUPPORTED)
 endif()
 

--- a/media_driver/linux/media_srcs.cmake
+++ b/media_driver/linux/media_srcs.cmake
@@ -20,43 +20,43 @@
 
 media_include_subdirectory(common)
 
-if(${GEN8_Supported} STREQUAL "yes")
+if(GEN8)
     media_include_subdirectory(gen8)
 endif()
 
-if(${GEN9_Supported} STREQUAL "yes")
+if(GEN9)
     media_include_subdirectory(gen9)
 endif()
 
-if(${GEN9_BXT_Supported} STREQUAL "yes")
+if(GEN9_BXT)
     media_include_subdirectory(gen9_bxt)
 endif()
 
-if(${GEN9_SKL_Supported} STREQUAL "yes")
+if(GEN9_SKL)
     media_include_subdirectory(gen9_skl)
 endif()
 
-if(${GEN9_KBL_Supported} STREQUAL "yes")
+if(GEN9_SKL)
     media_include_subdirectory(gen9_kbl)
 endif()
 
-if(${GEN9_GLK_Supported} STREQUAL "yes")
+if(GEN9_GLK)
     media_include_subdirectory(gen9_glk)
 endif()
 
-if(${GEN9_CFL_Supported} STREQUAL "yes")
+if(GEN9_CFL)
     media_include_subdirectory(gen9_cfl)
 endif()
 
-if(${GEN10_Supported} STREQUAL "yes")
+if(GEN10)
     media_include_subdirectory(gen10)
 endif()
 
-if(${GEN10_CNL_Supported} STREQUAL "yes")
+if(GEN10_CNL)
     media_include_subdirectory(gen10_cnl)
 endif()
 
-if(${GEN11_Supported} STREQUAL "yes")
+if(GEN11)
     media_include_subdirectory(gen11)
 endif()
 

--- a/media_driver/linux/ult/ult_app/CMakeLists.txt
+++ b/media_driver/linux/ult/ult_app/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 aux_source_directory(. SOURCES)
 aux_source_directory(./cm SOURCES)
 aux_source_directory(${agnostic_cm_tests} SOURCES)
-if (NOT "${Full_Open_Source_Support}" STREQUAL "yes")
+if (NOT FREE_KERNELS)
     aux_source_directory(./gpu_cmd SOURCES)
     set(SOURCES
         ${SOURCES}
@@ -67,7 +67,7 @@ if (DEFINED BYPASS_MEDIA_ULT AND "${BYPASS_MEDIA_ULT}" STREQUAL "yes")
     # must explictly pass along BYPASS_MEDIA_ULT as yes then could bypass the running of media ult
     message("-- media -- BYPASS_MEDIA_ULT = ${BYPASS_MEDIA_ULT}")
 else ()
-    if (NOT "${Full_Open_Source_Support}" STREQUAL "yes")
+    if (NOT FREE_KERNELS)
         add_custom_target(RunULT ALL DEPENDS ${LIB_NAME} devult)
 
         add_custom_command(


### PR DESCRIPTION
This PR refactors some driver build options:
1. Name them simpler
2. Make them standard cmake options rather than self-written
3. Set correct dependencies between them.

For example, equivalent of the the old
```
cmake ../media-driver \
-DGEN8_Supported="no" \
-DGEN8_BDW_Supported="no" \
-DGEN9_Supported="no" \
-DGEN9_BXT_Supported="no" \
-DGEN9_SKL_Supported="no" \
-DGEN9_CFL_Supported="no" \
-DGEN9_GLK_Supported="no" \
-DGEN9_KBL_Supported="no" \
-DFull_Open_Source_Support="yes" $@
```
will be just:
```
cmake ../media-driver \
-DGEN8=OFF \
-DGEN9=OFF \
-DFREE_KERNELS=ON $@
```
