### PR TITLE
Add X11_FOUND flag

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -41,7 +41,7 @@
 #include "media_interfaces.h"
 #include "media_ddi_decode_const.h"
 
-#ifndef ANDROID
+#if !defined(ANDROID) && defined(X11_FOUND)
 #include <X11/Xutil.h>
 #endif
 


### PR DESCRIPTION
There was an instance where the X11_FOUND flag was missing
causing build failures on systems which do not support X(eg. chrome).
Fix this by adding the check.

Signed-off-by: Azhar Shaikh <azhar.shaikh@intel.com>