### PR TITLE
Encoder: VP8: GEN9/GEN10/GEN11: Ensure forced_lf_adjustment update in media kernel

### DIFF
--- a/media_driver/agnostic/gen10/codec/hal/codechal_encode_vp8_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_encode_vp8_g10.cpp
@@ -7839,6 +7839,7 @@ MOS_STATUS CodechalEncodeVp8G10::SetMpuCurbe(struct CodechalVp8MpuCurbeParams* p
     cmd.DW1.SharpnessLevel = picParams->sharpness_level;
     cmd.DW1.LoopFilterAdjustmentOn = picParams->loop_filter_adj_enable;
     cmd.DW1.MBNoCoeffiscientSkip = picParams->mb_no_coeff_skip;
+    cmd.DW1.ForcedLFUpdateForKeyFrame = picParams->forced_lf_adjustment;
 
     // DDI spec is not mapping to codechal directly. It should be mapping as below
     if (picParams->refresh_golden_frame == 1)

--- a/media_driver/agnostic/gen11/codec/hal/codechal_encode_vp8_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_encode_vp8_g11.cpp
@@ -8548,6 +8548,7 @@ MOS_STATUS CodechalEncodeVp8G11::SetMpuCurbe(struct CodechalVp8MpuCurbeParams* p
     cmd.DW1.SharpnessLevel = picParams->sharpness_level;
     cmd.DW1.LoopFilterAdjustmentOn = picParams->loop_filter_adj_enable;
     cmd.DW1.MBNoCoeffiscientSkip = picParams->mb_no_coeff_skip;
+    cmd.DW1.ForcedLFUpdateForKeyFrame = picParams->forced_lf_adjustment;
 
     // DDI spec is not mapping to codechal directly. It should be mapping as below
     if (picParams->refresh_golden_frame == 1)

--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_vp8_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_vp8_g9.cpp
@@ -7839,6 +7839,7 @@ MOS_STATUS CodechalEncodeVp8G9::SetMpuCurbe(struct CodechalVp8MpuCurbeParams* pa
     cmd.DW1.SharpnessLevel = picParams->sharpness_level;
     cmd.DW1.LoopFilterAdjustmentOn = picParams->loop_filter_adj_enable;
     cmd.DW1.MBNoCoeffiscientSkip = picParams->mb_no_coeff_skip;
+    cmd.DW1.ForcedLFUpdateForKeyFrame = picParams->forced_lf_adjustment;
 
     // DDI spec is not mapping to codechal directly. It should be mapping as below
     if (picParams->refresh_golden_frame == 1)


### PR DESCRIPTION
Ensure the submission of forced_lf_adjustment in mode probablity
update kernel curbe for gen9, gen10 and gen11.This will help to fix
the ffmpeg decoder output md5 mismatch with vpxdec for
the Intel encoded video samples.

Reported, Tested and Verified by Hirokazu Honda<hiroh@google.com>