### PR TITLE
installing:  install driver with proper permissions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if("${LIBVA_DRIVERS_PATH}" STREQUAL "")
 endif()
 message(STATUS "LIBVA_DRIVERS_PATH = ${LIBVA_DRIVERS_PATH}")
 
-install (FILES ${CMAKE_CURRENT_BINARY_DIR}/media_driver/iHD_drv_video.so DESTINATION ${LIBVA_DRIVERS_PATH} COMPONENT media)
+install (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/media_driver/iHD_drv_video.so DESTINATION ${LIBVA_DRIVERS_PATH} COMPONENT media)
 
 option (INSTALL_DRIVER_SYSCONF "Install driver system configuration file" OFF)
 if (INSTALL_DRIVER_SYSCONF)


### PR DESCRIPTION
cmake install as PROGRAMS will set the proper permissions
to iHD_drv_video.so file to be 755 in linux

Fixes #215

Signed-off-by: Daniel Charles <daniel.charles@intel.com>