### PR TITLE
Gen12: Set correct value for VAConfigAttribRTFormat for HEVC main-444 and main-444-10

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1610,6 +1610,16 @@ VAStatus MediaLibvaCapsG12::CreateDecAttributes(
     else if(profile == VAProfileHEVCMain422_10)
     {
         attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV400 | VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV422_10;
+    } else if(profile == VAProfileHEVCMain444)
+    {
+        attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV400 | VA_RT_FORMAT_YUV444;
+        (*attribList)[attrib.type] = attrib.value;
+    }
+    else if(profile == VAProfileHEVCMain444_10)
+    {
+        attrib.value = VA_RT_FORMAT_YUV420 |VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV400 | VA_RT_FORMAT_YUV444;
+        attrib.value |= VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV422_10 | VA_RT_FORMAT_YUV444_10;
+        (*attribList)[attrib.type] = attrib.value;
     }
     else if (profile == VAProfileVP9Profile0
           || profile == VAProfileVP9Profile2


### PR DESCRIPTION
Without this setting, user application will fail to decode HEVC 8/10 bits 444 videos

Sample pipeline:

gst-launch-1.0 filesrc location=input.10bit.444.h265 ! h265parse ! vaapih265dec ! fakesink

Fixes https://github.com/intel/media-driver/issues/882