### PR TITLE
Fix bad vertical alignment and  corrupted image

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_util.cpp
+++ b/media_driver/linux/common/ddi/media_libva_util.cpp
@@ -229,16 +229,13 @@ VAStatus DdiMediaUtil_AllocateSurface(
         case Media_Format_VYUY:
         case Media_Format_YVYU:
         case Media_Format_UYVY:
-            if (VA_SURFACE_ATTRIB_USAGE_HINT_ENCODER != mediaSurface->surfaceUsageHint)
-            {
 #if UFO_GRALLOC_NEW_FORMAT
-                 //Planar type surface align 64 to improve performance.
-                alignedHeight = MOS_ALIGN_CEIL(height, 64);
+            //Planar type surface align 64 to improve performance.
+            alignedHeight = MOS_ALIGN_CEIL(height, 64);
 #else
-                //Planar type surface align 32 to improve performance.
-                alignedHeight = MOS_ALIGN_CEIL(height, 32);
+            //Planar type surface align 32 to improve performance.
+            alignedHeight = MOS_ALIGN_CEIL(height, 32);
 #endif
-            }
             alignedWidth = MOS_ALIGN_CEIL(width, 8);
             tileformat  = I915_TILING_Y;
             break;


### PR DESCRIPTION
When encoding with certain resolutions (eg. 320x240) and with
surfaceUsageHint set to VA_SURFACE_ATTRIB_USAGE_HINT_ENCODER,
media driver did not align color planes vertically. Nevertheless,
encoder expects aligned color planes, and this caused corrupted
colors in encoded frames. Fix this by always enabling vertical
alignment when the surface format is UYVY.

Change-Id: Ied4720186d169d14b734fd42c5692a20f5537df0