### PR TITLE
report the attribute, each refer list should be not empty when it is …

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -928,7 +928,7 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     if (IsHevcProfile(profile) && (entrypoint == VAEntrypointEncSliceLP))
     {
         attrib.type = (VAConfigAttribType) VAConfigAttribPredictionDirection;
-        attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS;
+        attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
         (*attribList)[attrib.type] = attrib.value;
     }
     return status;

--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1634,7 +1634,7 @@ VAStatus MediaLibvaCapsG12::CreateEncAttributes(
         else if (IsHevcProfile(profile))
         {
             attrib.type = (VAConfigAttribType) VAConfigAttribPredictionDirection;
-            attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE;
+            attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
             (*attribList)[attrib.type] = attrib.value;
         }
     }


### PR DESCRIPTION
…inter prediction

this attribute is used to distinguish whether driver support P frame or just support low delay B frame

Signed-off-by: XinfengZhang <carl.zhang@intel.com>