### PR TITLE
Fix DeriveImage with UYVY fourcc

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -4202,6 +4202,7 @@ VAStatus DdiMedia_DeriveImage (
         vaimg->pitches[0]               = mediaSurface->iPitch;
         break;
      case Media_Format_YUY2:
+     case Media_Format_UYVY:
         vaimg->format.bits_per_pixel    = 16;
         vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;


### PR DESCRIPTION
This makes the gst pipeline below works:

gst-launch-1.0 videotestsrc num-buffers=1 ! msdkvpp ! \
video/x-raw\(memory:DMABuf\),format=UYVY ! filesink location=a.yuv

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>