### PR TITLE
encode_mpeg2: use 16kb as the buf unit for mpeg2 vbvBuf

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_mpeg2.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_mpeg2.cpp
@@ -797,9 +797,9 @@ void DdiEncodeMpeg2::ParseMiscParamVBV(void *data)
 
     CodecEncodeMpeg2SequenceParams *mpeg2SeqParams = (CodecEncodeMpeg2SequenceParams *)m_encodeCtx->pSeqParams;
 
-    mpeg2SeqParams->m_vbvBufferSize              = vaEncMiscParamHRD->buffer_size;
+    mpeg2SeqParams->m_vbvBufferSize              = vaEncMiscParamHRD->buffer_size / CODEC_ENCODE_MPEG2_VBV_BUFFER_SIZE_UNITS;
     mpeg2SeqParams->m_initVBVBufferFullnessInBit = vaEncMiscParamHRD->initial_buffer_fullness;
-    mpeg2SeqParams->m_rateControlMethod          = RATECONTROL_CBR;
+    //mpeg2SeqParams->m_rateControlMethod          = RATECONTROL_CBR;
 }
 
 // Parse the frame rate paramters from app


### PR DESCRIPTION
Use vbvBuf in 16kb to match the behaviour in SetCurbeBrcInitReset()
to generate the correct m_bufSizeInBits.

Discard the default CBR mode to enable the setting for VBR.

Fix the issue in FFmpeg trac #7650 in driver level

Signed-off-by: Linjie Fu <linjie.fu@intel.com>