### PR TITLE
Keep the right slice number for bitstream buffer.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -280,6 +280,11 @@ static bool DdiMedia_ReleaseBsBuffer(
         }
         return false;
     }
+    else
+    {
+        if (bufMgr->dwNumSliceData)
+            bufMgr->dwNumSliceData--;
+    }
     return true;
 }
 


### PR DESCRIPTION
When destroy bitstream buffer, it should decrease
bufMgr->dwNumSliceData.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>
Signed-off-by: XinfengZhang <carl.zhang@intel.com>