### PR TITLE
ignore error status value for jpeg decode

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decoder.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_decoder.cpp
@@ -1603,14 +1603,14 @@ MOS_STATUS CodechalDecode::GetStatusReport(
                     else
                     {
                         // Check to see if decoding error occurs
-                        if ((m_decodeStatusBuf.m_decodeStatus[i].m_mmioErrorStatusReg &
-                             m_mfxInterface->GetMfxErrorFlagsMask()) != 0)
-                        {
-                            codecStatus[j].m_codecStatus = CODECHAL_STATUS_ERROR;
-                        }
-                        //MB Count bit[15:0] is error concealment MB count for none JPEG decoder.
                         if (m_standard != CODECHAL_JPEG)
                         {
+                            if ((m_decodeStatusBuf.m_decodeStatus[i].m_mmioErrorStatusReg &
+                                 m_mfxInterface->GetMfxErrorFlagsMask()) != 0)
+                            {
+                                codecStatus[j].m_codecStatus = CODECHAL_STATUS_ERROR;
+                            }
+                        //MB Count bit[15:0] is error concealment MB count for none JPEG decoder.
                             codecStatus[j].m_numMbsAffected =
                                 m_decodeStatusBuf.m_decodeStatus[i].m_mmioMBCountReg & 0xFFFF;
                         }


### PR DESCRIPTION
no clear description of the meaning of the value for jpeg
just the description for AVC MPEG2 ... so, ignore it

Signed-off-by: XinfengZhang <carl.zhang@intel.com>