### PR TITLE
Fix VC1 decode output corruption on GEN12

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_vc1_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_vc1_g12.cpp
@@ -528,6 +528,33 @@ MOS_STATUS CodechalDecodeVc1G12::DecodePrimitiveLevelVLD()
             int32_t lLength = slc->slice_data_size >> 3;
             int32_t lOffset = slc->macroblock_offset >> 3;
 
+            CodechalResLock ResourceLock(m_osInterface, &m_resDataBuffer);
+            auto buf = (uint8_t*)ResourceLock.Lock(CodechalResLock::readOnly);
+            buf += slc->slice_data_offset;
+            if (lOffset > 3 && buf != nullptr &&
+                m_vc1PicParams->sequence_fields.AdvancedProfileFlag)
+            {
+                int i = 0;
+                int j = 0;
+                for (i = 0, j = 0; i < lOffset - 1; i++, j++)
+                {
+                    if (!buf[j] && !buf[j + 1] && buf[j + 2] == 3 && buf[j + 3] < 4)
+                    {
+                        i++, j += 2;
+                    }
+                }
+                if (i == lOffset - 1)
+                {
+                    if (!buf[j] && !buf[j + 1] && buf[j + 2] == 3 && buf[j + 3] < 4)
+                    {
+                        buf[j + 2] = 0;
+                        j++;
+                    }
+                    j++;
+                }
+                lOffset = (8 * j + slc->macroblock_offset % 8)>>3;
+            }
+
             // Check that the slice data does not overrun the bitstream buffer size
             if ((slc->slice_data_offset + lLength) > m_dataSize)
             {


### PR DESCRIPTION
This is a copy of commit 18457ca9

Refer to https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/issues/220 for
issue details