### PR TITLE
Fix VP9 8K decoding.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -1890,6 +1890,10 @@ VAStatus MediaLibvaCaps::CheckDecodeResolution(
             maxWidth = m_decHevcMaxWidth;
             maxHeight = m_decHevcMaxHeight;
             break;
+        case CODECHAL_DECODE_MODE_VP9VLD:
+            maxWidth = m_decVp9MaxWidth;
+            maxHeight = m_decVp9MaxHeight;
+            break;
         default:
             maxWidth = m_decDefaultMaxWidth;
             maxHeight = m_decDefaultMaxHeight;
@@ -2540,6 +2544,11 @@ VAStatus MediaLibvaCaps::QuerySurfaceAttributes(
         {
             maxWidth = m_decJpegMaxWidth;
             maxHeight = m_decJpegMaxHeight;
+        }
+        else if(IsVp9Profile(profile))
+        {
+            maxWidth = m_decVp9MaxWidth;
+            maxHeight = m_decVp9MaxHeight;
         }
 
         attribs[i].type = VASurfaceAttribMaxWidth;

--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -914,6 +914,11 @@ VAStatus MediaLibvaCapsG11::QuerySurfaceAttributes(
             maxWidth = m_decJpegMaxWidth;
             maxHeight = m_decJpegMaxHeight;
         }
+        else if(IsVp9Profile(profile))
+        {
+            maxWidth = m_decVp9MaxWidth;
+            maxHeight = m_decVp9MaxHeight;
+        }
 
         attribs[i].type = VASurfaceAttribMaxWidth;
         attribs[i].value.type = VAGenericValueTypeInteger;


### PR DESCRIPTION
Use VP9 max resoltuion (8K) instead of default max resolution (4K).

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>