### PR TITLE
clang-10/11: fix compilation issues

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decode_avc.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_avc.h
@@ -70,7 +70,7 @@ public:
     //!
     //! \brief    Define params for AVC picture decoding
     //!
-    typedef struct
+    struct PIC_MHW_PARAMS
     {
         MHW_VDBOX_PIPE_MODE_SELECT_PARAMS  PipeModeSelectParams;
         MHW_VDBOX_SURFACE_PARAMS           SurfaceParams;
@@ -81,7 +81,7 @@ public:
         MHW_VDBOX_PIC_ID_PARAMS            PicIdParams;
         MHW_VDBOX_AVC_IMG_PARAMS           ImgParams;
         MHW_VDBOX_AVC_DIRECTMODE_PARAMS    AvcDirectmodeParams;
-    } PIC_MHW_PARAMS;
+    };
 
     //!
     //! \brief    Constructor

--- a/media_driver/agnostic/common/os/mos_utilities.c
+++ b/media_driver/agnostic/common/os/mos_utilities.c
@@ -70,7 +70,7 @@ PerfUtility::PerfUtility()
 
 PerfUtility::~PerfUtility()
 {
-    for (const auto data : records)
+    for (const auto &data : records)
     {
         if (data.second)
         {

--- a/media_driver/agnostic/common/renderhal/renderhal.cpp
+++ b/media_driver/agnostic/common/renderhal/renderhal.cpp
@@ -5218,7 +5218,10 @@ MOS_STATUS RenderHal_SendCscCoeffSurface(
     pOsInterface    = pRenderHal->pOsInterface;
     pMhwMiInterface = pRenderHal->pMhwMiInterface;
     dwOffset        = 0;
-    dwCount         = sizeof(pKernelEntry->pCscParams->Matrix[0].Coeff) / sizeof(uint64_t);
+    static_assert(
+        (sizeof(pKernelEntry->pCscParams->Matrix[0].Coeff) % sizeof(uint64_t)) == 0,
+        "Coeff array size must be multiple of 8");
+    dwCount         = sizeof(pKernelEntry->pCscParams->Matrix[0].Coeff) / (sizeof(uint64_t));
     MOS_ZeroMemory(&Surface, sizeof(Surface));
 
     // Register the buffer

--- a/media_driver/agnostic/gen11/codec/hal/codechal_huc_cmd_initializer_g11.h
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_huc_cmd_initializer_g11.h
@@ -142,13 +142,13 @@ struct HucInputCmd3G11
 //! \struct HucCopyParams
 //! \brief  The struct of params used for huc copy
 //!
-typedef struct
+struct HucCopyParams
 {
     PMOS_RESOURCE presSrc       = nullptr;
     PMOS_RESOURCE presDst       = nullptr;
     uint32_t      size          = 0;
     uint16_t      lengthOfTable = 0;
-} HucCopyParams;
+};
 
 //!
 //! \class  CodechalCmdInitializer


### PR DESCRIPTION
Fixes: #879

This fixes:
 * -Wnon-c-typedef-for-linkage
 * -Wsizeof-array-div
 * -Wrange-loop-construct

Change-Id: I0d081070ce5abb4c707af767330141eb87748065
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>