### PR TITLE
8K resolution size is only for HEVC not for AVC and VP9.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -920,7 +920,11 @@ VAStatus MediaLibvaCaps::CreateDecAttributes(
     {
         attrib.value = CODEC_4K_MAX_PIC_WIDTH;
     }
-    if(IsAvcProfile(profile)||IsHevcProfile(profile)|| IsVp9Profile(profile))
+    if(IsAvcProfile(profile))
+    {
+        attrib.value = CODEC_4K_MAX_PIC_WIDTH;
+    }
+    if(IsHevcProfile(profile) || IsVp9Profile(profile))
     {
         attrib.value = CODEC_8K_MAX_PIC_WIDTH;
     }
@@ -940,7 +944,11 @@ VAStatus MediaLibvaCaps::CreateDecAttributes(
     {
         attrib.value = CODEC_4K_MAX_PIC_HEIGHT;
     }
-    if(IsAvcProfile(profile)||IsHevcProfile(profile) || IsVp9Profile(profile))
+    if(IsAvcProfile(profile))
+    {
+        attrib.value = CODEC_4K_MAX_PIC_HEIGHT;
+    }
+    if(IsHevcProfile(profile) || IsVp9Profile(profile))
     {
         attrib.value = CODEC_8K_MAX_PIC_HEIGHT;
     }


### PR DESCRIPTION
Fixes #540.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>