### PR TITLE
Avoid invalid Max QP when AVC encoding.

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -239,6 +239,8 @@ VAStatus DdiEncodeAvc::ParseMiscParamRC(void *data)
     // Assuming picParams are sent before MiscParams
     picParams->ucMinimumQP = encMiscParamRC->min_qp;
     picParams->ucMaximumQP = encMiscParamRC->max_qp;
+    if (picParams->ucMaximumQP == 0 && picParams->ucMinimumQP)
+        picParams->ucMaximumQP = 51;
 
     if ((VA_RC_CBR == m_encodeCtx->uiRCMethod) || ((VA_RC_CBR | VA_RC_MB) == m_encodeCtx->uiRCMethod))
     {


### PR DESCRIPTION
When min QP is set but Max Qp is zero, need use Maximum QP (51) as Max
QP.
Fixes #587.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>