### PR TITLE
Add A2RGB10 and A2BGR10 format in vaQueryImageFormats.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -3069,6 +3069,8 @@ GMM_RESOURCE_FORMAT MediaLibvaCaps::ConvertFourccToGmmFmt(uint32_t fourcc)
         case VA_FOURCC_Y210   : return GMM_FORMAT_Y210_TYPE;
         case VA_FOURCC_Y410   : return GMM_FORMAT_Y410_TYPE;
         case VA_FOURCC_Y800   : return GMM_FORMAT_GENERIC_8BIT;
+        case VA_FOURCC_A2R10G10B10   : return GMM_FORMAT_R10G10B10A2_UNORM_TYPE;
+        case VA_FOURCC_A2B10G10R10   : return GMM_FORMAT_B10G10R10A2_UNORM_TYPE;
         default               : return GMM_FORMAT_INVALID;
     }
 }

--- a/media_driver/linux/gen10/ddi/media_libva_caps_g10.cpp
+++ b/media_driver/linux/gen10/ddi/media_libva_caps_g10.cpp
@@ -52,7 +52,9 @@ const VAImageFormat m_supportedImageformatsG10[] =
     {VA_FOURCC_422V,   VA_LSB_FIRST,   16, 0,0,0,0,0},
     {VA_FOURCC_444P,   VA_LSB_FIRST,   24, 0,0,0,0,0},
     {VA_FOURCC_IMC3,   VA_LSB_FIRST,   16, 0,0,0,0,0},
-    {VA_FOURCC_P010,   VA_LSB_FIRST,   24, 0,0,0,0,0}
+    {VA_FOURCC_P010,   VA_LSB_FIRST,   24, 0,0,0,0,0},
+    {VA_FOURCC_A2R10G10B10,    VA_LSB_FIRST,   32, 30, 0x3ff00000, 0x000ffc00, 0x000003ff, 0x30000000},  /* [31:0] A:R:G:B 2:10:10:10 little endian */
+    {VA_FOURCC_A2B10G10R10,    VA_LSB_FIRST,   32, 30, 0x000003ff, 0x000ffc00, 0x3ff00000, 0x30000000}   /* [31:0] A:B:G:R 2:10:10:10 little endian */
 };
 
 VAStatus MediaLibvaCapsG10::QueryImageFormats(VAImageFormat *formatList, int32_t *numFormats)

--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -59,7 +59,9 @@ const VAImageFormat m_supportedImageformatsG11[] =
     {VA_FOURCC_IMC3,   VA_LSB_FIRST,   16, 0,0,0,0,0},
     {VA_FOURCC_P010,   VA_LSB_FIRST,   24, 0,0,0,0,0},
     {VA_FOURCC_Y210,   VA_LSB_FIRST,   32, 0,0,0,0,0},
-    {VA_FOURCC_Y410,   VA_LSB_FIRST,   32, 0,0,0,0,0}
+    {VA_FOURCC_Y410,   VA_LSB_FIRST,   32, 0,0,0,0,0},
+    {VA_FOURCC_A2R10G10B10,    VA_LSB_FIRST,   32, 30, 0x3ff00000, 0x000ffc00, 0x000003ff, 0x30000000},  /* [31:0] A:R:G:B 2:10:10:10 little endian */
+    {VA_FOURCC_A2B10G10R10,    VA_LSB_FIRST,   32, 30, 0x000003ff, 0x000ffc00, 0x3ff00000, 0x30000000}   /* [31:0] A:B:G:R 2:10:10:10 little endian */
 };
 
 const VAConfigAttribValEncRateControlExt MediaLibvaCapsG11::m_encVp9RateControlExt =

--- a/media_driver/linux/gen9/ddi/media_libva_caps_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_libva_caps_g9.cpp
@@ -52,7 +52,9 @@ const VAImageFormat m_supportedImageformatsG9[] =
     {VA_FOURCC_422V,   VA_LSB_FIRST,   16, 0,0,0,0,0},
     {VA_FOURCC_444P,   VA_LSB_FIRST,   24, 0,0,0,0,0},
     {VA_FOURCC_IMC3,   VA_LSB_FIRST,   16, 0,0,0,0,0},
-    {VA_FOURCC_P010,   VA_LSB_FIRST,   24, 0,0,0,0,0}
+    {VA_FOURCC_P010,   VA_LSB_FIRST,   24, 0,0,0,0,0},
+    {VA_FOURCC_A2R10G10B10,    VA_LSB_FIRST,   32, 30, 0x3ff00000, 0x000ffc00, 0x000003ff, 0x30000000},  /* [31:0] A:R:G:B 2:10:10:10 little endian */
+    {VA_FOURCC_A2B10G10R10,    VA_LSB_FIRST,   32, 30, 0x000003ff, 0x000ffc00, 0x3ff00000, 0x30000000}   /* [31:0] A:B:G:R 2:10:10:10 little endian */
 };
 
 VAStatus MediaLibvaCapsG9::QueryImageFormats(VAImageFormat *formatList, int32_t *numFormats)


### PR DESCRIPTION
Signed-off-by: furongzh <furong.zhang@intel.com>