### PR TITLE
Start candidate searching after last active frame.

### DIFF
--- a/media_driver/linux/common/ddi/media_ddi_base.cpp
+++ b/media_driver/linux/common/ddi/media_ddi_base.cpp
@@ -86,8 +86,8 @@ VAStatus DdiMediaBase::RegisterRTSurfaces(DDI_CODEC_RENDER_TARGET_TABLE *rtTbl, 
     }
     else
     {
-        uint32_t j = 0;
-        for(j = 0; j < DDI_MEDIA_MAX_SURFACE_NUMBER_CONTEXT; j ++)
+        uint32_t j = (rtTbl->iLastFrameIdx + 1) % DDI_MEDIA_MAX_SURFACE_NUMBER_CONTEXT;
+        for(uint32_t k = 0; k < DDI_MEDIA_MAX_SURFACE_NUMBER_CONTEXT; k++, j = (j +1) % DDI_MEDIA_MAX_SURFACE_NUMBER_CONTEXT)
         {
             if(rtTbl->ucRTFlag[j] == SURFACE_STATE_INACTIVE)
             {
@@ -121,6 +121,7 @@ VAStatus DdiMediaBase::ClearRefList(DDI_CODEC_RENDER_TARGET_TABLE *rtTbl, bool w
             else if(rtTbl->ucRTFlag[i] == SURFACE_STATE_ACTIVE_IN_CURFRAME)
             {
                 rtTbl->ucRTFlag[i] = SURFACE_STATE_ACTIVE_IN_LASTFRAME;
+                rtTbl->iLastFrameIdx = i;
             }
         }
     }

--- a/media_driver/linux/common/ddi/media_libva.h
+++ b/media_driver/linux/common/ddi/media_libva.h
@@ -286,6 +286,7 @@ typedef struct _DDI_CODEC_RENDER_TARGET_TABLE
     DDI_MEDIA_SURFACE           *pCurrentReconTarget;  // recon surface for encode
     DDI_MEDIA_SURFACE           *pRT[DDI_MEDIA_MAX_SURFACE_NUMBER_CONTEXT];
     uint8_t                      ucRTFlag[DDI_MEDIA_MAX_SURFACE_NUMBER_CONTEXT];
+    int32_t                      iLastFrameIdx;
 } DDI_CODEC_RENDER_TARGET_TABLE, *PDDI_CODEC_RENDER_TARGET_TABLE;
 
 #define DDI_CODEC_INVALID_FRAME_INDEX              0xffffffff


### PR DESCRIPTION
It will avoid selecting the 1st element at rtTbl always and
overwriting needed reference frame when rtTbl is full.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>