### PR TITLE
Unbreak build without X11

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -41,7 +41,7 @@
 #include "media_interfaces.h"
 #include "media_ddi_decode_const.h"
 
-#ifndef ANDROID
+#if !defined(ANDROID) && defined(X11_FOUND)
 #include <X11/Xutil.h>
 #endif
 


### PR DESCRIPTION
Followup to #494. At least 18.4.1 doesn't build if libX11 isn't installed.
