### PR TITLE
vp8_decode: Ensure the Partition0BitOffset in VP8_BSD_OBJECT

### DIFF
--- a/media_driver/agnostic/common/codec/shared/codec_def_decode_vp8.h
+++ b/media_driver/agnostic/common/codec/shared/codec_def_decode_vp8.h
@@ -92,6 +92,7 @@ typedef struct _CODEC_VP8_PIC_PARAMS
     uint8_t             ucP0EntropyValue;
     uint32_t            uiP0EntropyRange;
     uint32_t            uiFirstMbByteOffset;
+    uint32_t            uiP0FirstmbbitoffsetFromFrameHeader;
     uint32_t            uiPartitionSize[CODEC_VP8_MAX_PARTITION_NUMBER];
 
     uint32_t            uiStatusReportFeedbackNumber;

--- a/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_mfx_generic.h
+++ b/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_mfx_generic.h
@@ -2828,6 +2828,7 @@ protected:
 
         uint8_t numPartitions = (1 << vp8PicParams->CodedCoeffTokenPartition);
 
+	cmd.DW1.Partition0FirstmbbitoffsetFromFrameHeader = vp8PicParams->uiP0FirstmbbitoffsetFromFrameHeader;
         cmd.DW1.CodedNumOfCoeffTokenPartitions = vp8PicParams->CodedCoeffTokenPartition;
         cmd.DW1.Partition0CpbacEntropyRange = vp8PicParams->uiP0EntropyRange;
         cmd.DW1.Partition0CpbacEntropyCount = vp8PicParams->ucP0EntropyCount;

--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
@@ -85,7 +85,8 @@ VAStatus DdiDecodeVP8::ParseSliceParams(
     //macroblock_offset is in unit of bit.it should be always the next byte, the byte is divided to two parts
     //used bits and remaining bits, if used bits == 8, uiFirstMbByteOffset should add 1, so use 8 to do the ceil operator
     picParams->uiFirstMbByteOffset = slcParam->slice_data_offset + ((slcParam->macroblock_offset + 8) >> 3);
-
+    //offset to the first bit of MB from the first byte of partition data
+    picParams->uiP0FirstmbbitoffsetFromFrameHeader = slcParam->macroblock_offset & 0x7;
     MOS_SecureMemcpy(picParams->uiPartitionSize, sizeof(picParams->uiPartitionSize), slcParam->partition_size, sizeof(picParams->uiPartitionSize));
     //partition 0 size in command buffer includes the one byte in bool decoder if remaining bits of bool decoder is zero.
     picParams->uiPartitionSize[0] -= (slcParam->macroblock_offset & 0x7) ? 0 : 1;


### PR DESCRIPTION
Partition0 FirstMBBitOffset from Frame Header allows HW
to jump to the location in the bitstream where per MB information starts in the Partition0