### PR TITLE
Fix VA_RT_FORMAT for VAProfileHEVCMain10.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -797,7 +797,7 @@ VAStatus MediaLibvaCaps::CreateDecAttributes(
     }
     else if(profile == VAProfileHEVCMain10)
     {
-        attrib.value = VA_RT_FORMAT_YUV420_10;
+        attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV420_10;
     }
     else if(profile == VAProfileHEVCMain422_10)
     {


### PR DESCRIPTION
Add VA_RT_FORMAT_Y420 8bit for VAProfileHEVCMain10.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>