### PR TITLE
FreeBSD support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,10 @@ jobs:
       install:
         - sudo ln -sf /usr/local/libdata/pkgconfig /usr/local/lib/
         - git clone https://github.com/intel/gmmlib.git
+        - | # Workaround until https://github.com/intel/gmmlib/pull/68 is merged
+          if ! fgrep -q freebsd gmmlib/.travis.yml; then
+            (cd gmmlib && git fetch origin pull/68/head:freebsd && git checkout freebsd)
+          fi
         - (cd gmmlib && cmake -B _build -G Ninja && cmake --build _build && sudo cmake --install _build)
         - git clone https://github.com/intel/libva.git
         - (cd libva && meson _build && meson compile -C _build && sudo meson install -C _build)

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,3 +111,27 @@ script:
       make -j8
   - ccache -s
   - ccache -z
+
+jobs:
+  include:
+    - os: linux
+    - os: freebsd
+      compiler: clang
+      before_install:
+        - sudo pkg install -y meson pkgconf libdrm libXext libXfixes wayland
+        - sudo pkg install -y -x '^mesa($|-libs)'
+      install:
+        - sudo ln -sf /usr/local/libdata/pkgconfig /usr/local/lib/
+        - git clone https://github.com/intel/gmmlib.git
+        - (cd gmmlib && cmake -B _build -G Ninja && cmake --build _build && sudo cmake --install _build)
+        - git clone https://github.com/intel/libva.git
+        - (cd libva && meson _build && meson compile -C _build && sudo meson install -C _build)
+      script:
+        - ccache -s
+        - ccache -z
+        - cmake -B _build -G Ninja
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DBUILD_TYPE=Release -DBUILD_CMRTLIB=OFF -DMEDIA_RUN_TEST_SUITE=OFF
+        - cmake --build _build
+        - ccache -s
+        - ccache -z

