### PR TITLE
GEN12: HEVC: Don't enable real tile if no subset parameters on Linux

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_hevc_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_hevc_g12.cpp
@@ -623,6 +623,7 @@ MOS_STATUS CodechalDecodeHevcG12 ::InitializeDecodeMode()
         initParams.u32PicWidthInPixel  = m_width;
         initParams.u32PicHeightInPixel = m_height;
         initParams.bIsTileEnabled      = m_hevcPicParams->tiles_enabled_flag;
+        initParams.bHasSubsetParams    = !!m_decodeParams.m_subsetParams;
         initParams.format              = m_decodeParams.m_destSurface->Format;
         initParams.usingSecureDecode   = m_secureDecoder ? m_secureDecoder->IsSecureDecodeEnabled() : false;
         // Only support SCC real tile mode. SCC virtual tile scalability mode is disabled here

--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_hevc_long_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_hevc_long_g12.cpp
@@ -371,7 +371,6 @@ MOS_STATUS HevcDecodeSliceLongG12::InitSliceTileParams(
     uint32_t                    bsdOffset = 0;
 
     CODECHAL_DECODE_CHK_NULL_RETURN(sliceTileParams);
-    CODECHAL_DECODE_CHK_NULL_RETURN(m_hevcSubsetParams);
 
     slc = sliceTileParams->slc;
     CODECHAL_DECODE_CHK_NULL_RETURN(slc);
@@ -379,7 +378,11 @@ MOS_STATUS HevcDecodeSliceLongG12::InitSliceTileParams(
 
     tileX = sliceTileParams->tileX;
     tileY = sliceTileParams->tileY;
-    entryPointOffsets = &m_hevcSubsetParams->entry_point_offset_minus1[slc->EntryOffsetToSubsetArray];
+
+    if (m_hevcSubsetParams)
+        entryPointOffsets = &m_hevcSubsetParams->entry_point_offset_minus1[slc->EntryOffsetToSubsetArray];
+    else
+        entryPointOffsets = NULL;
 
     for (uint16_t i = 0; i < sliceTileParams->numTiles; i++)
     {
@@ -389,7 +392,7 @@ MOS_STATUS HevcDecodeSliceLongG12::InitSliceTileParams(
         if (i == 0)
         {
             sliceTileParams->TileArray[i].bsdLength = slc->ByteOffsetToSliceData + slc->NumEmuPrevnBytesInSliceHdr;
-            sliceTileParams->TileArray[i].bsdLength += entryPointOffsets[i] + 1;
+            sliceTileParams->TileArray[i].bsdLength += entryPointOffsets ? entryPointOffsets[i] + 1 : 1;
         }
         else if (i == sliceTileParams->numTiles - 1)
         {
@@ -397,7 +400,7 @@ MOS_STATUS HevcDecodeSliceLongG12::InitSliceTileParams(
         }
         else
         {
-            sliceTileParams->TileArray[i].bsdLength = entryPointOffsets[i] + 1;
+            sliceTileParams->TileArray[i].bsdLength = entryPointOffsets ? entryPointOffsets[i] + 1 : 1;
         }
         bsdOffset += sliceTileParams->TileArray[i].bsdLength;
         if (++tileX > m_hevcPicParams->num_tile_columns_minus1)

--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_scalability_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_scalability_g12.cpp
@@ -492,7 +492,8 @@ MOS_STATUS CodecHalDecodeScalability_InitScalableParams_G12(
             u8MaxTileColumn = pScalabilityState->ucScalablePipeNum;
 #endif
         bCanEnableRealTile = bCanEnableRealTile && pInitParams->bIsTileEnabled && (pInitParams->u8NumTileColumns > 1) &&
-            (pInitParams->u8NumTileColumns <= u8MaxTileColumn) && (pInitParams->u8NumTileRows <= HEVC_NUM_MAX_TILE_ROW);
+            (pInitParams->u8NumTileColumns <= u8MaxTileColumn) && (pInitParams->u8NumTileRows <= HEVC_NUM_MAX_TILE_ROW) &&
+            pInitParams->bHasSubsetParams;
         if (bCanEnableRealTile)
         {
             pScalabilityState->bIsRtMode = true;
@@ -1430,7 +1431,8 @@ MOS_STATUS CodecHalDecodeScalability_DecidePipeNum_G12(
         u8MaxTileColumn = 2;
 #endif
     bCanEnableRealTile = bCanEnableRealTile && pInitParamsG12->bIsTileEnabled && (pInitParams->u8NumTileColumns > 1) &&
-                         (pInitParams->u8NumTileColumns <= u8MaxTileColumn) && (pInitParams->u8NumTileRows <= HEVC_NUM_MAX_TILE_ROW);
+                         (pInitParams->u8NumTileColumns <= u8MaxTileColumn) && (pInitParams->u8NumTileRows <= HEVC_NUM_MAX_TILE_ROW) &&
+                         pInitParamsG12->bHasSubsetParams;
 
     if (pInitParams->usingSFC)
     {

--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_scalability_g12.h
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_scalability_g12.h
@@ -61,6 +61,7 @@ typedef struct _CODECHAL_DECODE_SCALABILITY_INIT_PARAMS_G12 : public _CODECHAL_D
 {
     bool             bIsTileEnabled;                 //!< The picture can be partitioned into tiles
     bool             bIsSccDecoding;                 //!< Codec is HEVC SCC decoding
+    bool             bHasSubsetParams;               //!< Whether it has subset parameters
 }CODECHAL_DECODE_SCALABILITY_INIT_PARAMS_G12, *PCODECHAL_DECODE_SCALABILITY_INIT_PARAMS_G12;
 
 typedef struct _CODECHAL_DECODE_SFC_SCALABILITY_PARAMS

--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_hevc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_hevc.cpp
@@ -433,6 +433,14 @@ VAStatus DdiDecodeHEVC::RenderPicture(
         }
         case VASubsetsParameterBufferType:
         {
+
+            if (m_ddiDecodeCtx->DecodeParams.m_subsetParams == nullptr) {
+                m_ddiDecodeCtx->DecodeParams.m_subsetParams = MOS_AllocAndZeroMemory(sizeof(CODEC_HEVC_SUBSET_PARAMS));
+
+                if (m_ddiDecodeCtx->DecodeParams.m_subsetParams == nullptr)
+                    break;
+            }
+
             MOS_SecureMemcpy(m_ddiDecodeCtx->DecodeParams.m_subsetParams, dataSize, data, dataSize);
             break;
         }

--- a/media_driver/linux/gen12/codec/ddi/media_ddi_decode_hevc_g12.cpp
+++ b/media_driver/linux/gen12/codec/ddi/media_ddi_decode_hevc_g12.cpp
@@ -1001,13 +1001,6 @@ VAStatus DdiDecodeHEVCG12::CodecHalInit(
     }
 #endif
 
-    m_ddiDecodeCtx->DecodeParams.m_subsetParams = MOS_AllocAndZeroMemory(sizeof(CODEC_HEVC_SUBSET_PARAMS));
-    if (m_ddiDecodeCtx->DecodeParams.m_subsetParams == nullptr)
-    {
-        vaStatus = VA_STATUS_ERROR_ALLOCATION_FAILED;
-        goto CleanUpandReturn;
-    }
-
     vaStatus = CreateCodecHal(mediaCtx,
         ptr,
         &standardInfo);


### PR DESCRIPTION
Real tile decoding depends on subset parameters. It will result in GPU
hang if user doesn't provide subset parameters.

Example:
gst-launch-1.0 filesrc location=input.tile.h265 ! h265parse ! \
vaapih265dec ! fakesink