### PR TITLE
[Encode] use quality_factor under QVBR mode for h265 encode

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.cpp
@@ -1065,7 +1065,7 @@ VAStatus DdiEncodeHevc::ParseMiscParams(void *ptr)
         else if (VA_RC_QVBR & m_encodeCtx->uiRCMethod)
         {
             seqParams->RateControlMethod = RATECONTROL_QVBR;
-            seqParams->ICQQualityFactor = vaEncMiscParamRC->ICQ_quality_factor;
+            seqParams->ICQQualityFactor = vaEncMiscParamRC->quality_factor;
             seqParams->MBBRC = 1;
         }
         else


### PR DESCRIPTION
According the illustration of va.h, quality_factor will be used
under QVBR mode. ICQ_quality_factor is used only under ICQ mode.