### PR TITLE
Avoid invalid max/min qp for AVC encoding.

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -237,8 +237,8 @@ VAStatus DdiEncodeAvc::ParseMiscParamRC(void *data)
     seqParams->MBBRC                   = encMiscParamRC->rc_flags.bits.mb_rate_control;
 
     // Assuming picParams are sent before MiscParams
-    picParams->ucMinimumQP = encMiscParamRC->min_qp;
-    picParams->ucMaximumQP = encMiscParamRC->max_qp;
+    picParams->ucMaximumQP = (encMiscParamRC->max_qp == 0) ? 51 : (uint8_t)CodecHal_Clip3(1, 51, (int8_t)encMiscParamRC->max_qp);
+    picParams->ucMinimumQP = (encMiscParamRC->min_qp == 0) ? 1 : (uint8_t)CodecHal_Clip3(1, picParams->ucMaximumQP, (int8_t)encMiscParamRC->min_qp);
 
     if ((VA_RC_CBR == m_encodeCtx->uiRCMethod) || ((VA_RC_CBR | VA_RC_MB) == m_encodeCtx->uiRCMethod))
     {


### PR DESCRIPTION
Fixes #587.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>