### PR TITLE
gen12: fix -DENABLE_KERNELS=OFF build mode w/ removed kernels

### DIFF
--- a/media_driver/agnostic/gen12/cm/cm_hal_g12.cpp
+++ b/media_driver/agnostic/gen12/cm/cm_hal_g12.cpp
@@ -34,7 +34,7 @@
 #include "renderhal_g12.h"
 #include "hal_oca_interface.h"
 #include "mhw_mmio_g12.h"
-#ifdef ENABLE_KERNELS
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "cm_gpucopy_kernel_g12lp.h"
 #include "cm_gpuinit_kernel_g12lp.h"
 #else  // #ifdef ENABLE_KERNELS

--- a/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_g12.cpp
@@ -29,7 +29,9 @@
 #include "codechal_encode_sfc_g12.h"
 #include "codechal_kernel_header_g12.h"
 #include "codeckrnheader.h"
+#if defined(ENABLE_KERNELS)
 #include "igcodeckrn_g12.h"
+#endif
 #if USE_CODECHAL_DEBUG_TOOL
 #include "codechal_debug_encode_par_g12.h"
 #endif
@@ -787,7 +789,9 @@ CodechalEncodeCscDsG12::CodechalEncodeCscDsG12(CodechalEncoderState* encoder)
 {
     m_cscKernelUID = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
+#if defined(ENABLE_KERNELS)
     m_kernelBase = (uint8_t*)IGCODECKRN_G12;
+#endif
 }
 
 CodechalEncodeCscDsG12::~CodechalEncodeCscDsG12()

--- a/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_g12.cpp
@@ -29,7 +29,7 @@
 #include "codechal_encode_sfc_g12.h"
 #include "codechal_kernel_header_g12.h"
 #include "codeckrnheader.h"
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g12.h"
 #endif
 #if USE_CODECHAL_DEBUG_TOOL
@@ -789,7 +789,7 @@ CodechalEncodeCscDsG12::CodechalEncodeCscDsG12(CodechalEncoderState* encoder)
 {
     m_cscKernelUID = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
     m_cscCurbeLength = sizeof(CscKernelCurbeData);
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G12;
 #endif
 }

--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_avc_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_avc_g12.cpp
@@ -34,7 +34,7 @@
 #include "mhw_render_g12_X.h"
 #include "mos_util_user_interface_g12.h"
 #include "codeckrnheader.h"
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g12.h"
 #endif
 #if USE_CODECHAL_DEBUG_TOOL
