### PR TITLE
Enable supporting p010 output on SKL

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_renderer.cpp
@@ -997,7 +997,7 @@ bool VphalRenderer::IsFormatSupported(
     VPHAL_RENDER_ASSERT(pcRenderParams);
 
     // Protection mechanism
-    // P010 output support from BXT+
+    // P010 output support from SKL+
     if (m_pSkuTable)
     {
         if (pcRenderParams->pTarget[0])
@@ -1075,7 +1075,7 @@ MOS_STATUS VphalRenderer::Render(
         goto finish;
     }
 
-    // Protection mechanism, Only BXT+ support P010 output.
+    // Protection mechanism, Only SKL+ support P010 output.
     if (IsFormatSupported(pcRenderParams) == false)
     {
         VPHAL_RENDER_ASSERTMESSAGE("Invalid Render Target Output Format.");

--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -184,6 +184,8 @@ static bool InitSklMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrMemoryCompression, 0);
     MEDIA_WR_SKU(skuTable, FtrHcpDecMemoryCompression, 0);
 
+    MEDIA_WR_SKU(skuTable, FtrVpP010Output, 1);
+
     MEDIA_WR_SKU(skuTable, FtrPerCtxtPreemptionGranularityControl, 1);
 
     MEDIA_WR_SKU(skuTable, FtrTileY, 1);


### PR DESCRIPTION
Tested vpp with p010 output. Output streams are valid and they show good
metrics. All gen9 platforms support p010 output.