### PR TITLE
build: change FREE_KERNELS option to ENABLE_NONFREE_KERNELS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
       intelmediadriver/media-driver-docker
       cmake
       -DMEDIA_VERSION="0.1.0"
-      -DFREE_KERNELS=ON
+      -DENABLE_NONFREE_KERNELS=OFF
       -DBUILD_TYPE=Release
       ../media-driver
   - >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,15 +43,14 @@ endif()
 include(CMakeDependentOption)
 
 option (ENABLE_KERNELS "Build driver with shaders (kernels) support" ON)
-# FREE_KERNELS option means using only open source EU shaders (kernels) and
-# fixed function hardware. The opposite is a full-feature build which permits
-# usage of shaders (kernels) in binary form.
-cmake_dependent_option( FREE_KERNELS
-    "Use only shaders (kernels) with available sources" OFF
+# ENABLE_NONFREE_KERNELS option permits to enable closed source EU shaders (kernels)
+# additionally to open source EU shaders and fixed function hardware.
+cmake_dependent_option( ENABLE_NONFREE_KERNELS
+    "Use closed source pre-built  binary shaders (kernels)" ON
     "ENABLE_KERNELS" OFF)
 cmake_dependent_option( BUILD_KERNELS
     "Rebuild shaders (kernels) from sources" OFF
-    "ENABLE_KERNELS;FREE_KERNELS" OFF)
+    "ENABLE_KERNELS;NOT ENABLE_NONFREE_KERNELS" OFF)
 option (BUILD_CMRTLIB "Build and Install cmrtlib together with media driver" ON)
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ This section summarizes key driver build modes which can be used in the differen
 | Build option | Default value | Dependencies | Comments |
 |-|-|-|-|
 | ENABLE_KERNELS | ON | N/A | Enable/Disable shaders during driver build |
-| FREE_KERNELS | OFF | ENABLE_KERNELS=ON | If enabled, use only open source shaders (kernels) during the build |
-| BUILD_KERNELS | OFF | ENABLE_KERNELS=ON, FREE_KERNELS=ON | If enabled, rebuild open source shaders (kernels) from sources. Requires FREE_KERNELS=ON |
+| ENABLE_NONFREE_KERNELS | ON | ENABLE_KERNELS=ON | Enable/disable close source shaders (kernels) during the build |
+| BUILD_KERNELS | OFF | ENABLE_KERNELS=ON, ENABLE_NONFREE_KERNELS=OFF | If enabled, rebuild open source shaders (kernels) from sources. Requires ENABLE_NONFREE_KERNELS=OFF |
 
 With the above options it is possible to build (table assumes that non-listed options have default values):
 
 | No. | Build option(s) | HW Features | Shaders (Kernels) | Comments |
 |-|-|-|-|-|
-| 1 | ENABLE_KERNELS=ON | Yes | Close source (pre-built) | Default, full feature driver |
+| 1 | ENABLE_KERNELS=ON | Yes | Close source (pre-built) | **Default**, full feature driver |
 | 2 | ENABLE_KERNELS=OFF | Yes | None | HW features only, include HW decoder, HW VDEnc Encoder (CQP mode) |
-| 3 | FREE_KERNELS=ON | Yes | Open source | Same as FREE_KERNELS=ON driver, but shaders are rebuilt from sources |
-| 4 | FREE_KERNELS=ON BUILD_KERNELS=ON | Yes | Open source (pre-built) | HW features available in prev.mode (ENABLE_KERNELS=ON) and features supported by open source shaders |
+| 3 | ENABLE_NONFREE_KERNELS=OFF | Yes | Open source (pre-built) | HW features available in prev. mode (ENABLE_KERNELS=ON) and features supported by open source shaders |
+| 4 | ENABLE_NONFREE_KERNELS=OFF BUILD_KERNELS=ON | Yes | Open source | Same as ENABLE_NONFREE_KERNELS=OFF driver, but shaders are rebuilt from sources |
 
 ## Supported Platforms
 

--- a/distro_cmake.sh
+++ b/distro_cmake.sh
@@ -3,4 +3,4 @@
 cmake ../media-driver \
 -DGEN8=OFF \
 -DGEN9=OFF \
--DFREE_KERNELS=ON $@
+-DENABLE_NONFREE_KERNELS=OFF $@

--- a/media_driver/agnostic/gen10/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/codec/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()
 media_include_subdirectory(share)

--- a/media_driver/agnostic/gen10/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen10/vp/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kdll)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen11/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen11/codec/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()
 media_include_subdirectory(share)

--- a/media_driver/agnostic/gen11_icllp/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen11_icllp/codec/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11_icllp.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11_icllp.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11_icllp.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g11_icllp.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen11_icllp/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen11_icllp/codec/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
@@ -20,13 +20,23 @@
 
 set(TMP_SOURCES_
     ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g11_icllp.c
-    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.c
 )
 
 set(TMP_HEADERS_
     ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_g11_icllp.h
-    ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.h
 )
+
+if(ENABLE_NONFREE_KERNELS)
+    set(TMP_SOURCES_
+        ${TMP_SOURCES_}
+        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.c
+    )
+
+    set(TMP_HEADERS_
+        ${TMP_HEADERS_}
+        ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g11_icllp.h
+    )
+endif()
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen8/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/codec/media_srcs.cmake
@@ -19,6 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen8/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen8/vp/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kdll)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen9/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/codec/media_srcs.cmake
@@ -19,6 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen9/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen9/vp/media_srcs.cmake
@@ -19,7 +19,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-if(ENABLE_KERNELS AND NOT FREE_KERNELS)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
     media_include_subdirectory(kdll)
     media_include_subdirectory(kernel)
 endif()

--- a/media_driver/agnostic/gen9_bxt/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen9_bxt/codec/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_bxt.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_bxt.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_bxt.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_bxt.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen9_bxt/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen9_bxt/codec/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen9_kbl/codec/kernel/media_srcs.cmake
+++ b/media_driver/agnostic/gen9_kbl/codec/kernel/media_srcs.cmake
@@ -18,15 +18,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if(ENABLE_KERNELS)
-    set(TMP_SOURCES_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_kbl.c
-    )
+set(TMP_SOURCES_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_kbl.c
+)
 
-    set(TMP_HEADERS_
-        ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_kbl.h
-    )
-endif()
+set(TMP_HEADERS_
+    ${CMAKE_CURRENT_LIST_DIR}/igcodeckrn_g9_kbl.h
+)
 
 set(SOURCES_
     ${SOURCES_}

--- a/media_driver/agnostic/gen9_kbl/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen9_kbl/codec/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(kernel)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
+    media_include_subdirectory(kernel)
+endif()

--- a/media_driver/agnostic/gen9_skl/codec/media_srcs.cmake
+++ b/media_driver/agnostic/gen9_skl/codec/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
-media_include_subdirectory(cmrt_kernel)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
+    media_include_subdirectory(cmrt_kernel)
+endif()

--- a/media_driver/cmake/linux/media_feature_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_feature_flags_linux.cmake
@@ -29,7 +29,7 @@ bs_set_if_undefined(Encode_VDEnc_Supported "yes")
 # shaders or a build with free only shaders. The list of switched
 # off features correspnds to the free kernels case, but we can
 # reuse the full list for enable kernels as well.
-if(NOT ENABLE_KERNELS OR FREE_KERNELS)
+if(NOT ENABLE_KERNELS OR NOT ENABLE_NONFREE_KERNELS)
     # full-open-source
     bs_set_if_undefined(AVC_Encode_VME_Supported "no")
     bs_set_if_undefined(HEVC_Encode_VME_Supported "no")
@@ -162,7 +162,7 @@ if(ENABLE_KERNELS)
     add_definitions(-DENABLE_KERNELS)
 endif()
 
-if(FREE_KERNELS)
+if(NOT ENABLE_NONFREE_KERNELS)
     add_definitions(-D_FULL_OPEN_SOURCE)
 endif()
 

--- a/media_driver/linux/ult/ult_app/CMakeLists.txt
+++ b/media_driver/linux/ult/ult_app/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 aux_source_directory(. SOURCES)
 aux_source_directory(./cm SOURCES)
 aux_source_directory(${agnostic_cm_tests} SOURCES)
-if (NOT FREE_KERNELS)
+if (ENABLE_NONFREE_KERNELS)
     aux_source_directory(./gpu_cmd SOURCES)
     set(SOURCES
         ${SOURCES}
@@ -67,7 +67,7 @@ if (DEFINED BYPASS_MEDIA_ULT AND "${BYPASS_MEDIA_ULT}" STREQUAL "yes")
     # must explictly pass along BYPASS_MEDIA_ULT as yes then could bypass the running of media ult
     message("-- media -- BYPASS_MEDIA_ULT = ${BYPASS_MEDIA_ULT}")
 else ()
-    if (NOT FREE_KERNELS)
+    if (ENABLE_NONFREE_KERNELS)
         add_custom_target(RunULT ALL DEPENDS ${LIB_NAME} devult)
 
         add_custom_command(


### PR DESCRIPTION
It was noted that FREE_KERNELS may be confusing since with =OFF it
actually enables non-free kernels (wihtout published sources). So,
let's use ENABLE_NONFREE_KERNELS instead.

Mind that ENABLE_NONFREE_KERNELS default value is ON. So, driver
default behaviour did not change.

Change-Id: Ifae417c3ada32d065fa615c9d5cc17c41f3b93b5
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>