### PR TITLE
[Decode] Prevent mt read/write conflict

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -3289,6 +3289,8 @@ static VAStatus DdiMedia_SyncSurface (
     PDDI_DECODE_CONTEXT decCtx = (PDDI_DECODE_CONTEXT)surface->pDecCtx;
     if (decCtx && surface->curCtxType == DDI_MEDIA_CONTEXT_TYPE_DECODER)
     {
+        DdiMediaUtil_LockGuard guard(&mediaCtx->SurfaceMutex);
+
         Codechal *codecHal = decCtx->pCodecHal;
         DDI_CHK_NULL(codecHal, "nullptr decCtx->pCodecHal", VA_STATUS_ERROR_INVALID_CONTEXT);
 
@@ -3335,7 +3337,6 @@ static VAStatus DdiMedia_SyncSurface (
 
                     if ((tempNewReport.m_codecStatus == CODECHAL_STATUS_SUCCESSFUL) || (tempNewReport.m_codecStatus == CODECHAL_STATUS_ERROR) || (tempNewReport.m_codecStatus == CODECHAL_STATUS_INCOMPLETE))
                     {
-                        DdiMediaUtil_LockMutex(&mediaCtx->SurfaceMutex);
                         PDDI_MEDIA_SURFACE_HEAP_ELEMENT mediaSurfaceHeapElmt = (PDDI_MEDIA_SURFACE_HEAP_ELEMENT)mediaCtx->pSurfaceHeap->pHeapBase;
 
                         uint32_t j = 0;
@@ -3355,10 +3356,8 @@ static VAStatus DdiMedia_SyncSurface (
 
                         if (j == mediaCtx->pSurfaceHeap->uiAllocatedHeapElements)
                         {
-                            DdiMediaUtil_UnLockMutex(&mediaCtx->SurfaceMutex);
                             return VA_STATUS_ERROR_OPERATION_FAILED;
                         }
-                        DdiMediaUtil_UnLockMutex(&mediaCtx->SurfaceMutex);
                     }
                     else
                     {

--- a/media_driver/linux/common/ddi/media_libva_util.h
+++ b/media_driver/linux/common/ddi/media_libva_util.h
@@ -153,6 +153,28 @@ void     DdiMediaUtil_LockMutex(PMEDIA_MUTEX_T  mutex);
 void     DdiMediaUtil_UnLockMutex(PMEDIA_MUTEX_T  mutex);
 
 //!
+//! \brief  Helper inline class intended to simplify mutex lock/unlock
+//!         operations primarily used as a stack-allocated object.
+//!         In that case, the compiler guarantees to call the destructor
+//!         leaving the scope. The class becomes handy in functions
+//!         where there are several return statements with different
+//!         exit code value.
+//!
+class DdiMediaUtil_LockGuard {
+private:
+    PMEDIA_MUTEX_T m_pMutex;
+public:
+    DdiMediaUtil_LockGuard(PMEDIA_MUTEX_T pMutex):m_pMutex(pMutex)
+    {
+        DdiMediaUtil_LockMutex(m_pMutex);
+    }
+    ~DdiMediaUtil_LockGuard()
+    {
+        DdiMediaUtil_UnLockMutex(m_pMutex);
+    }
+};
+
+//!
 //! \brief  Destroy semaphore
 //! 
 //! \param  [in] sem


### PR DESCRIPTION
Two concurrent DdiMedia_SyncSurface function calls read and
write the same data when the second frame uses the first frame
as a reference frame.