### PR TITLE
cfl: add missing device id 0x3e98

### DIFF
--- a/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
@@ -816,6 +816,9 @@ static bool cflDevice3e91 = DeviceInfoFactory<GfxDeviceInfo>::
 static bool cflDevice3e96 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x3e96, &cflGt2Info);
 
+static bool cflDevice3e98 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x3e98, &cflGt2Info);
+
 static bool cflDevice3e9b = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x3e9b, &cflGt2Info);
 


### PR DESCRIPTION
Fixes: #507

This follows the ID in the kernel commit
d0e062e ("drm/i915/cfl: Add a new CFL PCI ID.")

Change-Id: If908627cbe59586c5140d545c62e3dd1e4236ab1
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>