### PR TITLE
cmake: check libva-x11 instead of X11

### DIFF
--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -21,7 +21,7 @@
 project( media )
 
 find_package(PkgConfig)
-find_package(X11)
+find_package(libva-x11)
 
 bs_set_if_undefined(LIB_NAME iHD_drv_video)
 


### PR DESCRIPTION
This fixes the error below when X11 is not available

In file included from
/home/xhh/graphics/ex/vaapi/media-driver/media_driver/linux/common/ddi/media_libva.cpp:47:
/home/xhh/graphics/ex/vaapi/media-driver/media_driver/linux/common/ddi/media_libva_putsurface_linux.h:31:10:
fatal error: va/va_dricommon.h: No such file or directory
 #include <va/va_dricommon.h>