### PR TITLE
[AVC Encode] add level_idc CODEC_AVC_LEVEL_1b

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_avc_base.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_avc_base.cpp
@@ -55,6 +55,7 @@ uint32_t CodecHalAvcEncode_GetMaxVmvR(uint8_t levelIdc)
     switch (levelIdc)
     {
     case CODEC_AVC_LEVEL_1:
+    case CODEC_AVC_LEVEL_1b:
         maxVmvR = 64 * 4;
         break;
     case CODEC_AVC_LEVEL_11:
@@ -96,6 +97,7 @@ uint32_t CodecHalAvcEncode_GetMaxMvLen(uint8_t levelIdc)
     switch (levelIdc)
     {
     case CODEC_AVC_LEVEL_1:
+    case CODEC_AVC_LEVEL_1b:
         maxMvLen = 63;
         break;
     case CODEC_AVC_LEVEL_11:
@@ -446,6 +448,7 @@ static int32_t GetMaxMBPS(uint8_t levelIdc)
     switch (levelIdc)
     {
     case CODEC_AVC_LEVEL_1:
+    case CODEC_AVC_LEVEL_1b:
         maxMBPS = 1485;
         break;
     case CODEC_AVC_LEVEL_11:

--- a/media_driver/agnostic/common/codec/shared/codec_def_common_avc.h
+++ b/media_driver/agnostic/common/codec/shared/codec_def_common_avc.h
@@ -68,6 +68,7 @@ typedef enum
 typedef enum
 {
     CODEC_AVC_LEVEL_1                    = 10,
+    CODEC_AVC_LEVEL_1b                   = 9,
     CODEC_AVC_LEVEL_11                   = 11,
     CODEC_AVC_LEVEL_12                   = 12,
     CODEC_AVC_LEVEL_13                   = 13,


### PR DESCRIPTION
in case the application input the level idc 9, add flag "CODEC_AVC_LEVEL_1b" to support it. 