### PR TITLE
media_libva: Fix memory leak

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -4083,6 +4083,8 @@ VAStatus DdiMedia_CreateImage(
     vaimg->height               = height;
     vaimg->data_size            = size;
 
+    mediaCtx->pGmmClientContext->DestroyResInfoObject(gmmResourceInfo);
+
      switch(format->fourcc)
     {
         case VA_FOURCC_RGBA:

--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -3370,8 +3370,12 @@ VAStatus DdiMedia_DestroyBuffer (
             else
             {
                 DdiMediaUtil_UnRefBufObjInMediaBuffer(buf);
+
+                if (buf->uiExportcount) {
+                    buf->bPostponedBufFree = true;
+                    return VA_STATUS_SUCCESS;
+                }
             }
-            break;
             break;
         case VAProcPipelineParameterBufferType:
         case VAProcFilterParameterBufferType:
@@ -6035,6 +6039,12 @@ VAStatus DdiMedia_ReleaseBufferHandle(
         buf->uiMemtype = 0;
     }
     DdiMediaUtil_UnLockMutex(&mediaCtx->BufferMutex);
+
+    if (!buf->uiExportcount && buf->bPostponedBufFree) {
+        MOS_FreeMemory(buf);
+        DdiMedia_DestroyBufFromVABufferID(mediaCtx, buf_id);
+    }
+
     return VA_STATUS_SUCCESS;
 }
 

--- a/media_driver/linux/common/ddi/media_libva_common.h
+++ b/media_driver/linux/common/ddi/media_libva_common.h
@@ -324,6 +324,7 @@ typedef struct _DDI_MEDIA_BUFFER
     uint32_t               uiMemtype;
     uint32_t               uiExportcount;
     uintptr_t              handle;
+    bool                   bPostponedBufFree;
 
     bool                   bCFlushReq; // No LLC between CPU & GPU, requries to call CPU Flush for CPU mapped buffer
     PDDI_MEDIA_SURFACE     pSurface;


### PR DESCRIPTION
This patchset fixed some memory leak in the driver. 