### PR TITLE
Fix Build fail under CentOS7.6 with its native gcc 4.8 compiler

### DIFF
--- a/media_driver/agnostic/common/os/mos_utilities.h
+++ b/media_driver/agnostic/common/os/mos_utilities.h
@@ -74,8 +74,8 @@ public:
     void setupFilePath(char *perfFilePath);
     void setupFilePath();
     bool bPerfUtilityKey;
-    char sSummaryFileName[MOS_MAX_PERF_FILENAME_LEN + 1] = "";
-    char sDetailsFileName[MOS_MAX_PERF_FILENAME_LEN + 1] = "";
+    char sSummaryFileName[MOS_MAX_PERF_FILENAME_LEN + 1] = {'\0'};
+    char sDetailsFileName[MOS_MAX_PERF_FILENAME_LEN + 1] = {'\0'};
     int32_t dwPerfUtilityIsEnabled;
 
 private:


### PR DESCRIPTION
array used as initializer

fixes #736 