### PR TITLE
[Encode][HEVC] Fix max width and height caps for gen9 platforms

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -443,11 +443,7 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     {
         attrib.value = ENCODE_JPEG_MAX_PIC_WIDTH;
     }
-    if(IsHevcProfile(profile))
-    {
-        attrib.value = CODEC_8K_MAX_PIC_WIDTH;
-    }
-    if(IsAvcProfile(profile) || IsVp8Profile(profile))
+    if(IsHevcProfile(profile) || IsAvcProfile(profile) || IsVp8Profile(profile))
     {
         attrib.value = CODEC_4K_MAX_PIC_WIDTH;
     }
@@ -459,11 +455,7 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     {
         attrib.value = ENCODE_JPEG_MAX_PIC_HEIGHT;
     }
-    if(IsHevcProfile(profile))
-    {
-        attrib.value = CODEC_8K_MAX_PIC_HEIGHT;
-    }
-    if(IsAvcProfile(profile) || IsVp8Profile(profile))
+    if(IsHevcProfile(profile) || IsAvcProfile(profile) || IsVp8Profile(profile))
     {
         attrib.value = CODEC_4K_MAX_PIC_HEIGHT;
     }


### PR DESCRIPTION
According to: https://github.com/intel/media-driver/blob/master/docs/media_features.md
Also in [MediaLibvaCaps::CheckEncodeResolution](https://github.com/intel/media-driver/blob/2711a3a1c3339b1a5f5d5e1c76fccd24f1998d81/media_driver/linux/common/ddi/media_libva_caps.cpp#L1954) function we check the max size as 4k.

Fixes #550

Signed-off-by: egorovdanil <danil.egorov@intel.com>