### PR TITLE
Enable supporting p010 output on BXT

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp
@@ -997,7 +997,7 @@ bool VphalRenderer::IsFormatSupported(
     VPHAL_RENDER_ASSERT(pcRenderParams);
 
     // Protection mechanism
-    // P010 output support from KBL+
+    // P010 output support from BXT+
     if (m_pSkuTable)
     {
         if (pcRenderParams->pTarget[0])
@@ -1075,7 +1075,7 @@ MOS_STATUS VphalRenderer::Render(
         goto finish;
     }
 
-    // Protection mechanism, Only KBL+ support P010 output.
+    // Protection mechanism, Only BXT+ support P010 output.
     if (IsFormatSupported(pcRenderParams) == false)
     {
         VPHAL_RENDER_ASSERTMESSAGE("Invalid Render Target Output Format.");

--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -264,6 +264,8 @@ static bool InitBxtMediaSku(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_SKU(skuTable, FtrPerCtxtPreemptionGranularityControl, 1);
 
+    MEDIA_WR_SKU(skuTable, FtrVpP010Output, 1);
+
     return true;
 }
 


### PR DESCRIPTION
BXT support P010 output. Decoded hevce 10b output sreams from BXT and CFL
are bit2bit.