### PR TITLE
[Encode] Fix for race condition in AVC FEI

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libva_encoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_encoder.cpp
@@ -222,11 +222,13 @@ VAStatus DdiEncode_CreateContext(
     VAProfile profile;
     VAEntrypoint entrypoint;
     uint32_t rcMode = 0;
+    uint32_t feiFunction = 0;
     VAStatus vaStatus = mediaDrvCtx->m_caps->GetEncConfigAttr(
             config_id + DDI_CODEC_GEN_CONFIG_ATTRIBUTES_ENC_BASE,
             &profile,
             &entrypoint,
-            &rcMode);
+            &rcMode,
+            &feiFunction);
     DDI_CHK_RET(vaStatus, "Invalide config_id!");
 
     vaStatus = mediaDrvCtx->m_caps->CheckEncodeResolution(
@@ -243,7 +245,7 @@ VAStatus DdiEncode_CreateContext(
         return VA_STATUS_ERROR_MAX_NUM_EXCEEDED;
     }
 
-    std::string    encodeKey = mediaDrvCtx->m_caps->GetEncodeCodecKey(profile, entrypoint);
+    std::string    encodeKey = mediaDrvCtx->m_caps->GetEncodeCodecKey(profile, entrypoint, feiFunction);
     DdiEncodeBase *ddiEncode = DdiEncodeFactory::CreateCodec(encodeKey);
     DDI_CHK_NULL(ddiEncode, "nullptr ddiEncode", VA_STATUS_ERROR_UNIMPLEMENTED);
 
@@ -292,7 +294,7 @@ VAStatus DdiEncode_CreateContext(
     encCtx->vaProfile     = profile;
     encCtx->uiRCMethod    = rcMode;
     encCtx->wModeType     = mediaDrvCtx->m_caps->GetEncodeCodecMode(profile, entrypoint);
-    encCtx->codecFunction = mediaDrvCtx->m_caps->GetEncodeCodecFunction(profile, entrypoint);
+    encCtx->codecFunction = mediaDrvCtx->m_caps->GetEncodeCodecFunction(profile, entrypoint, feiFunction);
 
     if (entrypoint == VAEntrypointEncSliceLP)
     {

--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -210,21 +210,19 @@ bool MediaLibvaCaps::CheckEntrypointCodecType(VAEntrypoint entrypoint, CodecType
 
 VAStatus MediaLibvaCaps::AddDecConfig(uint32_t slicemode, uint32_t encryptType, uint32_t processType)
 {
-    DecConfig decConfig = {slicemode, encryptType, processType};
-    m_decConfigs.push_back(decConfig);
-
+    m_decConfigs.emplace_back(slicemode, encryptType, processType);
     return VA_STATUS_SUCCESS;
 }
 
-VAStatus MediaLibvaCaps::AddEncConfig(uint32_t rcMode)
+VAStatus MediaLibvaCaps::AddEncConfig(uint32_t rcMode, uint32_t feiFunction)
 {
-    m_encConfigs.push_back(rcMode);
+    m_encConfigs.emplace_back(rcMode, feiFunction);
     return VA_STATUS_SUCCESS;
 }
 
 VAStatus MediaLibvaCaps::AddVpConfig(uint32_t attrib)
 {
-    m_vpConfigs.push_back(attrib);
+    m_vpConfigs.emplace_back(attrib);
     return VA_STATUS_SUCCESS;
 }
 
@@ -1066,6 +1064,12 @@ VAStatus MediaLibvaCaps::LoadAvcEncProfileEntrypoints()
             VAProfileH264ConstrainedBaseline};
 
         VAEntrypoint entrypoint[2] = {VAEntrypointEncSlice, VAEntrypointFEI};
+
+        uint32_t feiFunctions[3] = {
+                VA_FEI_FUNCTION_ENC,
+                VA_FEI_FUNCTION_PAK,
+                VA_FEI_FUNCTION_ENC_PAK};
+
         uint32_t configStartIdx;
 
         for (int32_t e = 0; e < 2; e++)
@@ -1076,10 +1080,19 @@ VAStatus MediaLibvaCaps::LoadAvcEncProfileEntrypoints()
             for (int32_t i = 0; i < 3; i++)
             {
                 configStartIdx = m_encConfigs.size();
+                bool isFei = !!(entrypoint[e] == VAEntrypointFEI);
                 int32_t maxRcMode = (entrypoint[e] == VAEntrypointEncSlice ? 9 : 1);
                 for (int32_t j = 0; j < maxRcMode; j++)
                 {
-                    AddEncConfig(m_encRcMode[j]);
+                    if (isFei)
+                    {
+                        for (int32_t k = 0; k < 3; k++)
+                        {
+                            AddEncConfig(m_encRcMode[j], feiFunctions[k]);
+                        }
+                    }
+                    else
+                        AddEncConfig(m_encRcMode[j]);
                 }
                 AddProfileEntry(profile[i], entrypoint[e], attributeList,
                         configStartIdx, m_encConfigs.size() - configStartIdx);
@@ -1774,7 +1787,6 @@ VAStatus MediaLibvaCaps::CreateEncConfig(
     {
         rcMode = VA_RC_NONE;
     }
-    m_mediaCtx->FeiFunction = 0;
 
     bool rc_mb_flag = false;
     if (entrypoint == VAEntrypointEncSliceLP)
@@ -1792,6 +1804,8 @@ VAStatus MediaLibvaCaps::CreateEncConfig(
                 break;
         }
     }
+
+    uint32_t feiFunction = 0;
 
     int32_t j;
     for (j = 0; j < numAttribs; j++)
@@ -1811,7 +1825,7 @@ VAStatus MediaLibvaCaps::CreateEncConfig(
         }
         if(VAConfigAttribFEIFunctionType == attribList[j].type)
         {
-            m_mediaCtx->FeiFunction = attribList[j].value;
+            feiFunction = attribList[j].value;
         }
         if(VAConfigAttribRTFormat == attribList[j].type)
         {
@@ -1828,7 +1842,8 @@ VAStatus MediaLibvaCaps::CreateEncConfig(
     int32_t configNum = m_profileEntryTbl[profileTableIdx].m_configNum;
     for (j = startIdx; j < (startIdx + configNum); j++)
     {
-        if (m_encConfigs[j] == rcMode)
+        if (m_encConfigs[j].m_rcMode == rcMode &&
+            m_encConfigs[j].m_FeiFunction == feiFunction)
         {
             break;
         }
@@ -2121,7 +2136,8 @@ VAStatus MediaLibvaCaps::GetEncConfigAttr(
         VAConfigID configId,
         VAProfile *profile,
         VAEntrypoint *entrypoint,
-        uint32_t *rcMode)
+        uint32_t *rcMode,
+        uint32_t *feiFunction)
 {
     DDI_CHK_NULL(profile, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);
     DDI_CHK_NULL(entrypoint, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);
@@ -2143,7 +2159,8 @@ VAStatus MediaLibvaCaps::GetEncConfigAttr(
     {
         return VA_STATUS_ERROR_INVALID_CONFIG;
     }
-    *rcMode = m_encConfigs[configOffset];
+    *rcMode = m_encConfigs[configOffset].m_rcMode;
+    *feiFunction = m_encConfigs[configOffset].m_FeiFunction;
     return VA_STATUS_SUCCESS;
 }
 
@@ -2736,12 +2753,12 @@ bool MediaLibvaCaps::IsJpegProfile(VAProfile profile)
     return (profile == VAProfileJPEGBaseline);
 }
 
-bool MediaLibvaCaps::IsEncFei(VAEntrypoint entrypoint)
+bool MediaLibvaCaps::IsEncFei(VAEntrypoint entrypoint, uint32_t feiFunction)
 {
-    if ((m_mediaCtx->FeiFunction & VA_FEI_FUNCTION_ENC_PAK)  ||
-            (m_mediaCtx->FeiFunction == VA_FEI_FUNCTION_ENC) ||
-            (m_mediaCtx->FeiFunction == VA_FEI_FUNCTION_PAK) ||
-            (m_mediaCtx->FeiFunction == (VA_FEI_FUNCTION_ENC | VA_FEI_FUNCTION_PAK)) ||
+    if ((feiFunction & VA_FEI_FUNCTION_ENC_PAK)  ||
+            (feiFunction == VA_FEI_FUNCTION_ENC) ||
+            (feiFunction == VA_FEI_FUNCTION_PAK) ||
+            (feiFunction == (VA_FEI_FUNCTION_ENC | VA_FEI_FUNCTION_PAK)) ||
             (entrypoint == VAEntrypointStats))
     {
         return true;
@@ -2749,7 +2766,7 @@ bool MediaLibvaCaps::IsEncFei(VAEntrypoint entrypoint)
     return false;
 }
 
-CODECHAL_FUNCTION MediaLibvaCaps::GetEncodeCodecFunction(VAProfile profile, VAEntrypoint entrypoint)
+CODECHAL_FUNCTION MediaLibvaCaps::GetEncodeCodecFunction(VAProfile profile, VAEntrypoint entrypoint, uint32_t feiFunction)
 {
     CODECHAL_FUNCTION codecFunction;
     if (profile == VAProfileJPEGBaseline)
@@ -2774,19 +2791,19 @@ CODECHAL_FUNCTION MediaLibvaCaps::GetEncodeCodecFunction(VAProfile profile, VAEn
         //
         //  b000 means ENC_PAK
         */
-        if (m_mediaCtx->FeiFunction & VA_FEI_FUNCTION_ENC_PAK)
+        if (feiFunction & VA_FEI_FUNCTION_ENC_PAK)
         {
             codecFunction = CODECHAL_FUNCTION_FEI_ENC_PAK;
         }
-        else if (m_mediaCtx->FeiFunction == VA_FEI_FUNCTION_ENC)
+        else if (feiFunction == VA_FEI_FUNCTION_ENC)
         {
             codecFunction = CODECHAL_FUNCTION_FEI_ENC;
         }
-        else if (m_mediaCtx->FeiFunction == VA_FEI_FUNCTION_PAK)
+        else if (feiFunction == VA_FEI_FUNCTION_PAK)
         {
             codecFunction = CODECHAL_FUNCTION_FEI_PAK;
         }
-        else if (m_mediaCtx->FeiFunction == (VA_FEI_FUNCTION_ENC | VA_FEI_FUNCTION_PAK))
+        else if (feiFunction == (VA_FEI_FUNCTION_ENC | VA_FEI_FUNCTION_PAK))
         {
             // codecFunction in context keeps FEI_ENC_PAK if input is ENC|PAK
             codecFunction = CODECHAL_FUNCTION_FEI_ENC_PAK;
@@ -2905,14 +2922,14 @@ std::string MediaLibvaCaps::GetDecodeCodecKey(VAProfile profile)
     }
 }
 
-std::string MediaLibvaCaps::GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint)
+std::string MediaLibvaCaps::GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint, uint32_t feiFunction)
 {
     switch (profile)
     {
         case VAProfileH264High:
         case VAProfileH264Main:
         case VAProfileH264ConstrainedBaseline:
-            if (IsEncFei(entrypoint))
+            if (IsEncFei(entrypoint, feiFunction))
             {
                 return ENCODE_ID_AVCFEI;
             }
@@ -2934,7 +2951,7 @@ std::string MediaLibvaCaps::GetEncodeCodecKey(VAProfile profile, VAEntrypoint en
         case VAProfileHEVCMain12:
         case VAProfileHEVCMain422_10:
         case VAProfileHEVCMain422_12:
-            if (IsEncFei(entrypoint))
+            if (IsEncFei(entrypoint, feiFunction))
             {
                 return ENCODE_ID_HEVCFEI;
             }
@@ -2943,7 +2960,7 @@ std::string MediaLibvaCaps::GetEncodeCodecKey(VAProfile profile, VAEntrypoint en
                 return ENCODE_ID_HEVC;
             }
         case VAProfileNone:
-            if (IsEncFei(entrypoint))
+            if (IsEncFei(entrypoint, feiFunction))
             {
                 return ENCODE_ID_AVCFEI;
             }

--- a/media_driver/linux/common/ddi/media_libva_caps.h
+++ b/media_driver/linux/common/ddi/media_libva_caps.h
@@ -203,6 +203,8 @@ public:
     //! \param    [in,out] rcMode 
     //!           Return the rcMode for the config ID. 
     //!
+    //! \param    [in,out] feiFunction
+    //!           Return the fei function type for the config ID.
     //!
     //! \return   VAStatus 
     //!           VA_STATUS_SUCCESS if success
@@ -211,7 +213,8 @@ public:
             VAConfigID configId,
             VAProfile *profile,
             VAEntrypoint *entrypoint,
-            uint32_t *rcMode);
+            uint32_t *rcMode,
+            uint32_t *feiFunction);
 
     //!
     //! \brief    Get attributes for a given decode config ID 
@@ -437,10 +440,13 @@ public:
     //! \param    [in] entrypoint 
     //!           Specify the VAEntrypoint for checking 
     //!
-    //! \return   True if the entrypoint or current FeiFuncton belong to FEI 
-    //!           False if the entrypoint and current FeiFuncton aren't FEI 
+    //! \param    [in] feiFunction
+    //!           Specify the VA_FEI_FUNCTION for checking
     //!
-    bool IsEncFei(VAEntrypoint entrypoint);
+    //! \return   True if the entrypoint or the feiFuncton belong to FEI
+    //!           False if the entrypoint and the FeiFuncton aren't FEI
+    //!
+    bool IsEncFei(VAEntrypoint entrypoint, uint32_t feiFunction);
 
     //! 
     //! \brief    Return the CODECHAL_FUNCTION type for give profile and entrypoint 
@@ -451,9 +457,12 @@ public:
     //! \param    [in] entrypoint 
     //!           Specify the VAEntrypoint 
     //!
+    //! \param    [in] feiFunction
+    //!           Specify the VA_FEI_FUNCTION
+    //!
     //! \return   Codehal function
     //!
-    CODECHAL_FUNCTION GetEncodeCodecFunction(VAProfile profile, VAEntrypoint entrypoint);
+    CODECHAL_FUNCTION GetEncodeCodecFunction(VAProfile profile, VAEntrypoint entrypoint, uint32_t feiFunction);
 
     //!
     //! \brief    Return internal encode mode for given profile and entrypoint 
@@ -497,9 +506,12 @@ public:
     //! \param    [in] entrypoint 
     //!           Specify the entrypoint 
     //!
+    //! \param    [in] feiFunction 
+    //!           Specify the feiFunction 
+    //!
     //! \return   Std::string encode codec key 
     //!
-    virtual std::string GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint);
+    virtual std::string GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint, uint32_t feiFunction);
 
     //!
     //! \brief    Query the suppported image formats 
@@ -674,9 +686,24 @@ protected:
     //!
     struct DecConfig
     {
-        uint32_t m_sliceMode; //!< Decode slice mode
+        uint32_t m_sliceMode;   //!< Decode slice mode
         uint32_t m_encryptType; //!< Decode entrypoint Type
         uint32_t m_processType; //!< Decode processing Type
+
+        DecConfig(const uint32_t sliceMode, const uint32_t encryptType, const uint32_t processType)
+        : m_sliceMode(sliceMode), m_encryptType(encryptType), m_processType(processType) {}
+    };
+
+    //!
+    //! \struct   EncConfig
+    //! \brief    Encode configuration
+    //!
+    struct EncConfig
+    {
+        uint32_t m_rcMode;      //!< RateControl Mode
+        uint32_t m_FeiFunction; //!< Decode entrypoint Type
+        EncConfig(const uint32_t rcMode, const uint32_t FeiFunction)
+        : m_rcMode(rcMode), m_FeiFunction(FeiFunction) {}
     };
 
     //!
@@ -773,9 +800,9 @@ protected:
 
     bool m_isEntryptSupported = false; //!< If decode encryption is supported on current platform
 
-    std::vector<uint32_t> m_encConfigs; //!< Store supported encode configs
+    std::vector<EncConfig> m_encConfigs; //!< Store supported encode configs
     std::vector<DecConfig> m_decConfigs; //!< Store supported decode configs
-    std::vector<uint32_t> m_vpConfigs; //!< Store supported vp configs
+    std::vector<uint32_t> m_vpConfigs;   //!< Store supported vp configs
 
     //!
     //! \brief    Check entrypoint codec type
@@ -811,11 +838,13 @@ protected:
     //!
     //! \param    [in] rcMode 
     //!           VA_RC_XXX 
+    //! \param    [in] feiFunction
+    //!           VA_FEI_FUNCTION_XXX [optional parameter]
     //!
     //! \return   VAStatus 
     //!           VA_STATUS_SUCCESS if success
     //!
-    VAStatus AddEncConfig(uint32_t rcMode);
+    VAStatus AddEncConfig(uint32_t rcMode, uint32_t feiFunction = 0);
 
     //!
     //! \brief    Add one vp configuration

--- a/media_driver/linux/common/ddi/media_libva_common.h
+++ b/media_driver/linux/common/ddi/media_libva_common.h
@@ -445,7 +445,6 @@ struct DDI_MEDIA_CONTEXT
         PMOS_CONTEXT  pMosCtx,
         PMOS_RESOURCE pOsResource);
 
-    uint32_t            FeiFunction;
     PLATFORM            platform;
 
     MediaLibvaCaps     *m_caps;

--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -180,14 +180,14 @@ std::string MediaLibvaCapsG11::GetDecodeCodecKey(VAProfile profile)
     }
 }
 
-std::string MediaLibvaCapsG11::GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint)
+std::string MediaLibvaCapsG11::GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint, uint32_t feiFunction)
 {
     switch (profile)
     {
         case VAProfileH264High:
         case VAProfileH264Main:
         case VAProfileH264ConstrainedBaseline:
-            if (IsEncFei(entrypoint))
+            if (IsEncFei(entrypoint, feiFunction))
             {
                 return ENCODE_ID_AVCFEI;
             }
@@ -211,7 +211,7 @@ std::string MediaLibvaCapsG11::GetEncodeCodecKey(VAProfile profile, VAEntrypoint
         case VAProfileHEVCMain10:
         case VAProfileHEVCMain444:
         case VAProfileHEVCMain444_10:
-            if (IsEncFei(entrypoint))
+            if (IsEncFei(entrypoint, feiFunction))
             {
                 return ENCODE_ID_HEVCFEI;
             }
@@ -220,7 +220,7 @@ std::string MediaLibvaCapsG11::GetEncodeCodecKey(VAProfile profile, VAEntrypoint
                 return ENCODE_ID_HEVC;
             }
         case VAProfileNone:
-            if (IsEncFei(entrypoint))
+            if (IsEncFei(entrypoint, feiFunction))
             {
                 return ENCODE_ID_AVCFEI;
             }

--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.h
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.h
@@ -94,9 +94,12 @@ public:
     //! \param    [in] entrypoint 
     //!           Specify the entrypoint 
     //!
+    //! \param    [in] feiFunction
+    //!           Specify the feiFunction
+    //!
     //! \return   Std::string encode codec key 
     //!
-    std::string GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint) override;
+    std::string GetEncodeCodecKey(VAProfile profile, VAEntrypoint entrypoint, uint32_t feiFunction) override;
 
     //!
     //! \brief convert Media Format to Gmm Format for GmmResCreate parameter.


### PR DESCRIPTION
This change aims to replace member FeiFunction of 'global' DDI_MEDIA_CONTEXT class
with retrieving fei function type from provided vaConfig.
Old implementation had a race condition bug when e.g. PREEnc and AVC FEI encode
are created simultaneously from two threads.

Fixes #590

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>