### PR TITLE
media_libva: Return P010 as a composite format

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -5929,6 +5929,7 @@ static uint32_t DdiMedia_GetDrmFormatOfCompositeObject(uint32_t fourcc)
     case VA_FOURCC_Y800:
         return DRM_FORMAT_R8;
     case VA_FOURCC_P010:
+        return DRM_FORMAT_P010;
     case VA_FOURCC_I010:
         // These currently have no composite DRM format - they are usable
         // only as separate planes.


### PR DESCRIPTION
Exporting P010 buffers fails because we don't recognize it as a
composite object. Add DRM_FORMAT_P010 as a return value for
VA_FOURCC_P010.

Signed-off-by: Harish Krupo <harishkrupo@gmail.com>