### PR TITLE
tgl: sync linux device id list with kernel upstream

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sysinfo_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sysinfo_g12.cpp
@@ -172,8 +172,23 @@ static struct GfxDeviceInfo tgllpGt2Info = {
     .InitShadowWa     = InitTglShadowWa,
 };
 
+static bool tgllpGt2Device9a40 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x9A40, &tgllpGt2Info);
+
 static bool tgllpGt2Device9a49 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x9A49, &tgllpGt2Info);
 
-static bool tgllpGt2Device9a40 = DeviceInfoFactory<GfxDeviceInfo>::
-    RegisterDevice(0x9A40, &tgllpGt2Info);
+static bool tgllpGt2Device9a59 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x9A59, &tgllpGt2Info);
+
+static bool tgllpGt2Device9a60 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x9A60, &tgllpGt2Info);
+
+static bool tgllpGt2Device9a68 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x9A68, &tgllpGt2Info);
+
+static bool tgllpGt2Device9a70 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x9A70, &tgllpGt2Info);
+
+static bool tgllpGt2Device9a78 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x9A78, &tgllpGt2Info);


### PR DESCRIPTION
TGL Device ID synced with public linux kernel upstream:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/drm/i915_pciids.h?h=v5.4-rc7#n590

Change-Id: Ice7dfa1087e5089ae37428448af6b8463b21633e
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>