### PR TITLE
Enable the WA for slice header insertion on GEN12

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -291,8 +291,7 @@ static bool InitTglMediaWa(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_WA(waTable, WaMidBatchPreemption, 0);
     MEDIA_WR_WA(waTable, WaArbitraryNumMbsInSlice, 1);
 
-    /* Not needed any more for VDENC */
-    MEDIA_WR_WA(waTable, WaSuperSliceHeaderPacking, 0);
+    MEDIA_WR_WA(waTable, WaSuperSliceHeaderPacking, 1);
 
     MEDIA_WR_WA(waTable, WaSFC270DegreeRotation, 0);
 


### PR DESCRIPTION
WaSuperSliceHeaderPacking is still needed for AVC VDEnc on GEN12, otherwise the output is
corrupted if the first 4 bytes is '00 00 00 01' in the packed slice header.

example:

gst-launch-1.0 videotestsrc num-buffers=500 ! video/x-raw,format=NV12 !
vaapih264enc tune=low-power ! filesink location=output.h264

Fixes https://github.com/intel/media-driver/issues/853