### PR TITLE
change media_features.md about resolution of Gen9 hevc encode

### DIFF
--- a/docs/media_features.md
+++ b/docs/media_features.md
@@ -66,7 +66,7 @@
 | VP8        |Input       |      |      |         | NV12 | NV12 | NV12 | NV12 | NV12           |
 |            |Max Res.    |      |      |         | 4k   | 4k   | 4k   | 4k   | 4k             |
 | HEVC 8bit  |Input       |      | NV12 |  NV12   | NV12 | NV12 | NV12 | NV12 | NV12/AYUV      |
-|            |Max Res.    |      | 8k   |  8k     | 8k   | 8k   | 8k   | 8k   | 8k             |
+|            |Max Res.    |      | 4k   |  4k     | 4k   | 4k   | 4k   | 4k   | 8k             |
 | HEVC 10bit |Input       |      |      |         |      |      |      |      | P010/Y410      |
 |            |Max Res.    |      |      |         |      |      |      |      | 8k             |
 


### PR DESCRIPTION
just verified gen9 hevc 4k encoder, so change the max resolution to 4k

Signed-off-by: XinfengZhang <carl.zhang@intel.com>