### PR TITLE
add prediction direction caps for AVC VDEnc

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -762,7 +762,13 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
         attrib.value = attribValMaxFrameSize.value;
         (*attribList)[attrib.type] = attrib.value;
     }
-
+    
+    if (IsAvcProfile(profile) && (entrypoint == VAEntrypointEncSliceLP))
+    {
+        attrib.type = (VAConfigAttribType) VAConfigAttribPredictionDirection;
+        attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS;
+        (*attribList)[attrib.type] = attrib.value;
+    }
     return status;
 }
 


### PR DESCRIPTION
related libva change: https://github.com/intel/libva/pull/220

Signed-off-by: XinfengZhang <carl.zhang@intel.com>