### PR TITLE
libva_caps: remove unused VA_SURFACE_ATTRIB_MEM_TYPE_ANDROID_GRALLOC

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -2348,18 +2348,10 @@ VAStatus MediaLibvaCaps::QuerySurfaceAttributes(
         attribs[i].type = VASurfaceAttribMemoryType;
         attribs[i].value.type = VAGenericValueTypeInteger;
         attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
-#ifdef ANDROID
-        attribs[i].value.value.i = VA_SURFACE_ATTRIB_MEM_TYPE_VA |
-            VA_SURFACE_ATTRIB_MEM_TYPE_USER_PTR |
-            VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM |
-            VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME |
-            VA_SURFACE_ATTRIB_MEM_TYPE_ANDROID_GRALLOC;
-#else
         attribs[i].value.value.i = VA_SURFACE_ATTRIB_MEM_TYPE_VA |
             VA_SURFACE_ATTRIB_MEM_TYPE_USER_PTR |
             VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM |
             VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME;
-#endif
         i++;
 
         attribs[i].type = VASurfaceAttribExternalBufferDescriptor;

--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -766,18 +766,10 @@ VAStatus MediaLibvaCapsG11::QuerySurfaceAttributes(
         attribs[i].type = VASurfaceAttribMemoryType;
         attribs[i].value.type = VAGenericValueTypeInteger;
         attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
-#ifdef ANDROID
-        attribs[i].value.value.i = VA_SURFACE_ATTRIB_MEM_TYPE_VA |
-            VA_SURFACE_ATTRIB_MEM_TYPE_USER_PTR |
-            VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM |
-            VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME |
-            VA_SURFACE_ATTRIB_MEM_TYPE_ANDROID_GRALLOC;
-#else
         attribs[i].value.value.i = VA_SURFACE_ATTRIB_MEM_TYPE_VA |
             VA_SURFACE_ATTRIB_MEM_TYPE_USER_PTR |
             VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM |
             VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME;
-#endif
         i++;
 
         attribs[i].type = VASurfaceAttribExternalBufferDescriptor;


### PR DESCRIPTION
it never used on android any more, we will use dma buf

@tchew6 , please help review this