### PR TITLE
Ignore the private VP9 status buffer

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_vp9.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_vp9.cpp
@@ -1062,7 +1062,12 @@ VAStatus DdiEncodeVp9::ReportExtraStatus(
     codedBufStatus->next_frame_width = encodeStatusReport->NextFrameWidthMinus1 + 1;
     codedBufStatus->next_frame_height = encodeStatusReport->NextFrameHeightMinus1 + 1;
 
-    codedBufferSegment->next = codedBufStatus;
+    /*
+     * Ignore the private status buffer temporarily. According to the comment for VACodedBufferVP9Status in VA-API,
+     * driver must set codedBufferSegment->status to be VA_CODED_BUF_STATUS_CODEC_SPECIFIC, however
+     * VA_CODED_BUF_STATUS_CODEC_SPECIFIC is not defined in VA-API
+     */
+    // codedBufferSegment->next = codedBufStatus;
 
     return vaStatus;
 }


### PR DESCRIPTION
Without a flag, user doesn't know VACodedBufferSegment.next pointing
to a private segment status, so we have to ignore this private
status buffer. Otherwise it will result in segmentation fault if user
takes VACodedBufferSegment.next as a VACodedBufferSegment pointer

Example:
gst-launch-1.0 videotestsrc !
video/x-raw,format=NV12,width=3840,height=2160 ! vaapivp9enc !
matroskamux ! filesink location=output.vp9