### PR TITLE
[MOS] correct the use of the return value of MOS_SecureStringPrint

### DIFF
--- a/media_driver/linux/common/os/mos_util_debug_specific.c
+++ b/media_driver/linux/common/os/mos_util_debug_specific.c
@@ -173,7 +173,7 @@ MOS_STATUS MOS_LogFileNamePrefix(char  *fileNamePrefix)
                      MOS_MAX_HLT_FILENAME_LEN,
                      MosUltLogPathPrefix);
 
-        if (iRet == 0)
+        if (iRet > 0)
         {
             eStatus = MOS_STATUS_SUCCESS;
         }
@@ -197,7 +197,7 @@ MOS_STATUS MOS_LogFileNamePrefix(char  *fileNamePrefix)
                      MOS_MAX_HLT_FILENAME_LEN,
                      MosLogPathPrefix);
 
-        if (iRet == 0)
+        if (iRet > 0)
         {
             MOS_ZeroMemory(&UserFeatureWriteData, sizeof(UserFeatureWriteData));
             UserFeatureWriteData.Value.StringData.pStringData = fileNamePrefix;


### PR DESCRIPTION
The return value of MOS_SecureStringPrint is the number of characters printed.