### PR TITLE
Fix command buffer initialization for virtual engine.

### DIFF
--- a/media_driver/linux/common/os/mos_gpucontext_specific.cpp
+++ b/media_driver/linux/common/os/mos_gpucontext_specific.cpp
@@ -323,6 +323,7 @@ MOS_STATUS GpuContextSpecific::GetCommandBuffer(
         comamndBuffer->iRemaining = cmdBuf->GetCmdBufSize();
         comamndBuffer->iCmdIndex  = m_nextFetchIndex;
         comamndBuffer->iVdboxNodeIndex = MOS_VDBOX_NODE_INVALID;
+        comamndBuffer->Attributes.pAttriVe = nullptr;
 
         // zero comamnd buffer
         MOS_ZeroMemory(comamndBuffer->pCmdBase, comamndBuffer->iRemaining);


### PR DESCRIPTION
Avoid pAttriVe access invalid memory area.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>