--- a/cmrtlib/linux/CMakeLists.txt
+++ b/cmrtlib/linux/CMakeLists.txt
@@ -101,7 +101,7 @@ set(CMRT_VERSION ${CMRT_VERSION_MAJOR}.${CMRT_VERSION_MINOR}.${CMRT_VERSION_PATC
 
 set_target_properties(igfxcmrt PROPERTIES VERSION ${CMRT_VERSION})
 set_target_properties(igfxcmrt PROPERTIES SOVERSION ${CMRT_VERSION_MAJOR})
-target_link_libraries( igfxcmrt dl va rt ${GCC_SECURE_LINK_FLAGS})
+target_link_libraries( igfxcmrt ${CMAKE_DL_LIBS} va rt ${GCC_SECURE_LINK_FLAGS})
 
 include(GNUInstallDirs)
 

--- a/cmrtlib/linux/hardware/drm_device.h
+++ b/cmrtlib/linux/hardware/drm_device.h
@@ -39,16 +39,16 @@
 #include <limits.h>
 #include <signal.h>
 #include <time.h>
-#include <sys/sysmacros.h>   //<sys/types.h>
+#include <sys/types.h>
 #include <sys/stat.h>
 #define stat_t struct stat
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <stdarg.h>
-#ifdef MAJOR_IN_MKDEV
+#ifdef __sun //#ifdef MAJOR_IN_MKDEV
 #include <sys/mkdev.h>
 #endif
-#ifdef MAJOR_IN_SYSMACROS
+#if defined(__GLIBC__) || defined(__linux__) //#ifdef MAJOR_IN_SYSMACROS
 #include <sys/sysmacros.h>
 #endif
 #include <math.h>

--- a/cmrtlib/linux/hardware/drm_device.h
+++ b/cmrtlib/linux/hardware/drm_device.h
@@ -53,7 +53,6 @@
 #endif
 #include <math.h>
 #include <string>
-#include <cstring>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
@@ -125,7 +124,7 @@ typedef void          *drmAddress, **drmAddressPtr; /**< For mapped regions */
 #define MAX3( A, B, C ) ((A) > (B) ? MAX2(A, C) : MAX2(B, C))
 
 #define __align_mask(value, mask)  (((value) + (mask)) & ~(mask))
-#define ALIGN_CEIL(value, alignment)    __align_mask(value, (__typeof__(value))((alignment) - 1))
+#define ALIGN(value, alignment)    __align_mask(value, (__typeof__(value))((alignment) - 1))
 #define DRM_PLATFORM_DEVICE_NAME_LEN 512
 
 typedef struct _drmPciBusInfo {
@@ -231,21 +230,6 @@ drm_device_validate_flags(uint32_t flags)
     return (flags & ~DRM_DEVICE_GET_PCI_REVISION);
 }
 
-static bool
-drm_device_has_rdev(drmDevicePtr device, dev_t find_rdev)
-{
-    struct stat sbuf;
-
-    for (int i = 0; i < DRM_NODE_MAX; i++) {
-        if (device->available_nodes & 1 << i) {
-            if (stat(device->nodes[i], &sbuf) == 0 &&
-                sbuf.st_rdev == find_rdev)
-                return true;
-        }
-    }
-    return false;
-}
-
 static int drmGetMaxNodeName(void)
 {
     return sizeof(DRM_DIR_NAME) +
@@ -305,7 +289,7 @@ static drmDevicePtr drmDeviceAlloc(unsigned int type, const char *node,
     unsigned int i;
     char *ptr;
 
-    max_node_length = ALIGN_CEIL(drmGetMaxNodeName(), sizeof(void *));
+    max_node_length = ALIGN(drmGetMaxNodeName(), sizeof(void *));
 
     extra = DRM_NODE_MAX * (sizeof(void *) + max_node_length);
 
@@ -1198,105 +1182,6 @@ int drmGetDevices(drmDevicePtr devices[], int max_devices)
     return drmGetDevices2(DRM_DEVICE_GET_PCI_REVISION, devices, max_devices);
 }
 
-/**
- * Get information about the opened drm device
- *
- * \param fd file descriptor of the drm device
- * \param flags feature/behaviour bitmask
- * \param device the address of a drmDevicePtr where the information
- *               will be allocated in stored
- *
- * \return zero on success, negative error code otherwise.
- *
- * \note Unlike drmGetDevice it does not retrieve the pci device revision field
- * unless the DRM_DEVICE_GET_PCI_REVISION \p flag is set.
- */
-int drmGetDevice2(int fd, uint32_t flags, drmDevicePtr *device)
-{
-    drmDevicePtr local_devices[MAX_DRM_NODES];
-    drmDevicePtr d;
-    DIR *sysdir;
-    struct dirent *dent;
-    struct stat sbuf;
-    int subsystem_type;
-    int maj, min;
-    int ret, i, node_count;
-    dev_t find_rdev;
-
-    if (drm_device_validate_flags(flags))
-        return -EINVAL;
-
-    if (fd == -1 || device == NULL)
-        return -EINVAL;
-
-    if (fstat(fd, &sbuf))
-        return -errno;
-
-    find_rdev = sbuf.st_rdev;
-    maj = major(sbuf.st_rdev);
-    min = minor(sbuf.st_rdev);
-
-    if (!drmNodeIsDRM(maj, min) || !S_ISCHR(sbuf.st_mode))
-        return -EINVAL;
-
-    subsystem_type = drmParseSubsystemType(maj, min);
-    if (subsystem_type < 0)
-        return subsystem_type;
-
-    sysdir = opendir(DRM_DIR_NAME);
-    if (!sysdir)
-        return -errno;
-
-    i = 0;
-    while ((dent = readdir(sysdir))) {
-        ret = process_device(&d, dent->d_name, subsystem_type, true, flags);
-        if (ret)
-            continue;
-
-        if (i >= MAX_DRM_NODES) {
-            fprintf(stderr, "More than %d drm nodes detected. "
-                    "Please report a bug - that should not happen.\n"
-                    "Skipping extra nodes\n", MAX_DRM_NODES);
-            break;
-        }
-        local_devices[i] = d;
-        i++;
-    }
-    node_count = i;
-
-    drmFoldDuplicatedDevices(local_devices, node_count);
-
-    *device = NULL;
-
-    for (i = 0; i < node_count; i++) {
-        if (!local_devices[i])
-            continue;
-
-        if (drm_device_has_rdev(local_devices[i], find_rdev))
-            *device = local_devices[i];
-        else
-            drmFreeDevice(&local_devices[i]);
-    }
-
-    closedir(sysdir);
-    if (*device == NULL)
-        return -ENODEV;
-    return 0;
-}
-
-/**
- * Get information about the opened drm device
- *
- * \param fd file descriptor of the drm device
- * \param device the address of a drmDevicePtr where the information
- *               will be allocated in stored
- *
- * \return zero on success, negative error code otherwise.
- */
-int drmGetDevice(int fd, drmDevicePtr *device)
-{
-    return drmGetDevice2(fd, DRM_DEVICE_GET_PCI_REVISION, device);
-}
 
 static int32_t GetRendererFileDescriptor(char * drm_node)
 {

--- a/cmrtlib/linux/share/cm_def_os.h
+++ b/cmrtlib/linux/share/cm_def_os.h
@@ -32,15 +32,15 @@
 #define Display unsigned int
 #endif
 
+#include <cstdlib>
 #include <cstring>
 #include "pthread.h"
-#include <malloc.h>
 
 
 ////////////////////////////////////////////////////////////////////////////////////
 // MS-specific defines/typedefs, which are absent under Linux but still used
 ////////////////////////////////////////////////////////////////////////////////////
-#define _aligned_malloc(size, alignment) memalign(alignment, size)
+#define _aligned_malloc(size, alignment) aligned_alloc(alignment, size)
 #define _aligned_free(ptr) free(ptr)
 typedef uint8_t BOOLEAN, *PBOOLEAN;
 ////////////////////////////////////////////////////////////////////////////////////
@@ -101,7 +101,7 @@ typedef enum _VACMTEXTUREFILTERTYPE {
 
 inline void * CM_ALIGNED_MALLOC(size_t size, size_t alignment)
 {
-  return memalign(alignment, size);
+  return aligned_alloc(alignment, size);
 }
 
 inline void CM_ALIGNED_FREE(void * memory)

--- a/cmrtlib/linux/share/cm_rt_def_os.h
+++ b/cmrtlib/linux/share/cm_rt_def_os.h
@@ -36,7 +36,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <math.h>
-#include <malloc.h>
 #include <string.h>
 #include <sys/time.h>
 #include <pthread.h>
@@ -175,7 +174,7 @@ template<> inline const char * CM_TYPE_NAME_UNMANGLED<double>() { return "double
 
 inline void * CM_ALIGNED_MALLOC(size_t size, size_t alignment) 
 {
-  return memalign(alignment, size);
+  return aligned_alloc(alignment, size);
 } 
 
 inline void CM_ALIGNED_FREE(void * memory) 

--- a/media_driver/agnostic/ult/cm/buffer_up_test.cpp
+++ b/media_driver/agnostic/ult/cm/buffer_up_test.cpp
@@ -21,7 +21,6 @@
 */
 
 #include "cm_test.h"
-#include <malloc.h>
 
 class BufferUPTest: public CmTest
 {

--- a/media_driver/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_compile_flags_linux.cmake
@@ -89,7 +89,6 @@ endif()
 if(NOT ${PLATFORM} STREQUAL "android")
     set(MEDIA_COMPILER_FLAGS_COMMON
         ${MEDIA_COMPILER_FLAGS_COMMON}
-        -D__linux__
             -fno-tree-pre
         -fPIC
             -Wl,--no-as-needed

--- a/media_driver/linux/common/cm/hal/cm_innerdef_os.h
+++ b/media_driver/linux/common/cm/hal/cm_innerdef_os.h
@@ -36,7 +36,15 @@
 #include "mos_os.h"
 #include "media_libva_common.h"
 #include <sys/types.h>
+#if defined(__linux__)
 #include <sys/syscall.h>
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
+#include <pthread_np.h>
+#elif defined(__NetBSD__)
+#include <lwp.h>
+#elif defined(__sun)
+#include <thread.h>
+#endif
 #include <unistd.h>
 
 //Require DRM VMAP patch,
@@ -95,5 +103,18 @@ inline void GetLocalTime(PSYSTEMTIME psystime)
 #endif
 
 #define CmGetCurProcessId() getpid()
+#if defined(__linux__)
 #define CmGetCurThreadId()  syscall(SYS_gettid)
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
+#define CmGetCurThreadId()  pthread_getthreadid_np()
+#elif defined(__NetBSD__)
+#define CmGetCurThreadId()  _lwp_self()
+#elif defined(__OpenBSD__)
+#define CmGetCurThreadId()  getthrid()
+#elif defined(__sun)
+#define CmGetCurThreadId()  thr_self()
+#else
+#warning "Cannot get kernel thread identifier on this platform."
+#define CmGetCurThreadId()  (uintptr_t)pthread_self()
+#endif
 

--- a/media_driver/linux/common/cm/hal/osservice/cm_mem_os.h
+++ b/media_driver/linux/common/cm/hal/osservice/cm_mem_os.h
@@ -30,6 +30,9 @@
 #include <smmintrin.h>
 
 typedef uintptr_t           UINT_PTR;
+#ifdef __fastcall
+    #undef __fastcall
+#endif
 #define __fastcall
 #define __noop
 

--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -47,7 +47,40 @@
 #include <X11/Xutil.h>
 #endif
 
+#if defined(__linux__)
 #include <linux/fb.h>
+#define DEFAULT_FBDEV "/dev/graphics/fb0"
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__sun)
+#include <sys/fbio.h>
+# if defined(__sun)
+#define DEFAULT_FBDEV "/dev/fb"
+# else
+#define DEFAULT_FBDEV "/dev/ttyv0"
+# endif
+#define FBIOGET_VSCREENINFO FBIOGTYPE
+#define fb_var_screeninfo fbtype
+#define xres fb_width
+#define yres fb_height
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#include <dev/wscons/wsconsio.h>
+# if defined(__OpenBSD__)
+#define DEFAULT_FBDEV "/dev/ttyC0"
+# else
+#define DEFAULT_FBDEV "/dev/ttyE0"
+# endif
+#define FBIOGET_VSCREENINFO WSDISPLAYIO_GINFO
+#define fb_var_screeninfo wsdisplay_fbinfo
+#define xres width
+#define yres height
+#else
+#warning "Cannot query framebuffer properties on this platform."
+#define DEFAULT_FBDEV "/dev/fb0"
+#define FBIOGET_VSCREENINFO 0
+struct fb_var_screeninfo {
+    uint32_t xres;
+    uint32_t yres;
+};
+#endif
 
 typedef MediaDdiFactory<DdiMediaDecode, DDI_DECODE_CONFIG_ATTR> DdiDecodeFactory;
 
@@ -800,7 +833,7 @@ static int32_t DdiDecode_GetDisplayInfo(VADriverContextP ctx)
     vsinfo.xres                           = 0;
     vsinfo.yres                           = 0;
 
-    fd = open("/dev/graphics/fb0",O_RDONLY);
+    fd = open(DEFAULT_FBDEV,O_RDONLY);
     if(fd > 0)
     {
         if(ioctl(fd, FBIOGET_VSCREENINFO, &vsinfo) < 0)

--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -36,8 +36,6 @@
 #include <X11/Xutil.h>
 #endif
 
-#include <linux/fb.h>
-
 #include "media_libva.h"
 
 #include "media_libva_util.h"

--- a/media_driver/linux/common/os/i915/include/mos_bufmgr_priv.h
+++ b/media_driver/linux/common/os/i915/include/mos_bufmgr_priv.h
@@ -348,6 +348,10 @@ struct mos_bufmgr {
     bool     has_full_vd   = true;
 };
 
+#ifdef ALIGN
+/* <sys/param.h> via <pthread_np.h> on FreeBSD also defines ALIGN */
+#undef ALIGN
+#endif
 #define ALIGN(value, alignment)    ((value + alignment - 1) & ~(alignment - 1))
 #define ROUND_UP_TO(x, y)    (((x) + (y) - 1) / (y) * (y))
 #define ROUND_UP_TO_MB(x)    ROUND_UP_TO((x), 1024*1024)

--- a/media_driver/linux/common/os/i915/include/xf86drm.h
+++ b/media_driver/linux/common/os/i915/include/xf86drm.h
@@ -713,6 +713,39 @@ extern char *drmGetRenderDeviceNameFromFd(int fd);
 
 #define DRM_BUS_PCI   0
 
+typedef struct _drmPciBusInfo {
+    uint16_t domain;
+    uint8_t bus;
+    uint8_t dev;
+    uint8_t func;
+} drmPciBusInfo, *drmPciBusInfoPtr;
+
+typedef struct _drmPciDeviceInfo {
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint16_t subvendor_id;
+    uint16_t subdevice_id;
+    uint8_t revision_id;
+} drmPciDeviceInfo, *drmPciDeviceInfoPtr;
+
+typedef struct _drmDevice {
+    char **nodes; /* DRM_NODE_MAX sized array */
+    int available_nodes; /* DRM_NODE_* bitmask */
+    int bustype;
+    union {
+        drmPciBusInfoPtr pci;
+    } businfo;
+    union {
+        drmPciDeviceInfoPtr pci;
+    } deviceinfo;
+} drmDevice, *drmDevicePtr;
+
+extern int drmGetDevice(int fd, drmDevicePtr *device);
+extern void drmFreeDevice(drmDevicePtr *device);
+
+extern int drmGetDevices(drmDevicePtr devices[], int max_devices);
+extern void drmFreeDevices(drmDevicePtr devices[], int count);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/media_driver/linux/common/os/i915/xf86drm.c
+++ b/media_driver/linux/common/os/i915/xf86drm.c
@@ -47,14 +47,16 @@
 #include <signal.h>
 #include <time.h>
 #include <sys/types.h>
-#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #define stat_t struct stat
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <stdarg.h>
-#ifdef HAVE_SYS_MKDEV_H
+#ifdef __sun //#ifdef MAJOR_IN_MKDEV
 # include <sys/mkdev.h> /* defines major(), minor(), and makedev() on Solaris */
+#endif
+#if defined(__GLIBC__) || defined(__linux__) //#ifdef MAJOR_IN_SYSMACROS
+# include <sys/sysmacros.h>
 #endif
 
 /* Not all systems have MAP_FAILED defined */

--- a/media_driver/linux/common/os/linux_skuwa_debug.h
+++ b/media_driver/linux/common/os/linux_skuwa_debug.h
@@ -35,7 +35,7 @@
 #define DEVINFO_WARNING(msg) ALOGW(msg)
 #define DEVINFO_ERROR(msg) ALOGE(msg)
 
-#elif defined(__linux__) // Linux libskuwa
+#elif !defined(_WIN32) // Linux libskuwa
 #include <stdio.h>
 #include <assert.h>
 

--- a/media_driver/linux/common/os/media_srcs.cmake
+++ b/media_driver/linux/common/os/media_srcs.cmake
@@ -25,10 +25,6 @@ if(ENABLE_PRODUCTION_KMD)
     media_include_subdirectory(i915_production)
 endif()
 
-# This is to include drm_device.h in cmrtlib, no cpp file needed.
-include_directories(${BS_DIR_MEDIA}/cmrtlib/linux/hardware)
-
-
 set(TMP_SOURCES_
     ${CMAKE_CURRENT_LIST_DIR}/hwinfo_linux.c
     ${CMAKE_CURRENT_LIST_DIR}/mos_context_specific.cpp

--- a/media_driver/linux/common/os/mos_interface.cpp
+++ b/media_driver/linux/common/os/mos_interface.cpp
@@ -34,7 +34,6 @@
 #include "mos_os_virtualengine_scalability_specific_next.h"
 #include "mos_graphicsresource_specific_next.h"
 #include "mos_bufmgr_priv.h"
-#include "drm_device.h"
 
 #if (_DEBUG || _RELEASE_INTERNAL)
 #include <stdlib.h>   //for simulate random OS API failure

--- a/media_driver/linux/ult/libdrm_mock/xf86drm_mock.c
+++ b/media_driver/linux/ult/libdrm_mock/xf86drm_mock.c
@@ -47,16 +47,17 @@
 #include <signal.h>
 #include <time.h>
 #include <sys/types.h>
-#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #define stat_t struct stat
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <stdarg.h>
-#ifdef HAVE_SYS_MKDEV_H
+#ifdef __sun //#ifdef MAJOR_IN_MKDEV
 # include <sys/mkdev.h> /* defines major(), minor(), and makedev() on Solaris */
 #endif
-#include <sys/sysmacros.h>
+#if defined(__GLIBC__) || defined(__linux__) //#ifdef MAJOR_IN_SYSMACROS
+# include <sys/sysmacros.h>
+#endif
 
 /* Not all systems have MAP_FAILED defined */
 #ifndef MAP_FAILED

--- a/media_driver/linux/ult/ult_app/CMakeLists.txt
+++ b/media_driver/linux/ult/ult_app/CMakeLists.txt
@@ -61,7 +61,7 @@ else ()
 endif ()
 
 add_executable(devult ${SOURCES})
-target_link_libraries(devult libgtest libdl.so)
+target_link_libraries(devult libgtest ${CMAKE_DL_LIBS})
 
 if (DEFINED BYPASS_MEDIA_ULT AND "${BYPASS_MEDIA_ULT}" STREQUAL "yes")
     # must explictly pass along BYPASS_MEDIA_ULT as yes then could bypass the running of media ult

--- a/media_driver/linux/ult/ult_app/cm/cm_test.h
+++ b/media_driver/linux/ult/ult_app/cm/cm_test.h
@@ -23,7 +23,6 @@
 #ifndef MEDIADRIVER_LINUX_CODECHAL_ULT_ULTAPP_CMTEST_H_
 #define MEDIADRIVER_LINUX_CODECHAL_ULT_ULTAPP_CMTEST_H_
 
-#include <malloc.h>
 #include "gtest/gtest.h"
 #include "mock_device.h"
 #include "../memory_leak_detector.h"
@@ -34,7 +33,7 @@ class CmTest: public testing::Test
 {
 public:
     static void* AllocateAlignedMemory(size_t size, size_t alignment)
-    { return memalign(alignment, size); }
+    { return aligned_alloc(alignment, size); }
 
     static void FreeAlignedMemory(void *memory) { free(memory); }
 

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -222,7 +222,7 @@ if (NOT DEFINED INCLUDED_LIBS OR "${INCLUDED_LIBS}" STREQUAL "")
     endif()
 
     target_compile_options( ${LIB_NAME} PUBLIC ${LIBGMM_CFLAGS_OTHER})
-    target_link_libraries ( ${LIB_NAME} ${LIBGMM_LIBRARIES})
+    target_link_libraries ( ${LIB_NAME} ${LIBGMM_LIBRARIES} drm)
 
     include(${MEDIA_EXT_CMAKE}/ext/media_feature_include_ext.cmake OPTIONAL)
 

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -202,7 +202,7 @@ MediaAddCommonTargetDefines(${LIB_NAME}_CP)
 bs_ufo_link_libraries_noBsymbolic(
     ${LIB_NAME}
     "${INCLUDED_LIBS}"
-    "${PKG_PCIACCESS_LIBRARIES} m pthread dl"
+    "${PKG_PCIACCESS_LIBRARIES} m pthread ${CMAKE_DL_LIBS}"
 )
 
 if (NOT DEFINED INCLUDED_LIBS OR "${INCLUDED_LIBS}" STREQUAL "")

--- a/media_softlet/agnostic/common/os/mos_utilities_next.cpp
+++ b/media_softlet/agnostic/common/os/mos_utilities_next.cpp
@@ -27,7 +27,6 @@
 
 #include <sstream>
 #include <fcntl.h>     //open
-#include <malloc.h>    // For memalign
 #include <stdlib.h>    // atoi atol
 #include <math.h>
 #include <time.h>     //for simulate random memory allcation failure

--- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
+++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
@@ -51,7 +51,9 @@
 #include <signal.h>
 #include <unistd.h>  // fork
 #include <algorithm>
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h> // backtrace
+#endif
 
 const char           *MosUtilitiesSpecificNext::m_szUserFeatureFile     = USER_FEATURE_FILE;
 MOS_PUF_KEYLIST      MosUtilitiesSpecificNext::m_ufKeyList              = nullptr;
@@ -2489,6 +2491,7 @@ void MosUtilities::MosTraceEvent(
                 MOS_FreeMemory(pTraceBuf);
             }
         }
+#ifdef HAVE_EXECINFO_H
         if (m_mosTraceFilter & (1ULL << TR_KEY_CALL_STACK))
         {
             // reserve space for header and stack size field.
@@ -2508,6 +2511,7 @@ void MosUtilities::MosTraceEvent(
                 size_t ret = write(MosUtilitiesSpecificNext::m_mosTraceFd, traceBuf, nLen);
             }
         }
+#endif /* HAVE_EXECINFO_H */
     }
     return;
 }

--- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
+++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
@@ -2094,7 +2094,7 @@ uint32_t MosUtilities::MosGetThreadId(
 
 uint32_t MosUtilities::MosGetCurrentThreadId()
 {
-    return (uint32_t)pthread_self();
+    return (uintptr_t)pthread_self();
 }
 
 MOS_STATUS MosUtilities::MosWaitThread(

--- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
+++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
@@ -27,7 +27,6 @@
 #define __MOS_UTILITIES_SPECIFIC_H__
 
 #include <map>
-#include <malloc.h>
 #include "mos_defs.h"
 #include "media_class_trace.h"
 
@@ -35,7 +34,7 @@
 
 #define NOT_FOUND            -1
 
-#define _aligned_malloc(size, alignment)  memalign(alignment, size)
+#define _aligned_malloc(size, alignment)  aligned_alloc(alignment, size)
 #define _aligned_free(ptr)                free(ptr)
 
 typedef void (*MOS_UserFeatureCallback)( void*, bool);

--- a/media_softlet/media_top_cmake.cmake
+++ b/media_softlet/media_top_cmake.cmake
@@ -29,6 +29,15 @@ option (MEDIA_RUN_TEST_SUITE "run google test module after install" ON)
 include(${MEDIA_SOFTLET_CMAKE}/media_gen_flags.cmake)
 include(${MEDIA_SOFTLET_CMAKE}/media_feature_flags.cmake)
 
+check_include_file_cxx("execinfo.h" HAVE_EXECINFO_H)
+if(HAVE_EXECINFO_H)
+    target_compile_definitions(${LIB_NAME} PRIVATE HAVE_EXECINFO_H)
+endif()
+
+check_library_exists(execinfo backtrace "" HAVE_LIBEXECINFO)
+if(HAVE_LIBEXECINFO)
+    target_link_libraries (${LIB_NAME} PRIVATE execinfo)
+endif()
 
 if(NOT DEFINED SKIP_GMM_CHECK)
     # checking dependencies


### PR DESCRIPTION
Depends on https://github.com/intel/libva/pull/363 and https://github.com/intel/gmmlib/pull/68

<details><summary>Build logs</summary>

http://beefy9.nyi.freebsd.org/data/latest-per-pkg/libva-intel-media-driver/21.1.1/114amd64-default.log
http://beefy10.nyi.freebsd.org/data/latest-per-pkg/libva-intel-media-driver/21.1.1/114i386-default.log
http://beefy6.nyi.freebsd.org/data/latest-per-pkg/libva-intel-media-driver/21.1.1/122amd64-default.log
http://beefy5.nyi.freebsd.org/data/latest-per-pkg/libva-intel-media-driver/21.1.1/122i386-default.log
http://beefy18.nyi.freebsd.org/data/latest-per-pkg/libva-intel-media-driver/21.1.1/main-amd64-default.log
http://beefy17.nyi.freebsd.org/data/latest-per-pkg/libva-intel-media-driver/21.1.1/main-i386-default.log
https://sting.dragonflybsd.org/dports/logs/multimedia___libva-intel-media-driver.log
</details>

<details><summary>Tests output</summary>

```
[==========] Running 43 tests from 13 test cases.
[----------] Global test environment set-up.
[----------] 1 test from MediaCapsDdiTest
[ RUN      ] MediaCapsDdiTest.DecodeEncodeProfile
[       OK ] MediaCapsDdiTest.DecodeEncodeProfile (11 ms)
[----------] 1 test from MediaCapsDdiTest (11 ms total)

[----------] 2 tests from MediaDecodeDdiTest
[ RUN      ] MediaDecodeDdiTest.DecodeHEVCLong
[       OK ] MediaDecodeDdiTest.DecodeHEVCLong (6 ms)
[ RUN      ] MediaDecodeDdiTest.DecodeAVCLong
[       OK ] MediaDecodeDdiTest.DecodeAVCLong (10 ms)
[----------] 2 tests from MediaDecodeDdiTest (16 ms total)

[----------] 2 tests from MediaEncodeDdiTest
[ RUN      ] MediaEncodeDdiTest.EncodeHEVC_DualPipe
[       OK ] MediaEncodeDdiTest.EncodeHEVC_DualPipe (10 ms)
[ RUN      ] MediaEncodeDdiTest.EncodeAVC_DualPipe
[       OK ] MediaEncodeDdiTest.EncodeAVC_DualPipe (12 ms)
[----------] 2 tests from MediaEncodeDdiTest (22 ms total)

[----------] 5 tests from KernelTest
[ RUN      ] KernelTest.LoadDestroyProgram
[       OK ] KernelTest.LoadDestroyProgram (67 ms)
[ RUN      ] KernelTest.LoadWrongIsa
[       OK ] KernelTest.LoadWrongIsa (13 ms)
[ RUN      ] KernelTest.CreateKernel
[       OK ] KernelTest.CreateKernel (26 ms)
[ RUN      ] KernelTest.SetArgument
[       OK ] KernelTest.SetArgument (78 ms)
[ RUN      ] KernelTest.SetSamplerBTI
[       OK ] KernelTest.SetSamplerBTI (67 ms)
[----------] 5 tests from KernelTest (251 ms total)

[----------] 3 tests from BufferTest
[ RUN      ] BufferTest.MultipleSizes
[       OK ] BufferTest.MultipleSizes (79 ms)
[ RUN      ] BufferTest.ReadWrite
[       OK ] BufferTest.ReadWrite (13 ms)
[ RUN      ] BufferTest.Initialization
[       OK ] BufferTest.Initialization (14 ms)
[----------] 3 tests from BufferTest (106 ms total)

[----------] 2 tests from BufferUPTest
[ RUN      ] BufferUPTest.MultipleSizes
[       OK ] BufferUPTest.MultipleSizes (79 ms)
[ RUN      ] BufferUPTest.InvalidSystemMemory
[       OK ] BufferUPTest.InvalidSystemMemory (28 ms)
[----------] 2 tests from BufferUPTest (107 ms total)

[----------] 8 tests from DeviceTest
[ RUN      ] DeviceTest.Destroy
[       OK ] DeviceTest.Destroy (13 ms)
[ RUN      ] DeviceTest.NoScratchSpace
[       OK ] DeviceTest.NoScratchSpace (18 ms)
[ RUN      ] DeviceTest.QueryGpuPlatform
[       OK ] DeviceTest.QueryGpuPlatform (14 ms)
[ RUN      ] DeviceTest.QueryThreadCount
[       OK ] DeviceTest.QueryThreadCount (13 ms)
[ RUN      ] DeviceTest.QueryFrequency
[       OK ] DeviceTest.QueryFrequency (13 ms)
[ RUN      ] DeviceTest.QueryPlatformInformation
[       OK ] DeviceTest.QueryPlatformInformation (13 ms)
[ RUN      ] DeviceTest.SetThreadCount
[       OK ] DeviceTest.SetThreadCount (13 ms)
[ RUN      ] DeviceTest.GetInvalidCap
[       OK ] DeviceTest.GetInvalidCap (13 ms)
[----------] 8 tests from DeviceTest (111 ms total)

[----------] 2 tests from QueueTest
[ RUN      ] QueueTest.CreateTwice
[       OK ] QueueTest.CreateTwice (14 ms)
[ RUN      ] QueueTest.EnqueueWithoutTask
[       OK ] QueueTest.EnqueueWithoutTask (13 ms)
[----------] 2 tests from QueueTest (27 ms total)

[----------] 7 tests from Surface2DTest
[ RUN      ] Surface2DTest.MultipleSizes
[       OK ] Surface2DTest.MultipleSizes (172 ms)
[ RUN      ] Surface2DTest.PlanarFormats
[       OK ] Surface2DTest.PlanarFormats (80 ms)
[ RUN      ] Surface2DTest.DestroyNull
[       OK ] Surface2DTest.DestroyNull (14 ms)
[ RUN      ] Surface2DTest.ReadWrite
[       OK ] Surface2DTest.ReadWrite (29 ms)
[ RUN      ] Surface2DTest.ReadWriteWithStride
[       OK ] Surface2DTest.ReadWriteWithStride (14 ms)
[ RUN      ] Surface2DTest.Initialization
[       OK ] Surface2DTest.Initialization (13 ms)
[ RUN      ] Surface2DTest.GetInfo
[       OK ] Surface2DTest.GetInfo (27 ms)
[----------] 7 tests from Surface2DTest (349 ms total)

[----------] 3 tests from Surface2DUPTest
[ RUN      ] Surface2DUPTest.MultipleSizes
[       OK ] Surface2DUPTest.MultipleSizes (138 ms)
[ RUN      ] Surface2DUPTest.InvalidSystemMemory
[       OK ] Surface2DUPTest.InvalidSystemMemory (27 ms)
[ RUN      ] Surface2DUPTest.PlanarFormat
[       OK ] Surface2DUPTest.PlanarFormat (53 ms)
[----------] 3 tests from Surface2DUPTest (218 ms total)

[----------] 4 tests from Surface3DTest
[ RUN      ] Surface3DTest.MultipleSizes
[       OK ] Surface3DTest.MultipleSizes (135 ms)
[ RUN      ] Surface3DTest.Abgr16Format
[       OK ] Surface3DTest.Abgr16Format (27 ms)
[ RUN      ] Surface3DTest.ReadWrite
[       OK ] Surface3DTest.ReadWrite (13 ms)
[ RUN      ] Surface3DTest.Initialization
[       OK ] Surface3DTest.Initialization (14 ms)
[----------] 4 tests from Surface3DTest (189 ms total)

[----------] 1 test from TaskTest
[ RUN      ] TaskTest.CreateDestroy
[       OK ] TaskTest.CreateDestroy (14 ms)
[----------] 1 test from TaskTest (14 ms total)

[----------] 3 tests from ThreadSpaceTest
[ RUN      ] ThreadSpaceTest.MultipleSizes
[       OK ] ThreadSpaceTest.MultipleSizes (27 ms)
[ RUN      ] ThreadSpaceTest.DependencyPattern
[       OK ] ThreadSpaceTest.DependencyPattern (27 ms)
[ RUN      ] ThreadSpaceTest.MediaWalkingPattern
[       OK ] ThreadSpaceTest.MediaWalkingPattern (29 ms)
[----------] 3 tests from ThreadSpaceTest (84 ms total)

[----------] Global test environment tear-down
[==========] 43 tests from 13 test cases ran. (1505 ms total)
[  PASSED  ] 43 tests.
```
</details>

Note, to avoid regressing build in future consider [FreeBSD-friendly CI](https://wiki.freebsd.org/HostedCI).
