### PR TITLE
Don't create the GEM buffer manager for invalid device

### DIFF
--- a/media_driver/linux/common/os/i915/mos_bufmgr.c
+++ b/media_driver/linux/common/os/i915/mos_bufmgr.c
@@ -4415,6 +4415,12 @@ mos_bufmgr_gem_init(int fd, int batch_size)
     /* support Gen 8+ */
     bufmgr_gem->pci_device = get_pci_device_id(bufmgr_gem);
 
+    if (bufmgr_gem->pci_device == 0) {
+        free(bufmgr_gem);
+        bufmgr_gem = nullptr;
+        goto exit;
+    }
+
     memclear(gp);
     gp.value = &tmp;
 


### PR DESCRIPTION
In a dual GPU system, it is possible to open a non-Intel GPU device node then try to use iHD driver.  See https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/issues/135 for details.