### PR TITLE
Fix device info for GT1 BXT / GLK SKUs

### DIFF
--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -253,7 +253,20 @@ static bool InitBxtMediaSku(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_SKU(skuTable, FtrEnableMediaKernels, drvInfo->hasHuc);
 
-    MEDIA_WR_SKU(skuTable, FtrGT1, 1);
+    if (devInfo->eGTType == GTTYPE_GT1)
+    {
+        MEDIA_WR_SKU(skuTable, FtrGT1, 1);
+    }
+    else if (devInfo->eGTType == GTTYPE_GT1_5)
+    {
+        MEDIA_WR_SKU(skuTable, FtrGT1_5, 1);
+    }
+    else
+    {
+        /* GT1 is by default */
+        MEDIA_WR_SKU(skuTable, FtrGT1, 1);
+    }
+
     MEDIA_WR_SKU(skuTable, FtrLCIA, 1);
     MEDIA_WR_SKU(skuTable, FtrVERing, drvInfo->hasVebox);
     MEDIA_WR_SKU(skuTable, FtrEDram, devInfo->hasERAM);
@@ -470,7 +483,20 @@ static bool InitGlkMediaSku(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_SKU(skuTable, FtrEnableMediaKernels, drvInfo->hasHuc);
 
-    MEDIA_WR_SKU(skuTable, FtrGT1, 1);
+    if (devInfo->eGTType == GTTYPE_GT1)
+    {
+        MEDIA_WR_SKU(skuTable, FtrGT1, 1);
+    }
+    else if (devInfo->eGTType == GTTYPE_GT1_5)
+    {
+        MEDIA_WR_SKU(skuTable, FtrGT1_5, 1);
+    }
+    else
+    {
+        /* GT1 is by default */
+        MEDIA_WR_SKU(skuTable, FtrGT1, 1);
+    }
+
     MEDIA_WR_SKU(skuTable, FtrLCIA, 1);
     MEDIA_WR_SKU(skuTable, FtrVERing, drvInfo->hasVebox);
     MEDIA_WR_SKU(skuTable, FtrPPGTT, drvInfo->hasPpgtt);

--- a/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
@@ -423,6 +423,26 @@ static struct GfxDeviceInfo bxtGt1Info = {
     .eGTType       = GTTYPE_GT1,
     .L3CacheSizeInKb = 384,
     .L3BankCount   = 2,
+    .EUCount       = 12,
+    .SliceCount    = 1,
+    .SubSliceCount = 2,
+    .MaxEuPerSubSlice = 6,
+    .isLCIA        = 1,
+    .hasLLC        = 0,
+    .hasERAM       = 0,
+    .InitMediaSysInfo = InitLCIAMediaSysInfo,
+    .InitShadowSku    = InitLCIAShadowSku,
+    .InitShadowWa     = InitLCIAShadowWa,
+};
+
+static struct GfxDeviceInfo bxtGt1f5Info = {
+    .platformType  = PLATFORM_MOBILE,
+    .productFamily = IGFX_BROXTON,
+    .displayFamily = IGFX_GEN9_CORE,
+    .renderFamily  = IGFX_GEN9_CORE,
+    .eGTType       = GTTYPE_GT1_5,
+    .L3CacheSizeInKb = 384,
+    .L3BankCount   = 2,
     .EUCount       = 18,
     .SliceCount    = 1,
     .SubSliceCount = 3,
@@ -436,6 +456,26 @@ static struct GfxDeviceInfo bxtGt1Info = {
 };
 
 static struct GfxDeviceInfo glkGt1Info = {
+    .platformType  = PLATFORM_MOBILE,
+    .productFamily = IGFX_GEMINILAKE,
+    .displayFamily = IGFX_GEN9_CORE,
+    .renderFamily  = IGFX_GEN9_CORE,
+    .eGTType       = GTTYPE_GT1,
+    .L3CacheSizeInKb = 384,
+    .L3BankCount   = 2,
+    .EUCount       = 12,
+    .SliceCount    = 1,
+    .SubSliceCount = 2,
+    .MaxEuPerSubSlice = 6,
+    .isLCIA        = 1,
+    .hasLLC        = 0,
+    .hasERAM       = 0,
+    .InitMediaSysInfo = InitLCIAMediaSysInfo,
+    .InitShadowSku    = InitLCIAShadowSku,
+    .InitShadowWa     = InitLCIAShadowWa,
+};
+
+static struct GfxDeviceInfo glkGt1f5Info = {
     .platformType  = PLATFORM_MOBILE,
     .productFamily = IGFX_GEMINILAKE,
     .displayFamily = IGFX_GEN9_CORE,
@@ -460,7 +500,7 @@ static struct GfxDeviceInfo kblGt1Info = {
     .productFamily = IGFX_KABYLAKE,
     .displayFamily = IGFX_GEN9_CORE,
     .renderFamily  = IGFX_GEN9_CORE,
-    .eGTType       = GTTYPE_GT1,
+    .eGTType       = GTTYPE_GT1_5,
     .L3CacheSizeInKb = 384,
     .L3BankCount   = 2,
     .EUCount       = 12,
@@ -712,19 +752,19 @@ static bool sklDevice193d = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x193d, &sklGt4eInfo);
 
 static bool bxtDevice1a84 = DeviceInfoFactory<GfxDeviceInfo>::
-    RegisterDevice(0x1a84, &bxtGt1Info);
+    RegisterDevice(0x1a84, &bxtGt1f5Info);
 
 static bool bxtDevice1a85 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x1a85, &bxtGt1Info);
 
 static bool bxtDevice5a84 = DeviceInfoFactory<GfxDeviceInfo>::
-    RegisterDevice(0x5a84, &bxtGt1Info);
+    RegisterDevice(0x5a84, &bxtGt1f5Info);
 
 static bool bxtDevice5a85 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x5a85, &bxtGt1Info);
 
 static bool glkDevice3a84 = DeviceInfoFactory<GfxDeviceInfo>::
-    RegisterDevice(0x3184, &glkGt1Info);
+    RegisterDevice(0x3184, &glkGt1f5Info);
 
 static bool glkDevice3a85 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x3185, &glkGt1Info);

--- a/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sysinfo_g9.cpp
@@ -751,6 +751,9 @@ static bool sklDevice193b = DeviceInfoFactory<GfxDeviceInfo>::
 static bool sklDevice193d = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x193d, &sklGt4eInfo);
 
+static bool bxtDevice0a84 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x0a84, &bxtGt1f5Info);
+
 static bool bxtDevice1a84 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x1a84, &bxtGt1f5Info);
 


### PR DESCRIPTION
* UHD Graphics 500 / 600 are 12 EU GT1 SKUs
* UHD Graphics 505 / 605 are 18 EU GT1.5 SKUs

This also changes 18 EU SKUs to be treated as GT 1.5.

I've also added `0x0a84` as BXT 18 EU device based on [i965_pci_ids.h](https://gitlab.freedesktop.org/mesa/mesa/blob/master/include/pci_ids/i965_pci_ids.h) from mesa.