### PR TITLE
Drop one compile flag for gcc9

### DIFF
--- a/media_driver/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_compile_flags_linux.cmake
@@ -32,7 +32,6 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -Wno-overflow
     -Wno-parentheses
     -Wno-delete-incomplete
-    -Werror=implicit-function-declaration
     -Werror=address
     -Werror=format-security
     -Werror=non-virtual-dtor


### PR DESCRIPTION
Drop " -Werror=implicit-function-declaration"  flag.Since gcc9 ,this error flag only makes sense for C code.
fixes #712