### PR TITLE
Add free logic of picParams->pDeltaQp for avoiding memory leak.

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -2066,3 +2066,15 @@ uint32_t DdiEncodeAvc::getQMatrixBufferSize()
 {
     return sizeof(VAIQMatrixBufferH264);
 }
+
+void DdiEncodeAvc::ClearPicParams()
+{
+    uint8_t ppsIdx = ((PCODEC_AVC_ENCODE_SLICE_PARAMS)(m_encodeCtx->pSliceParams))->pic_parameter_set_id;
+    PCODEC_AVC_ENCODE_PIC_PARAMS  picParams = (PCODEC_AVC_ENCODE_PIC_PARAMS)m_encodeCtx->pPicParams + ppsIdx;
+
+    if (picParams != nullptr && picParams->pDeltaQp != nullptr)
+    {
+        MOS_FreeMemory(picParams->pDeltaQp);
+        picParams->pDeltaQp = nullptr;
+    }
+}

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.h
@@ -180,6 +180,8 @@ protected:
         DDI_MEDIA_CONTEXT *mediaCtx,
         void              *ptr);
 
+    virtual void ClearPicParams() override;
+
     //!
     //! \brief    Convert slice struct from VA to codechal
     //! \details  Convert slice struct from VA to codechal

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_base.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_base.cpp
@@ -75,6 +75,7 @@ VAStatus DdiEncodeBase::EndPicture(
     DDI_CHK_NULL(mediaCtx, "Null mediaCtx", VA_STATUS_ERROR_INVALID_CONTEXT);
 
     VAStatus status = EncodeInCodecHal(m_encodeCtx->dwNumSlices);
+    ClearPicParams();
     if (VA_STATUS_SUCCESS != status)
     {
         DDI_ASSERTMESSAGE("DDI:DdiEncode_EncodeInCodecHal return failure.");
@@ -1353,4 +1354,8 @@ uint32_t DdiEncodeBase::getPictureParameterBufferSize()
 uint32_t DdiEncodeBase::getQMatrixBufferSize()
 {
     return 0xffffffff;
+}
+
+void DdiEncodeBase::ClearPicParams()
+{
 }

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_base.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_base.h
@@ -307,6 +307,14 @@ protected:
         void *             ptr) = 0;
 
     //!
+    //! \brief    Clear picture params
+    //! \details  Clear picture params called by EndPicture
+    //!
+    //! \return   void
+    //!
+    virtual void ClearPicParams();
+
+    //!
     //! \brief    get Slice Parameter Buffer Size
     //!
     //! \return   uint32_t


### PR DESCRIPTION
Fixes #611.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>