### PR TITLE
Fix Y410 YUV dump.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_debug.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_debug.cpp
@@ -686,7 +686,6 @@ MOS_STATUS CodechalDebugInterface::DumpYUVSurface(
             break;
         case  Format_Y416:
         case  Format_AUYV:
-        case  Format_Y410: //444 10bit
         case  Format_R10G10B10A2:
             height *= 2;
             break;


### PR DESCRIPTION
It should not be height*2 because one pixel only occupies DWORD.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>