### PR TITLE
Travis: add libva path in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       -w /opt/src/libva
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      make -j 8
+      make -j8
   - >
       docker run
       -v $HOME/.ccache:/opt/ccache
@@ -38,7 +38,7 @@ script:
       -w /opt/src/libva
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      make install
+      make install DESTDIR=/opt/src/libva-install
   - ccache -s
   - ccache -z
   - >
@@ -48,9 +48,11 @@ script:
       -w /opt/src/build
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      cmake
+      cmake ../media-driver
+      -DCMAKE_INSTALL_PREFIX=/usr
+      -DLIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri
+      -DLIBVA_INSTALL_PATH=/opt/src/libva-install/usr/include
       -DBUILD_TYPE=Release
-      ../media-driver
   - >
       docker run
       -v $HOME/.ccache:/opt/ccache
@@ -58,7 +60,7 @@ script:
       -w /opt/src/build
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      cmake  --build . -- -j 8
+      make -j8
   - ccache -s
   - ccache -z
   - sudo rm -rf ${TRAVIS_BUILD_DIR}/../build && mkdir ${TRAVIS_BUILD_DIR}/../build
@@ -69,10 +71,12 @@ script:
       -w /opt/src/build
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      cmake
+      cmake ../media-driver
+      -DCMAKE_INSTALL_PREFIX=/usr
+      -DLIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri
+      -DLIBVA_INSTALL_PATH=/opt/src/libva-install/usr/include
       -DENABLE_KERNELS=OFF
       -DBUILD_TYPE=Release
-      ../media-driver
   - >
       docker run
       -v $HOME/.ccache:/opt/ccache
@@ -80,7 +84,7 @@ script:
       -w /opt/src/build
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      cmake  --build . -- -j 8
+      make -j8
   - ccache -s
   - ccache -z
   - sudo rm -rf ${TRAVIS_BUILD_DIR}/../build && mkdir ${TRAVIS_BUILD_DIR}/../build
@@ -91,10 +95,12 @@ script:
       -w /opt/src/build
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      cmake
+      cmake ../media-driver
+      -DCMAKE_INSTALL_PREFIX=/usr
+      -DLIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri
+      -DLIBVA_INSTALL_PATH=/opt/src/libva-install/usr/include
       -DENABLE_NONFREE_KERNELS=OFF
       -DBUILD_TYPE=Release
-      ../media-driver
   - >
       docker run
       -v $HOME/.ccache:/opt/ccache
@@ -102,6 +108,6 @@ script:
       -w /opt/src/build
       -e CCACHE_DIR=/opt/ccache
       intelmediadriver/media-driver-docker
-      cmake  --build . -- -j 8
+      make -j8
   - ccache -s
   - ccache -z


### PR DESCRIPTION
Add DLIBVA_DRIVERS_PATH and DLIBVA_INSTALL_PATH to make sure driver in
docker image use the correct libva lib.