### PR TITLE
vp: avoid segfault on Linux if vp failed to initialize

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp
@@ -1438,15 +1438,18 @@ VphalRenderer::~VphalRenderer()
     VPHAL_RENDER_CHK_NULL_NO_STATUS(m_pOsInterface);
 
 #if defined(LINUX)
-    MOS_USER_FEATURE_VALUE_WRITE_DATA   userFeatureWriteData;
-    MOS_ZeroMemory(&userFeatureWriteData, sizeof(userFeatureWriteData));
-    userFeatureWriteData.Value.i32Data  = m_reporting->OutputPipeMode;
-    userFeatureWriteData.ValueID        = __VPHAL_VEBOX_OUTPUTPIPE_MODE_ID;
-    MOS_UserFeature_WriteValues_ID(nullptr, &userFeatureWriteData, 1);
-    MOS_ZeroMemory(&userFeatureWriteData, sizeof(userFeatureWriteData));
-    userFeatureWriteData.Value.bData  = m_reporting->VEFeatureInUse;
-    userFeatureWriteData.ValueID        = __VPHAL_VEBOX_FEATURE_INUSE_ID;
-    MOS_UserFeature_WriteValues_ID(nullptr, &userFeatureWriteData, 1);
+    if (m_reporting)
+    {
+        MOS_USER_FEATURE_VALUE_WRITE_DATA   userFeatureWriteData;
+        MOS_ZeroMemory(&userFeatureWriteData, sizeof(userFeatureWriteData));
+        userFeatureWriteData.Value.i32Data  = m_reporting->OutputPipeMode;
+        userFeatureWriteData.ValueID        = __VPHAL_VEBOX_OUTPUTPIPE_MODE_ID;
+        MOS_UserFeature_WriteValues_ID(nullptr, &userFeatureWriteData, 1);
+        MOS_ZeroMemory(&userFeatureWriteData, sizeof(userFeatureWriteData));
+        userFeatureWriteData.Value.bData  = m_reporting->VEFeatureInUse;
+        userFeatureWriteData.ValueID        = __VPHAL_VEBOX_FEATURE_INUSE_ID;
+        MOS_UserFeature_WriteValues_ID(nullptr, &userFeatureWriteData, 1);
+    }
 #endif
 
     FreeIntermediateSurfaces();


### PR DESCRIPTION
m_reporting is initialized in constructor as nullptr:
https://github.com/intel/media-driver/blob/baa8b1f7a8b903abdf0e8ad9882773752b120262/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp#L1665

Hence, we should assume that it may fail to be initialized later on and protect the code at least in the destructor:
https://github.com/intel/media-driver/blob/baa8b1f7a8b903abdf0e8ad9882773752b120262/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp#L1443

This will be a real segmentation fault on the on-screen rendering attempt if driver will be built with ENABLE_NONFREE_KERNELS=OFF and at least DRI2 rendering path will be selected.
