### PR TITLE
[Encode] fix hevc QVBR BRC caps regression

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -669,7 +669,7 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
         if (IsHevcProfile(profile))
         {
             if (entrypoint != VAEntrypointEncSliceLP)
-                attrib.value |= VA_RC_ICQ;
+                attrib.value |= VA_RC_ICQ | VA_RC_QVBR;
 
             attrib.value |= VA_RC_VCM;
         }


### PR DESCRIPTION
VAConfigAttribRateControl supports VA_RC_QVBR at
VAEntrypointEncSlice.

This fixes a regression introduced by
```
 commit 296ad00146499e6aecb247a2cb0fdef09b64bce1
 Author: ShawnLi <shawn.li@intel.com>
 Date:   Thu Apr 2 15:01:17 2020 +0800

    [Encode] fix rate control caps issue

    VAConfigAttribRateControl do not support VA_RC_QVBR
    at VAEntrypointEncSliceLP before gen12
```
Fixes #918