### PR TITLE
Avoid disable half of sub slices if only one sub slice.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encoder_base.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encoder_base.cpp
@@ -202,7 +202,10 @@ MOS_STATUS CodechalEncoderState::CreateGpuContexts()
 
         if (m_hwInterface->m_slicePowerGate)
         {
-            createOption.packed.SubSliceCount = (m_gtSystemInfo->SubSliceCount / m_gtSystemInfo->SliceCount) >> 1;
+            createOption.packed.SubSliceCount = (m_gtSystemInfo->SubSliceCount / m_gtSystemInfo->SliceCount);
+            // If there are multiply sub slices, disable half of sub slices.
+            if (createOption.packed.SubSliceCount > 1)
+                createOption.packed.SubSliceCount >>= 1;
             createOption.packed.SliceCount = (uint8_t)m_gtSystemInfo->SliceCount;
             createOption.packed.MaxEUcountPerSubSlice = (uint8_t)(m_gtSystemInfo->EUCount / m_gtSystemInfo->SubSliceCount);
             createOption.packed.MinEUcountPerSubSlice = (uint8_t)(m_gtSystemInfo->EUCount / m_gtSystemInfo->SubSliceCount);


### PR DESCRIPTION
It will cause error in drm IO Ctrl.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>