### PR TITLE
Set MOS GmmClientContext locally for avoiding wrong pointer.

### DIFF
--- a/media_driver/linux/common/cm/cm_wrapper_os.cpp
+++ b/media_driver/linux/common/cm/cm_wrapper_os.cpp
@@ -82,6 +82,7 @@ int32_t CreateCmDeviceFromVA(VADriverContextP vaDriverCtx,
     cmCtx->mosCtx.gtSystemInfo    = *(mediaCtx->pGtSystemInfo);
     cmCtx->mosCtx.platform        = mediaCtx->platform;
     cmCtx->mosCtx.pPerfData       = (PERF_DATA *)MOS_AllocAndZeroMemory(sizeof(PERF_DATA));
+    cmCtx->mosCtx.pGmmClientContext = mediaCtx->pGmmClientContext;
     if(cmCtx->mosCtx.pPerfData == nullptr)
     {
         MOS_FreeMemAndSetNull(cmCtx); // free cm ctx

--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -315,6 +315,7 @@ VAStatus DdiDecode_CreateContext (
     mosCtx.pfnMemoryDecompress   = mediaCtx->pfnMemoryDecompress;
     mosCtx.pPerfData             = (PERF_DATA *)MOS_AllocAndZeroMemory(sizeof(PERF_DATA));
     mosCtx.m_auxTableMgr         = mediaCtx->m_auxTableMgr;
+    mosCtx.pGmmClientContext     = mediaCtx->pGmmClientContext;
 
     if (nullptr == mosCtx.pPerfData)
     {

--- a/media_driver/linux/common/codec/ddi/media_libva_encoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_encoder.cpp
@@ -282,6 +282,7 @@ VAStatus DdiEncode_CreateContext(
     mosCtx.pPerfData             = (PERF_DATA *)MOS_AllocAndZeroMemory(sizeof(PERF_DATA));
     mosCtx.gtSystemInfo          = *mediaDrvCtx->pGtSystemInfo;
     mosCtx.m_auxTableMgr         = mediaDrvCtx->m_auxTableMgr;
+    mosCtx.pGmmClientContext     = mediaDrvCtx->pGmmClientContext;
 
     if (nullptr == mosCtx.pPerfData)
     {


### PR DESCRIPTION
Signed-off-by: Yan Wang <yan.wang@linux.intel.com>