### PR TITLE
replace the swizzle function to Mos_SwizzleData

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -4660,8 +4660,8 @@ VAStatus DdiMedia_GetImage(
     }
     else
     {
-        //Mos_SwizzleData((uint8_t*)surfData, (uint8_t *)imageData, (MOS_TILE_TYPE)mediaSurface->TileType, MOS_TILE_LINEAR, vaimg->data_size / mediaSurface->iPitch, mediaSurface->iPitch, mediaSurface->uiMapFlag);
-        vaStatus = SwizzleSurface(mediaSurface->pMediaCtx,mediaSurface->pGmmResourceInfo, surfData, (MOS_TILE_TYPE)mediaSurface->TileType, (uint8_t *)imageData, false);
+        Mos_SwizzleData((uint8_t*)surfData, (uint8_t *)imageData, (MOS_TILE_TYPE)mediaSurface->TileType, MOS_TILE_LINEAR, vaimg->data_size / mediaSurface->iPitch, mediaSurface->iPitch, mediaSurface->uiMapFlag);
+        //vaStatus = SwizzleSurface(mediaSurface->pMediaCtx,mediaSurface->pGmmResourceInfo, surfData, (MOS_TILE_TYPE)mediaSurface->TileType, (uint8_t *)imageData, false);
     }
     if (vaStatus != MOS_STATUS_SUCCESS)
     {


### PR DESCRIPTION
fixes #715
the swizzleSurface function will call GmmLib::GmmResourceInfoCommon::CpuBlt
and CpuSwizzleBlt, in this function _mm_storeu_si128  will write some invalid memory
it is not rootcause, jus a finding. should not merged until real rootcause is found

Signed-off-by: XinfengZhang <carl.zhang@intel.com>