### PR TITLE
media_libva_caps_g11: add max resolution support for vp8 encode

### DIFF
--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -1092,7 +1092,7 @@ VAStatus MediaLibvaCapsG11::QuerySurfaceAttributes(
         {
             attribs[i].value.value.i = CODEC_8K_MAX_PIC_WIDTH;
         }
-        else if(IsAvcProfile(profile))
+        else if(IsAvcProfile(profile) || IsVp8Profile(profile))
         {
             attribs[i].value.value.i = CODEC_4K_MAX_PIC_WIDTH;
         }
@@ -1114,7 +1114,7 @@ VAStatus MediaLibvaCapsG11::QuerySurfaceAttributes(
         {
             attribs[i].value.value.i = CODEC_8K_MAX_PIC_HEIGHT;
         }
-        else if(IsAvcProfile(profile))
+        else if(IsAvcProfile(profile) || IsVp8Profile(profile))
         {
             attribs[i].value.value.i = CODEC_4K_MAX_PIC_HEIGHT;
         }


### PR DESCRIPTION
Based on docs/media_features.md, the Max Res supported for ICL is 4K.

Same support in common media_libva_caps:
https://github.com/intel/media-driver/blob/master/media_driver/linux/common/ddi/media_libva_caps.cpp#L2640

Signed-off-by: Linjie Fu <linjie.fu@intel.com>