### PR TITLE
[Encode] Fix caps report for HEVC/VP9 on SKL

### DIFF
--- a/media_driver/linux/gen9_skl/ddi/media_libva_caps_g9_skl.cpp
+++ b/media_driver/linux/gen9_skl/ddi/media_libva_caps_g9_skl.cpp
@@ -36,8 +36,7 @@ MediaLibvaCapsG9Skl::MediaLibvaCapsG9Skl(DDI_MEDIA_CONTEXT *mediaCtx) : MediaLib
     {
         {AVC, DualPipe, VA_RT_FORMAT_YUV420},
         {AVC, Vdenc, VA_RT_FORMAT_YUV420},
-        {HEVC, DualPipe, VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV420_10BPP},
-        {VP9, DualPipe, VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV420_10BPP},
+        {HEVC, DualPipe, VA_RT_FORMAT_YUV420},
     };
     m_encodeFormatTable = (struct EncodeFormatTable*)(&encodeFormatTableSKL[0]);
     m_encodeFormatCount = sizeof(encodeFormatTableSKL)/sizeof(struct EncodeFormatTable);


### PR DESCRIPTION
According to media-driver readme, SKL doens`t support HEVC 10b encoding,
but media-driver has incorrect report. Same situation for VP9.
fixes #693 