### PR TITLE
media_libva_caps_g11: add caps query support for Y210 in VAEntrypointEncSlice

### DIFF
--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -1041,6 +1041,20 @@ VAStatus MediaLibvaCapsG11::QuerySurfaceAttributes(
             attribs[i].value.value.i = VA_FOURCC_Y410;
             i++;
         }
+        else if(profile == VAProfileHEVCMain422_10)
+        {
+            attribs[i].type = VASurfaceAttribPixelFormat;
+            attribs[i].value.type = VAGenericValueTypeInteger;
+            attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+            attribs[i].value.value.i = VA_FOURCC_YUY2;
+            i++;
+
+            attribs[i].type = VASurfaceAttribPixelFormat;
+            attribs[i].value.type = VAGenericValueTypeInteger;
+            attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+            attribs[i].value.value.i = VA_FOURCC_Y210;
+            i++;
+        }
         else if (profile == VAProfileVP9Profile1)
         {
             attribs[i].type = VASurfaceAttribPixelFormat;


### PR DESCRIPTION

Signed-off-by: Linjie Fu <linjie.fu@intel.com>

Fix the HEVC 422 10-bit encoding for FFmpeg vaapi.