### PR TITLE
media_libva_caps: add VAConfigAttribEncSliceStructure caps for VAEntrypointEncSliceLP

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -622,7 +622,8 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     attrib.type = VAConfigAttribEncSliceStructure;
     if (entrypoint == VAEntrypointEncSliceLP)
     {
-        attrib.value = VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS | VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE;
+        attrib.value = VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS | VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE |
+                       VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS;
     }
     else
     {


### PR DESCRIPTION

Add VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS for VAEntrypointEncSliceLP.

Fix #805.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>

Not sure whether it's proper to fix like this, please help to comment.
