### PR TITLE
[VP] Explicitly initialize maxSrcRect of VphalRenderer

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal.cpp
@@ -562,6 +562,11 @@ MOS_STATUS VphalState::Render(
     VPHAL_PUBLIC_CHK_NULL(pcRenderParams);
     RenderParams    = *pcRenderParams;
 
+    // Explicitly initialize the maxSrcRect of VphalRenderer
+    // so that the maxSrcRect for the last set of surfaces does not get
+    // re-used for the current set of surfaces.
+    m_renderer->InitMaxSrcRect();
+
     if (VpHal_IsAvsSampleForMultiStreamsEnabled(pcRenderParams))
     {
         eStatus = VpHal_RenderWithAvsForMultiStreams(m_renderer, pcRenderParams);

--- a/media_driver/agnostic/common/vp/hal/vphal_renderer.h
+++ b/media_driver/agnostic/common/vp/hal/vphal_renderer.h
@@ -312,6 +312,21 @@ public:
     //!
     virtual MOS_STATUS SetRenderGpuContext(VPHAL_RENDER_PARAMS& RenderParams);
 
+    //!
+    //! \brief    Explicitly initialize the maxSrcRect member
+    //! \details  The maxSrcRect member keeps track of the maximum rectangle
+    //!           among a set of source surfaces.  There is a need to
+    //!           explicitly re-initialize this member in VphalState::Render
+    //!           prior to calling the main render function.  This is so that
+    //!           the maxSrcRect value for the last set of surfaces does not
+    //!           get re-used for the current set of surfaces.
+    //! \return   void
+    //!
+    void InitMaxSrcRect()
+    {
+        maxSrcRect = {0, 0, 0, 0};
+    }
+
 protected:
     //!
     //! \brief    Prepare input surface list for top level render processing


### PR DESCRIPTION
The maxSrcRect member keeps track of the maximum rectangle
among a set of source surfaces.  There is a need to
explicitly re-initialize this member in VphalState::Render
prior to calling the main render function.  This is so that
the maxSrcRect value for the last set of surfaces does not
get re-used for the current set of surfaces.

This fixes https://github.com/intel/media-driver/issues/905.