### PR TITLE
[VP] fix crash in vp8 playback.

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
@@ -167,21 +167,18 @@ VAStatus DdiDecodeVP8::ParsePicParams(
         {
             DdiMedia_MediaSurfaceToMosResource(lastRefSurface, &m_resNoneRegLastRefFrame);
             m_ddiDecodeCtx->DecodeParams.m_presNoneRegLastRefFrame = &m_resNoneRegLastRefFrame;
-            RegisterRTSurfaces(&m_ddiDecodeCtx->RTtbl, lastRefSurface);
         }
         goldenRefSurface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->golden_ref_frame);
         if(goldenRefSurface)
         {
             DdiMedia_MediaSurfaceToMosResource(lastRefSurface, &m_resNoneRegGoldenRefFrame);
             m_ddiDecodeCtx->DecodeParams.m_presNoneRegGoldenRefFrame = &m_resNoneRegGoldenRefFrame;
-            RegisterRTSurfaces(&m_ddiDecodeCtx->RTtbl, lastRefSurface);
         }
         altRefSurface    = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParam->alt_ref_frame);
         if(altRefSurface)
         {
             DdiMedia_MediaSurfaceToMosResource(lastRefSurface, &m_resNoneRegAltRefFrame);
             m_ddiDecodeCtx->DecodeParams.m_presNoneRegAltRefFrame = &m_resNoneRegAltRefFrame;
-            RegisterRTSurfaces(&m_ddiDecodeCtx->RTtbl, lastRefSurface);
         }
     }
 


### PR DESCRIPTION
fixes vp8 decoding crash in chromeos,
ffmpeg 4.2 vp8 decoding works fine
in kbl/cml/jsl 
fixes #910 