### PR TITLE
[Encode][RIR] correct the value of "IntraRefreshMBSizeMinusOne" to kernel or hardware.

### DIFF
--- a/media_driver/agnostic/gen10/codec/hal/codechal_encode_avc_g10.cpp
+++ b/media_driver/agnostic/gen10/codec/hal/codechal_encode_avc_g10.cpp
@@ -4956,8 +4956,6 @@ MOS_STATUS CodechalEncodeAvcEncG10::SetCurbeAvcMbEnc(
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.m_encCurbe.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         if (ROLLING_I_SQUARE == picParams->EnableRollingIntraRefresh && RATECONTROL_CQP != seqParams->RateControlMethod)
         {
             /*BRC update kernel updates these CURBE to MBEnc*/
@@ -4973,7 +4971,7 @@ MOS_STATUS CodechalEncodeAvcEncG10::SetCurbeAvcMbEnc(
             cmd.m_encCurbe.DW48.IntraRefreshMBx   = picParams->IntraRefreshMBx; /* MB column number */
             cmd.m_encCurbe.DW61.IntraRefreshMBy   = picParams->IntraRefreshMBy; /* MB row number */
         }
-        cmd.m_encCurbe.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.m_encCurbe.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.m_encCurbe.DW48.IntraRefreshQPDelta        = picParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen10/hw/vdbox/mhw_vdbox_vdenc_g10_X.cpp
+++ b/media_driver/agnostic/gen10/hw/vdbox/mhw_vdbox_vdenc_g10_X.cpp
@@ -1120,7 +1120,7 @@ MOS_STATUS MhwVdboxVdencInterfaceG10::AddVdencImgStateCmd(
         cmd.DW21.IntraRefreshEnableRollingIEnable = avcPicParams->EnableRollingIntraRefresh != ROLLING_I_DISABLED ? 1 : 0;        // 0->Row based ; 1->Column based
         cmd.DW21.IntraRefreshMode                 = avcPicParams->EnableRollingIntraRefresh == ROLLING_I_ROW ? 0 : 1;
         cmd.DW21.IntraRefreshMBPos                = avcPicParams->IntraRefreshMBNum;
-        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB;
+        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB - 1;
         cmd.DW21.QpAdjustmentForRollingI          = avcPicParams->IntraRefreshQPDelta;
     }
 

--- a/media_driver/agnostic/gen11/codec/hal/codechal_encode_avc_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_encode_avc_g11.cpp
@@ -6557,8 +6557,6 @@ MOS_STATUS CodechalEncodeAvcEncG11::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBENC_
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.m_dw32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         if (ROLLING_I_SQUARE == picParams->EnableRollingIntraRefresh && RATECONTROL_CQP != seqParams->RateControlMethod)
         {
             /*BRC update kernel updates these CURBE to MBEnc*/
@@ -6574,7 +6572,7 @@ MOS_STATUS CodechalEncodeAvcEncG11::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBENC_
             cmd.m_dw48.IntraRefreshMBx   = picParams->IntraRefreshMBx; /* MB column number */
             cmd.m_dw61.IntraRefreshMBy   = picParams->IntraRefreshMBy; /* MB row number */
         }
-        cmd.m_dw48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.m_dw48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.m_dw48.IntraRefreshQPDelta        = picParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_vdenc_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_vdenc_g11_X.h
@@ -1354,7 +1354,7 @@ public:
             cmd.DW21.IntraRefreshEnableRollingIEnable = avcPicParams->EnableRollingIntraRefresh != ROLLING_I_DISABLED ? 1 : 0;        // 0->Row based ; 1->Column based
             cmd.DW21.IntraRefreshMode                 = avcPicParams->EnableRollingIntraRefresh == ROLLING_I_ROW ? 0 : 1;
             cmd.DW21.IntraRefreshMBPos                = avcPicParams->IntraRefreshMBNum;
-            cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB;
+            cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB - 1;
             cmd.DW21.QpAdjustmentForRollingI          = avcPicParams->IntraRefreshQPDelta;
         }
 

--- a/media_driver/agnostic/gen12/codec/hal/codechal_encode_avc_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_encode_avc_g12.cpp
@@ -3537,8 +3537,6 @@ MOS_STATUS CodechalEncodeAvcEncG12::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBENC_
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.m_curbe.DW32.m_multiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         if (ROLLING_I_SQUARE == picParams->EnableRollingIntraRefresh && RATECONTROL_CQP != seqParams->RateControlMethod)
         {
             /*BRC update kernel updates these CURBE to MBEnc*/
@@ -3554,7 +3552,7 @@ MOS_STATUS CodechalEncodeAvcEncG12::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBENC_
             cmd.m_curbe.DW48.m_IntraRefreshMBx   = picParams->IntraRefreshMBx; /* MB column number */
             cmd.m_curbe.DW61.m_IntraRefreshMBy   = picParams->IntraRefreshMBy; /* MB row number */
         }
-        cmd.m_curbe.DW48.m_IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.m_curbe.DW48.m_IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.m_curbe.DW48.m_IntraRefreshQPDelta        = picParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_vdenc_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_vdenc_g12_X.h
@@ -1671,7 +1671,7 @@ public:
             cmd.DW21.IntraRefreshEnableRollingIEnable = avcPicParams->EnableRollingIntraRefresh != ROLLING_I_DISABLED ? 1 : 0;        // 0->Row based ; 1->Column based
             cmd.DW21.IntraRefreshMode                 = avcPicParams->EnableRollingIntraRefresh == ROLLING_I_ROW ? 0 : 1;
             cmd.DW21.IntraRefreshMBPos                = avcPicParams->IntraRefreshMBNum;
-            cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB;
+            cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB - 1;
             cmd.DW21.QpAdjustmentForRollingI          = avcPicParams->IntraRefreshQPDelta;
         }
 

