### PR TITLE
register VP8 decode reference frame

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decode_vp8.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_vp8.cpp
@@ -1128,6 +1128,10 @@ MOS_STATUS CodechalDecodeVp8::SetFrameStates()
     m_dataSize          = m_decodeParams.m_dataSize;
     m_dataOffset        = m_decodeParams.m_dataOffset;
     m_destSurface       = *(m_decodeParams.m_destSurface);
+    m_presLastRefSurface    = m_decodeParams.m_presNoneRegLastRefFrame;
+    m_presAltRefSurface     = m_decodeParams.m_presNoneRegAltRefFrame;
+    m_presGoldenRefSurface  = m_decodeParams.m_presNoneRegGoldenRefFrame;
+
     m_resDataBuffer     = *(m_decodeParams.m_dataBuffer);
     m_vp8PicParams      = (PCODEC_VP8_PIC_PARAMS)m_decodeParams.m_picParams;
     m_vp8IqMatrixParams = (PCODEC_VP8_IQ_MATRIX_PARAMS)m_decodeParams.m_iqMatrixBuffer;
@@ -1235,9 +1239,30 @@ MOS_STATUS CodechalDecodeVp8::DecodeStateLevel()
     }
     else
     {
-        m_presLastRefSurface   = &(m_vp8RefList[m_vp8PicParams->ucLastRefPicIndex]->resRefPic);
-        m_presGoldenRefSurface = &(m_vp8RefList[m_vp8PicParams->ucGoldenRefPicIndex]->resRefPic);
-        m_presAltRefSurface    = &(m_vp8RefList[m_vp8PicParams->ucAltRefPicIndex]->resRefPic);
+        if((Mos_ResourceIsNull(&m_vp8RefList[m_vp8PicParams->ucLastRefPicIndex]->resRefPic)) && (m_presLastRefSurface))
+        {
+           m_vp8RefList[m_vp8PicParams->ucLastRefPicIndex]->resRefPic = *m_presLastRefSurface;
+        }
+        else
+        {
+           m_presLastRefSurface = &(m_vp8RefList[m_vp8PicParams->ucLastRefPicIndex]->resRefPic);
+        }
+        if((Mos_ResourceIsNull(&m_vp8RefList[m_vp8PicParams->ucGoldenRefPicIndex]->resRefPic)) && (m_presGoldenRefSurface))
+        {
+           m_vp8RefList[m_vp8PicParams->ucGoldenRefPicIndex]->resRefPic = *m_presGoldenRefSurface;
+        }
+        else
+        {
+           m_presGoldenRefSurface = &(m_vp8RefList[m_vp8PicParams->ucGoldenRefPicIndex]->resRefPic);
+        }
+        if((Mos_ResourceIsNull(&m_vp8RefList[m_vp8PicParams->ucAltRefPicIndex]->resRefPic)) && (m_presAltRefSurface))
+        {
+           m_vp8RefList[m_vp8PicParams->ucAltRefPicIndex]->resRefPic = *m_presAltRefSurface;
+        }
+        else
+        {
+           m_presAltRefSurface = &(m_vp8RefList[m_vp8PicParams->ucAltRefPicIndex]->resRefPic);
+        }
     }
 
     MOS_COMMAND_BUFFER cmdBuffer;

--- a/media_driver/agnostic/common/codec/shared/codec_def_decode.h
+++ b/media_driver/agnostic/common/codec/shared/codec_def_decode.h
@@ -51,6 +51,12 @@ struct CodechalDecodeParams
     PMOS_RESOURCE           m_bitplaneBuffer = nullptr;
     //! \brief [VP8 & VP9] resource containing coefficient probability data
     PMOS_RESOURCE           m_coefProbBuffer = nullptr;
+    //! \brief [VP8 & VP9] resource containing the last reference surface which was not registered.
+    PMOS_RESOURCE           m_presNoneRegLastRefFrame = nullptr;
+    //! \brief [VP8 & VP9] resource containing the golden reference surface which was not registered.
+    PMOS_RESOURCE           m_presNoneRegGoldenRefFrame = nullptr;
+    //! \brief [VP8 & VP9] resource containing the alt reference surface which was not registered.
+    PMOS_RESOURCE           m_presNoneRegAltRefFrame = nullptr;
     //! \brief [VC1 IT] Deblock data
     //!    For advanced profile P frames, this data should be formated as an array of 6 bytes for each MB:
     //!        Byte0: ILDBControlDataforY0

--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
@@ -163,8 +163,26 @@ VAStatus DdiDecodeVP8::ParsePicParams(
     if (picParam->pic_fields.bits.key_frame)
     {
         lastRefSurface   = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->last_ref_frame);
+        if(lastRefSurface)
+        {
+            DdiMedia_MediaSurfaceToMosResource(lastRefSurface, &m_resNoneRegLastRefFrame);
+            m_ddiDecodeCtx->DecodeParams.m_presNoneRegLastRefFrame = &m_resNoneRegLastRefFrame;
+            RegisterRTSurfaces(&m_ddiDecodeCtx->RTtbl, lastRefSurface);
+        }
         goldenRefSurface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->golden_ref_frame);
+        if(goldenRefSurface)
+        {
+            DdiMedia_MediaSurfaceToMosResource(lastRefSurface, &m_resNoneRegGoldenRefFrame);
+            m_ddiDecodeCtx->DecodeParams.m_presNoneRegGoldenRefFrame = &m_resNoneRegGoldenRefFrame;
+            RegisterRTSurfaces(&m_ddiDecodeCtx->RTtbl, lastRefSurface);
+        }
         altRefSurface    = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->alt_ref_frame);
+        if(altRefSurface)
+        {
+            DdiMedia_MediaSurfaceToMosResource(lastRefSurface, &m_resNoneRegAltRefFrame);
+            m_ddiDecodeCtx->DecodeParams.m_presNoneRegAltRefFrame = &m_resNoneRegAltRefFrame;
+            RegisterRTSurfaces(&m_ddiDecodeCtx->RTtbl, lastRefSurface);
+        }
     }
 
     int32_t frameIdx;

--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.h
@@ -144,6 +144,10 @@ private:
     //! \brief   Free Resource buffer for VP8
     //!
     void FreeResourceBuffer();
+
+    MOS_RESOURCE m_resNoneRegLastRefFrame;
+    MOS_RESOURCE m_resNoneRegGoldenRefFrame;
+    MOS_RESOURCE m_resNoneRegAltRefFrame;
 };
 
 #endif /* _MEDIA_DDI_DECODE_VP8_H */


### PR DESCRIPTION
the fix should be exist in ffmpeg
it is another solution. ffmpeg use the surface which is decoded by other
context to be reference. so need to register it

Signed-off-by: XinfengZhang <carl.zhang@intel.com>