### PR TITLE
Fix X11 detect support

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -6072,11 +6072,7 @@ VAStatus __vaDriverInit(VADriverContextP ctx )
     pVTable->vaQuerySurfaceStatus            = DdiMedia_QuerySurfaceStatus;
     pVTable->vaQuerySurfaceError             = DdiMedia_QuerySurfaceError;
     pVTable->vaQuerySurfaceAttributes        = DdiMedia_QuerySurfaceAttributes;
-#if defined(X11_FOUND)
     pVTable->vaPutSurface                    = DdiMedia_PutSurface;
-#else
-    pVTable->vaPutSurface                    = NULL;
-#endif
     pVTable->vaQueryImageFormats             = DdiMedia_QueryImageFormats;
 
     pVTable->vaCreateImage                   = DdiMedia_CreateImage;


### PR DESCRIPTION
PR #494 set vaPutSurface as NULL, libva throws an error
and iHD driver is not initialized.

Signed-off-by: Azhar Shaikh <azhar.shaikh@intel.com>