### PR TITLE
Correct error code returned from VAGetConfigAttributes

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -1695,9 +1695,14 @@ VAStatus MediaLibvaCaps::GetConfigAttributes(VAProfile profile,
     DDI_CHK_NULL(attribList, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);
     int32_t i = GetProfileTableIdx(profile, entrypoint);
 
-    if (i < 0)
+    switch(i)
     {
-        return VA_STATUS_ERROR_INVALID_PARAMETER;
+        case -2:
+            return VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT;
+        case -1:
+            return VA_STATUS_ERROR_UNSUPPORTED_PROFILE;
+        default:
+            break;
     }
 
     DDI_CHK_NULL(m_profileEntryTbl[i].m_attributes, "Null pointer", VA_STATUS_ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
change distinguish VA_STATUS_ERROR_INVALID_VIDEO_PARAMETER
with VA_STATUS_ERROR_UNSUPPORTED_PROFILE and
VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT