### PR TITLE
Fix SurfaceFromID get rid of false alarm

### DIFF
--- a/media_driver/agnostic/common/cm/cm_hal.cpp
+++ b/media_driver/agnostic/common/cm/cm_hal.cpp
@@ -11950,4 +11950,3 @@ bool HalCm_IsValidGpuContext(
         return false;
     }
 }
-

--- a/media_driver/agnostic/common/cm/cm_hal.h
+++ b/media_driver/agnostic/common/cm/cm_hal.h
@@ -54,6 +54,8 @@
 #define SURFACE_FLAG_ASSUME_NOT_IN_USE 1
 #define CM_THREADSPACE_MAX_COLOR_COUNT 16
 
+static const uint32_t INVALID_STREAM_INDEX = 0xFFFFFFFF;
+
 //*-----------------------------------------------------------------------------
 //| Macro unsets bitPos bit in value
 //*-----------------------------------------------------------------------------
@@ -1898,6 +1900,8 @@ typedef struct _CM_HAL_STATE
         (
         PCM_HAL_STATE               state,
         uint64_t                    kernelId);
+
+    uint32_t (*pfnRegisterStream) (PCM_HAL_STATE state);
 } CM_HAL_STATE, *PCM_HAL_STATE;
 
 typedef struct _CM_HAL_MI_REG_OFFSETS

--- a/media_driver/agnostic/common/cm/cm_queue_rt.h
+++ b/media_driver/agnostic/common/cm/cm_queue_rt.h
@@ -243,6 +243,8 @@ public:
 
     int32_t GetOSSyncEventHandle(void *& hOSSyncEvent);
 
+    uint32_t StreamIndex() const { return m_streamIndex; }
+
 protected:
     CmQueueRT(CmDeviceRT *device, CM_QUEUE_CREATE_OPTION queueCreateOption);
 
@@ -354,6 +356,18 @@ protected:
     void  *m_osSyncEvent;   //KMD Notification
 
 private:
+    uint32_t m_streamIndex;
+
+    MOS_STATUS CreateGpuContext(CM_HAL_STATE *halState,
+                                MOS_GPU_CONTEXT gpuContextName,
+                                MOS_GPU_NODE gpuNode,
+                                MOS_GPUCTX_CREATOPTIONS *createOptions);
+
+    // Calls CM HAL API to submit a group task to command buffer.
+    MOS_STATUS ExecuteGroupTask(CM_HAL_STATE *halState,
+                                CM_HAL_EXEC_TASK_GROUP_PARAM *taskParam,
+                                MOS_GPU_CONTEXT gpuContextName);
+
     CmQueueRT(const CmQueueRT& other);
     CmQueueRT& operator=(const CmQueueRT& other);
 };

--- a/media_driver/linux/common/cm/cm_hal_os.cpp
+++ b/media_driver/linux/common/cm/cm_hal_os.cpp
@@ -1123,6 +1123,11 @@ MOS_STATUS HalCm_UpdateTrackerResource_Linux(
     return eStatus;
 }
 
+uint32_t HalCm_RegisterStream(CM_HAL_STATE *state)
+{
+    return state->osInterface->streamIndex;
+}
+
 void HalCm_OsInitInterface(
     PCM_HAL_STATE           cmState)          // [out]  pointer to CM State
 {
@@ -1142,6 +1147,7 @@ void HalCm_OsInitInterface(
     cmState->pfnIsWASLMinL3Cache                    = HalCm_IsWaSLMinL3Cache_Linux;
     cmState->pfnEnableTurboBoost                    = HalCm_EnableTurboBoost_Linux;
     cmState->pfnUpdateTrackerResource               = HalCm_UpdateTrackerResource_Linux;
+    cmState->pfnRegisterStream                      = HalCm_RegisterStream;
 
     HalCm_GetLibDrmVMapFnt(cmState);
     return;

--- a/media_driver/linux/common/ddi/media_libva_common.cpp
+++ b/media_driver/linux/common/ddi/media_libva_common.cpp
@@ -290,12 +290,16 @@ DDI_MEDIA_SURFACE* DdiMedia_GetSurfaceFromVASurfaceID (PDDI_MEDIA_CONTEXT mediaC
     DDI_CHK_NULL(mediaCtx, "nullptr mediaCtx", nullptr);
 
     i                = (uint32_t)surfaceID;
-    DDI_CHK_LESS(i, mediaCtx->pSurfaceHeap->uiAllocatedHeapElements, "invalid surface id", nullptr);
-    DdiMediaUtil_LockMutex(&mediaCtx->SurfaceMutex);
-    surfaceElement  = (PDDI_MEDIA_SURFACE_HEAP_ELEMENT)mediaCtx->pSurfaceHeap->pHeapBase;
-    surfaceElement += i;
-    surface         = surfaceElement->pSurface;
-    DdiMediaUtil_UnLockMutex(&mediaCtx->SurfaceMutex);
+    bool validSurface = (i != VA_INVALID_SURFACE);
+    if(validSurface)
+    {
+        DDI_CHK_LESS(i, mediaCtx->pSurfaceHeap->uiAllocatedHeapElements, "invalid surface id", nullptr);
+        DdiMediaUtil_LockMutex(&mediaCtx->SurfaceMutex);
+        surfaceElement  = (PDDI_MEDIA_SURFACE_HEAP_ELEMENT)mediaCtx->pSurfaceHeap->pHeapBase;
+        surfaceElement += i;
+        surface         = surfaceElement->pSurface;
+        DdiMediaUtil_UnLockMutex(&mediaCtx->SurfaceMutex);
+    }
 
     return surface;
 }


### PR DESCRIPTION
Ignore special surfaceID value VA_INVALID_SURFACE.
GetSurfaceFromVASurfaceID may be called
for non existing reference frame,
e.g., for Intra-only frame with surfaceID = -1.
The caller validates the surface again,
fix non-existing reference,
and decoding proceeds without any problem.
But the driver reports about critical error constantly.