### PR TITLE
Avoid connect status report.

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_vp8.cpp
@@ -240,8 +240,7 @@ VAStatus DdiEncodeVp8::StatusReport(
             // if HDCP2 is enabled, the second segment for counter values is already there  So, move the connection as the third one
             if (m_encodeCtx->pCpDdiInterface->IsHdcp2Enabled())
                 pFindTheLastEntry = (VACodedBufferSegment *)pFindTheLastEntry->next;
-            // connect Status report here
-            pFindTheLastEntry->next = pVACodedBufferSegmentForStatusReport;
+            pFindTheLastEntry->next = NULL;
 
             break;
         }


### PR DESCRIPTION
It will cause FFMPEG encoding error.
Fixes #409.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>