@@ -594,7 +594,7 @@ CodechalVdencAvcStateG12::CodechalVdencAvcStateG12(
 
     Mos_CheckVirtualEngineSupported(m_osInterface, false, true);
 
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G12;
 #endif
     m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;

--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_avc_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_avc_g12.cpp
@@ -34,7 +34,9 @@
 #include "mhw_render_g12_X.h"
 #include "mos_util_user_interface_g12.h"
 #include "codeckrnheader.h"
+#if defined(ENABLE_KERNELS)
 #include "igcodeckrn_g12.h"
+#endif
 #if USE_CODECHAL_DEBUG_TOOL
 #include "codechal_debug_encode_par_g12.h"
 #include "mhw_vdbox_mfx_hwcmd_g12_X.h"
@@ -592,7 +594,9 @@ CodechalVdencAvcStateG12::CodechalVdencAvcStateG12(
 
     Mos_CheckVirtualEngineSupported(m_osInterface, false, true);
 
+#if defined(ENABLE_KERNELS)
     m_kernelBase = (uint8_t*)IGCODECKRN_G12;
+#endif
     m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
     AddIshSize(m_kuidCommon, m_kernelBase);
 

--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
@@ -29,7 +29,7 @@
 #include "codechal_kernel_header_g12.h"
 #include "codechal_kernel_hme_g12.h"
 #include "codeckrnheader.h"
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
 #include "igcodeckrn_g12.h"
 #endif
 #include "mhw_vdbox_hcp_g12_X.h"
@@ -97,7 +97,7 @@ CodechalVdencVp9StateG12::CodechalVdencVp9StateG12(
     {
         m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
         eStatus = CodecHalGetKernelBinaryAndSize(
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
             (uint8_t*)IGCODECKRN_G12,
 #else
             nullptr,
@@ -641,7 +641,7 @@ MOS_STATUS CodechalVdencVp9StateG12::InitKernelStates()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     m_kernelBase = (uint8_t*)IGCODECKRN_G12;
 #endif
 
@@ -703,7 +703,7 @@ MOS_STATUS CodechalVdencVp9StateG12::InitKernelStateDys()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
-#if defined(ENABLE_KERNELS)
+#if defined(ENABLE_KERNELS) && !defined(_FULL_OPEN_SOURCE)
     uint32_t combinedKernelSize = 0;
     uint8_t* binary = nullptr;
     CODECHAL_ENCODE_CHK_STATUS_RETURN(CodecHalGetKernelBinaryAndSize(

--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
@@ -29,7 +29,9 @@
 #include "codechal_kernel_header_g12.h"
 #include "codechal_kernel_hme_g12.h"
 #include "codeckrnheader.h"
+#if defined(ENABLE_KERNELS)
 #include "igcodeckrn_g12.h"
+#endif
 #include "mhw_vdbox_hcp_g12_X.h"
 #include "mhw_vdbox_vdenc_g12_X.h"
 #include "mhw_vdbox_g12_X.h"
@@ -95,7 +97,11 @@ CodechalVdencVp9StateG12::CodechalVdencVp9StateG12(
     {
         m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
         eStatus = CodecHalGetKernelBinaryAndSize(
+#if defined(ENABLE_KERNELS)
             (uint8_t*)IGCODECKRN_G12,
+#else
+            nullptr,
+#endif
             m_kuidCommon,
             &binary,
             &combinedKernelSize);
@@ -635,7 +641,9 @@ MOS_STATUS CodechalVdencVp9StateG12::InitKernelStates()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
+#if defined(ENABLE_KERNELS)
     m_kernelBase = (uint8_t*)IGCODECKRN_G12;
+#endif
 
     // KUID for HME + DS + SW SCOREBOARD Kernel
     m_kuidCommon = IDR_CODEC_HME_DS_SCOREBOARD_KERNEL;
@@ -695,6 +703,7 @@ MOS_STATUS CodechalVdencVp9StateG12::InitKernelStateDys()
 
     CODECHAL_ENCODE_FUNCTION_ENTER;
 
+#if defined(ENABLE_KERNELS)
     uint32_t combinedKernelSize = 0;
     uint8_t* binary = nullptr;
     CODECHAL_ENCODE_CHK_STATUS_RETURN(CodecHalGetKernelBinaryAndSize(
@@ -738,6 +747,7 @@ MOS_STATUS CodechalVdencVp9StateG12::InitKernelStateDys()
         MOS_ALIGN_CEIL(kernelState->KernelParams.iSamplerLength * kernelState->KernelParams.iSamplerCount, MHW_SAMPLER_STATE_AVS_ALIGN);
 
     CODECHAL_ENCODE_CHK_STATUS_RETURN(m_hwInterface->MhwInitISH(m_stateHeapInterface, kernelState));
+#endif
 
     return eStatus;
 }

--- a/media_driver/agnostic/gen12_tgllp/vp/media_srcs.cmake
+++ b/media_driver/agnostic/gen12_tgllp/vp/media_srcs.cmake
@@ -20,6 +20,10 @@
 
 media_include_subdirectory(hal)
 media_include_subdirectory(kdll)
-media_include_subdirectory(kernel)
-
-
+if(ENABLE_KERNELS)
+        if(ENABLE_NONFREE_KERNELS)
+            media_include_subdirectory(kernel)
+        else()
+            media_include_subdirectory(kernel_free)
+        endif()
+endif()


### PR DESCRIPTION
Fixes: #786

This fixed -DENABLE_KERNELS=OFF build mode if kernels will be physically
removed from the repository.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>