### PR TITLE
media_libva_caps_g12: update VAEntrypointEncSliceLP

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1443,8 +1443,7 @@ VAStatus MediaLibvaCapsG12::CreateEncAttributes(
     attrib.type = VAConfigAttribEncSliceStructure;
     if (entrypoint == VAEntrypointEncSliceLP)
     {
-        attrib.value = VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS | VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE |
-                       VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS;
+        attrib.value = VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS | VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE;
     }
     else
     {


### PR DESCRIPTION
Remove VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS from it.
It was reverted from MediaLibvaCaps::CreateEncAttributes()
as e90d17e5, align with it.