--- a/media_driver/agnostic/gen8/codec/hal/codechal_encode_avc_g8.cpp
+++ b/media_driver/agnostic/gen8/codec/hal/codechal_encode_avc_g8.cpp
@@ -4797,8 +4797,6 @@ MOS_STATUS CodechalEncodeAvcEncG8::SetCurbeAvcMbEnc(
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         if (ROLLING_I_SQUARE == picParams->EnableRollingIntraRefresh && RATECONTROL_CQP != seqParams->RateControlMethod)
         {
         /*BRC update kernel updates these CURBE to MBEnc*/
@@ -4814,7 +4812,7 @@ MOS_STATUS CodechalEncodeAvcEncG8::SetCurbeAvcMbEnc(
         cmd.DW48.IntraRefreshMBx            = picParams->IntraRefreshMBx; /* MB column number */
         cmd.DW58.IntraRefreshMBy            = picParams->IntraRefreshMBy; /* MB row number */
         }
-        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.DW48.IntraRefreshQPDelta        = picParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen8/codec/hal/codechal_fei_avc_g8.cpp
+++ b/media_driver/agnostic/gen8/codec/hal/codechal_fei_avc_g8.cpp
@@ -7501,10 +7501,8 @@ MOS_STATUS CodechalEncodeAvcEncFeiG8::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBEN
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         cmd.DW48.IntraRefreshMBNum = picParams->IntraRefreshMBNum; /* MB row or column number */
-        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.DW48.IntraRefreshQPDelta = picParams->IntraRefreshQPDelta;
     }
 

--- a/media_driver/agnostic/gen9/codec/hal/codechal_fei_avc_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_fei_avc_g9.cpp
@@ -4808,10 +4808,8 @@ MOS_STATUS CodechalEncodeAvcEncFeiG9::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBEN
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         cmd.DW48.IntraRefreshMBNum = picParams->IntraRefreshMBNum; /* MB row or column number */
-        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.DW48.IntraRefreshQPDelta = picParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen9_bxt/codec/hal/codechal_encode_avc_g9_bxt.cpp
+++ b/media_driver/agnostic/gen9_bxt/codec/hal/codechal_encode_avc_g9_bxt.cpp
@@ -2455,10 +2455,8 @@ MOS_STATUS CodechalEncodeAvcEncG9Bxt::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBEN
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         Cmd.common.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         Cmd.common.DW48.IntraRefreshMBNum = pPicParams->IntraRefreshMBNum; /* MB row or column number */
-        Cmd.common.DW48.IntraRefreshUnitInMBMinus1 = pPicParams->IntraRefreshUnitinMB;
+        Cmd.common.DW48.IntraRefreshUnitInMBMinus1 = pPicParams->IntraRefreshUnitinMB - 1;
         Cmd.common.DW48.IntraRefreshQPDelta = pPicParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_vdenc_g9_bxt.cpp
+++ b/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_vdenc_g9_bxt.cpp
@@ -207,7 +207,7 @@ MOS_STATUS MhwVdboxVdencInterfaceG9Bxt::AddVdencImgStateCmd(
         cmd.DW21.IntraRefreshEnableRollingIEnable = avcPicParams->EnableRollingIntraRefresh != ROLLING_I_DISABLED ? 1 : 0;        // 0->Row based ; 1->Column based
         cmd.DW21.IntraRefreshMode                 = avcPicParams->EnableRollingIntraRefresh == ROLLING_I_ROW ? 0 : 1;
         cmd.DW21.IntraRefreshMBPos                = avcPicParams->IntraRefreshMBNum;
-        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB;
+        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB - 1;
         cmd.DW21.QpAdjustmentForRollingI          = avcPicParams->IntraRefreshQPDelta;
     }
 

--- a/media_driver/agnostic/gen9_kbl/codec/hal/codechal_encode_avc_g9_kbl.cpp
+++ b/media_driver/agnostic/gen9_kbl/codec/hal/codechal_encode_avc_g9_kbl.cpp
@@ -2845,8 +2845,6 @@ MOS_STATUS CodechalEncodeAvcEncG9Kbl::SetCurbeAvcMbEnc(
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         cmd.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-         across one P frame to another P frame, as needed by the RollingI algo */
         if (ROLLING_I_SQUARE == picParams->EnableRollingIntraRefresh && RATECONTROL_CQP != seqParams->RateControlMethod)
         {
             /*BRC update kernel updates these CURBE to MBEnc*/
@@ -2862,7 +2860,7 @@ MOS_STATUS CodechalEncodeAvcEncG9Kbl::SetCurbeAvcMbEnc(
             cmd.DW48.IntraRefreshMBx = picParams->IntraRefreshMBx; /* MB column number */
             cmd.DW61.IntraRefreshMBy = picParams->IntraRefreshMBy; /* MB row number */
         }
-        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB;
+        cmd.DW48.IntraRefreshUnitInMBMinus1 = picParams->IntraRefreshUnitinMB - 1;
         cmd.DW48.IntraRefreshQPDelta = picParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_vdenc_g9_kbl.cpp
+++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_vdenc_g9_kbl.cpp
@@ -260,7 +260,7 @@ MOS_STATUS MhwVdboxVdencInterfaceG9Kbl::AddVdencImgStateCmd(
         cmd.DW21.IntraRefreshEnableRollingIEnable = avcPicParams->EnableRollingIntraRefresh != ROLLING_I_DISABLED ? 1 : 0;        // 0->Row based ; 1->Column based
         cmd.DW21.IntraRefreshMode                 = avcPicParams->EnableRollingIntraRefresh == ROLLING_I_ROW ? 0 : 1;
         cmd.DW21.IntraRefreshMBPos                = avcPicParams->IntraRefreshMBNum;
-        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB;
+        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB - 1;
         cmd.DW21.QpAdjustmentForRollingI          = avcPicParams->IntraRefreshQPDelta;
     }
 

--- a/media_driver/agnostic/gen9_skl/codec/hal/codechal_encode_avc_g9_skl.cpp
+++ b/media_driver/agnostic/gen9_skl/codec/hal/codechal_encode_avc_g9_skl.cpp
@@ -2455,10 +2455,8 @@ MOS_STATUS CodechalEncodeAvcEncG9Skl::SetCurbeAvcMbEnc(PCODECHAL_ENCODE_AVC_MBEN
         /* Multiple predictor should be completely disabled for the RollingI feature. This does not lead to much quality drop for P frames especially for TU as 1 */
         Cmd.common.DW32.MultiPredL0Disable = CODECHAL_ENCODE_AVC_MULTIPRED_DISABLE;
 
-        /* Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks
-        across one P frame to another P frame, as needed by the RollingI algo */
         Cmd.common.DW48.IntraRefreshMBNum = pPicParams->IntraRefreshMBNum; /* MB row or column number */
-        Cmd.common.DW48.IntraRefreshUnitInMBMinus1 = pPicParams->IntraRefreshUnitinMB;
+        Cmd.common.DW48.IntraRefreshUnitInMBMinus1 = pPicParams->IntraRefreshUnitinMB - 1;
         Cmd.common.DW48.IntraRefreshQPDelta = pPicParams->IntraRefreshQPDelta;
     }
     else

--- a/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_vdenc_g9_skl.cpp
+++ b/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_vdenc_g9_skl.cpp
@@ -202,7 +202,7 @@ MOS_STATUS MhwVdboxVdencInterfaceG9Skl::AddVdencImgStateCmd(
         cmd.DW21.IntraRefreshEnableRollingIEnable = avcPicParams->EnableRollingIntraRefresh != ROLLING_I_DISABLED ? 1 : 0;        // 0->Row based ; 1->Column based
         cmd.DW21.IntraRefreshMode                 = avcPicParams->EnableRollingIntraRefresh == ROLLING_I_ROW ? 0 : 1;
         cmd.DW21.IntraRefreshMBPos                = avcPicParams->IntraRefreshMBNum;
-        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB;
+        cmd.DW21.IntraRefreshMBSizeMinusOne       = avcPicParams->IntraRefreshUnitinMB - 1;
         cmd.DW21.QpAdjustmentForRollingI          = avcPicParams->IntraRefreshQPDelta;
     }
 

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -510,6 +510,10 @@ VAStatus DdiEncodeAvc::ParseMiscParameterRIR(void *data)
         return MOS_STATUS_INVALID_PARAMETER;
     }
     picParams->IntraRefreshQPDelta = vaEncMiscParamRIR->qp_delta_for_inserted_intra;
+    if (1 > picParams->IntraRefreshUnitinMB)
+    {
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
+    }
 
     // UMD tracks the MBx/MBy for the intra square
     uint32_t rightBorder  = ((seqParams->FrameWidth + CODECHAL_ENCODE_AVC_ROI_WIDTH_SCALE_FACTOR - 1) / CODECHAL_ENCODE_AVC_ROI_WIDTH_SCALE_FACTOR) - 1;


### PR DESCRIPTION
Correctly set the value of "IntraRefreshMBSizeMinusOne".

The incorrect assignment makes that in the encoded stream, size of the Intra refresh MBs is actual VAEncMiscParameterRIR::intra_insert_size + 1, which is one bug as it fails the documentation in VAAPI which says that "intra_insert_size" "Indicates the number of columns or rows in MB".
In the source file, there is comment says "Pass the same IntraRefreshUnit to the kernel w/o the adjustment by -1, so as to have an overlap of one MB row or column of Intra macroblocks across one P frame to another P frame, as needed by the RollingI algo", explains the reason for the assignment.
I don't understand why the "RollingI algo" requires overlap of one MB row of column. Even it's the case, it should be set to VAEncMiscParameterRIR::intra_insertion_location from VAAPI application level to make the overlap.

Change-Id: I0ebc387dfd92f58dec313fc53eca8dd6a6a20110