### PR TITLE
Fix VP8 CQP encoding.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_vp8.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_vp8.cpp
@@ -263,6 +263,10 @@ CodechalEncodeVp8::CodechalEncodeVp8(
     m_verticalLineStrideOffset = CODECHAL_VLINESTRIDEOFFSET_TOP_FIELD;
 
     m_codecGetStatusReportDefined = true;
+
+    m_mbEncCurbeSetInBrcUpdate = false;
+    m_mpuCurbeSetInBrcUpdate = false;
+    m_tpuCurbeSetInBrcUpdate = false;
 }
 
 CodechalEncodeVp8::~CodechalEncodeVp8()
@@ -1276,7 +1280,7 @@ MOS_STATUS CodechalEncodeVp8::SetPictureStructs()
     else
     {
         m_averagePFrameQp     = averageQp;
-        m_pFramePositionInGop = (m_storeData - 1) % m_vp8SeqParams->GopPicSize;
+        m_pFramePositionInGop = m_vp8SeqParams->RateControlMethod == RATECONTROL_CQP ? 0 : (m_storeData - 1) % m_vp8SeqParams->GopPicSize;
     }
 
     numRef = 0;

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_vp8.cpp
@@ -604,7 +604,7 @@ VAStatus DdiEncodeVp8::EncodeInCodecHal(uint32_t numSlices)
 
     if (VA_RC_CQP == m_encodeCtx->uiRCMethod)
     {
-        seqParams->RateControlMethod          = 0;
+        seqParams->RateControlMethod          = RATECONTROL_CQP;
         seqParams->TargetBitRate[0]           = 0;
         seqParams->MaxBitRate                 = 0;
         seqParams->MinBitRate                 = 0;
@@ -613,13 +613,13 @@ VAStatus DdiEncodeVp8::EncodeInCodecHal(uint32_t numSlices)
     }
     else if (VA_RC_CBR == m_encodeCtx->uiRCMethod)
     {
-        seqParams->RateControlMethod = 1;
+        seqParams->RateControlMethod = RATECONTROL_CBR;
         seqParams->MaxBitRate        = seqParams->TargetBitRate[0];
         seqParams->MinBitRate        = seqParams->TargetBitRate[0];
     }
     else if (VA_RC_VBR == m_encodeCtx->uiRCMethod)
     {
-        seqParams->RateControlMethod = 2;
+        seqParams->RateControlMethod = RATECONTROL_VBR;
     }
     if((m_encodeCtx->uiTargetBitRate != seqParams->TargetBitRate[0]) || (m_encodeCtx->uiMaxBitRate != seqParams-> MaxBitRate))
     {


### PR DESCRIPTION
1. Initialize BRC variales for avoiding wrong DSH allocation.
2. Set the right CQP enum number (RATECONTROL_CQP = 3).
3. Avoid division by zero in CQP mode.
Fixes #578.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>