### PR TITLE
Disable the scalability on TGL for Linux.

### DIFF
--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_mfx_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_mfx_g12_X.h
@@ -117,6 +117,9 @@ public:
         MHW_FUNCTION_ENTER;
 
         m_osInterface = osInterface;
+#ifdef LINUX
+        m_scalabilitySupported = false;
+#else
         if (m_numVdbox > 1
 #if (_DEBUG || _RELEASE_INTERNAL)
             && m_osInterface != nullptr
@@ -126,6 +129,7 @@ public:
         {
             m_scalabilitySupported = true;
         }
+#endif
 
         m_rhoDomainStatsEnabled = true;
 


### PR DESCRIPTION
The scalability on TGL for Linux hasn't been finished yet.
If enabling, it will cause GPU hang.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>