### PR TITLE
use gmmlib caculate the NV12 surface offset

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -4406,12 +4406,24 @@ VAStatus DdiMedia_DeriveImage (
     vaimg->height                   = mediaSurface->iRealHeight;
     vaimg->format.byte_order        = VA_LSB_FIRST;
 
+    GMM_RESOURCE_INFO          *gmmResourceInfo = mediaSurface->pGmmResourceInfo;
+    GMM_REQ_OFFSET_INFO reqInfo     = {0};
+    reqInfo.Plane                   = GMM_PLANE_U;
+    reqInfo.ReqRender               = 1;
+    gmmResourceInfo->GetOffset(reqInfo);
+    uint32_t offsetU                = reqInfo.Render.Offset;
+    MOS_ZeroMemory(&reqInfo, sizeof(GMM_REQ_OFFSET_INFO));
+    reqInfo.Plane                   = GMM_PLANE_V;
+    reqInfo.ReqRender               = 1;
+    gmmResourceInfo->GetOffset(reqInfo);
+    uint32_t offsetV                = reqInfo.Render.Offset;
+    vaimg->data_size                = (uint32_t)gmmResourceInfo->GetSizeSurface();
+
     switch( mediaSurface->format )
     {
     case Media_Format_YV12:
     case Media_Format_I420:
         vaimg->format.bits_per_pixel    = 12;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 3 / 2;
         vaimg->num_planes               = 3;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->pitches[1]               =
@@ -4425,7 +4437,6 @@ VAStatus DdiMedia_DeriveImage (
     case Media_Format_A8R8G8B8:
         vaimg->format.bits_per_pixel    = 32;
         vaimg->format.alpha_mask        = RGB_8BIT_ALPHAMASK;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
@@ -4433,7 +4444,6 @@ VAStatus DdiMedia_DeriveImage (
     case Media_Format_X8R8G8B8:
     case Media_Format_X8B8G8R8:
         vaimg->format.bits_per_pixel    = 32;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
@@ -4442,7 +4452,6 @@ VAStatus DdiMedia_DeriveImage (
     case Media_Format_B10G10R10A2:
         vaimg->format.bits_per_pixel    = 32;
         vaimg->format.alpha_mask        = RGB_10BIT_ALPHAMASK;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
@@ -4450,13 +4459,11 @@ VAStatus DdiMedia_DeriveImage (
     case Media_Format_R10G10B10X2:
     case Media_Format_B10G10R10X2:
         vaimg->format.bits_per_pixel    = 32;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
         break;
     case Media_Format_R5G6B5:
-        vaimg->format.bits_per_pixel    = 16;
         vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
@@ -4464,7 +4471,6 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_R8G8B8:
         vaimg->format.bits_per_pixel    = 24;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
@@ -4479,7 +4485,6 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_400P:
         vaimg->format.bits_per_pixel    = 8;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
@@ -4488,7 +4493,6 @@ VAStatus DdiMedia_DeriveImage (
     case Media_Format_RGBP:
     case Media_Format_BGRP:
         vaimg->format.bits_per_pixel    = 24;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 3;
         vaimg->num_planes               = 3;
         vaimg->pitches[0]               =
         vaimg->pitches[1]               =
@@ -4499,7 +4503,6 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_IMC3:
         vaimg->format.bits_per_pixel    = 12;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 2;
         vaimg->num_planes               = 3;
         vaimg->pitches[0]               =
         vaimg->pitches[1]               =
@@ -4510,7 +4513,6 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_411P:
         vaimg->format.bits_per_pixel    = 12;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 3;
         vaimg->num_planes               = 3;
         vaimg->pitches[0]               =
         vaimg->pitches[1]               =
@@ -4521,7 +4523,6 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_422V:
         vaimg->format.bits_per_pixel    = 16;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 2;
         vaimg->num_planes               = 3;
         vaimg->pitches[0]               =
         vaimg->pitches[1]               =
@@ -4532,7 +4533,6 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_422H:
         vaimg->format.bits_per_pixel    = 16;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 3;
         vaimg->num_planes               = 3;
         vaimg->pitches[0]               =
         vaimg->pitches[1]               =
@@ -4544,7 +4544,6 @@ VAStatus DdiMedia_DeriveImage (
     case Media_Format_P010:
     case Media_Format_P016:
         vaimg->format.bits_per_pixel    = 24;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 3 / 2;
         vaimg->num_planes               = 2;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->pitches[1]               =
@@ -4564,21 +4563,27 @@ VAStatus DdiMedia_DeriveImage (
         break;
     case Media_Format_Y416:
         vaimg->format.bits_per_pixel    = 64; // packed format [alpha, Y, U, V], 16 bits per channel
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight;
         vaimg->num_planes               = 1;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
         break;
      default:
         vaimg->format.bits_per_pixel    = 12;
-        vaimg->data_size                = mediaSurface->iPitch * mediaSurface->iHeight * 3 / 2;
         vaimg->num_planes               = 2;
         vaimg->pitches[0]               = mediaSurface->iPitch;
         vaimg->pitches[1]               =
         vaimg->pitches[2]               = mediaSurface->iPitch;
         vaimg->offsets[0]               = 0;
-        vaimg->offsets[1]               = mediaSurface->iHeight * mediaSurface->iPitch;
-        vaimg->offsets[2]               = vaimg->offsets[1] + 1;
+        if(MEDIA_IS_WA(&mediaCtx->WaTable, FtrE2ECompression))
+        {
+            vaimg->offsets[1]           = mediaSurface->iHeight * mediaSurface->iPitch;
+            vaimg->offsets[2]           = vaimg->offsets[1] + 1;
+        }
+        else
+        {
+            vaimg->offsets[1]           = offsetU;
+            vaimg->offsets[2]           = offsetV;
+        }
         break;
     }
 


### PR DESCRIPTION
should apply similiar changes for other planar format in near future
it is quick fix for chromium encoding issue

Signed-off-by: XinfengZhang <carl.zhang@intel.com>