### PR TITLE
[CP] Unload CP lib only if it was loaded.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -1509,7 +1509,8 @@ VAStatus DdiMedia__Initialize (
     mediaCtx->apoMosEnabled = g_apoMosEnabled;
 
     // LoadCPLib after mediaCtx->apoMosEnabled is set correctly. cp lib init would use it.
-    if (!CPLibUtils::LoadCPLib(ctx))
+    mediaCtx->cpLibWasLoaded = CPLibUtils::LoadCPLib(ctx);
+    if (!mediaCtx->cpLibWasLoaded)
     {
         DDI_NORMALMESSAGE("CPLIB is not loaded.");
     }
@@ -1942,7 +1943,10 @@ static VAStatus DdiMedia_Terminate (
     MOS_FreeMemory(mediaCtx);
 
     ctx->pDriverData = nullptr;
-    CPLibUtils::UnloadCPLib(ctx);
+    if (mediaCtx->cpLibWasLoaded)
+    {
+        CPLibUtils::UnloadCPLib(ctx);
+    }
 
     DdiMediaUtil_UnLockMutex(&GlobalMutex);
 

--- a/media_driver/linux/common/ddi/media_libva_common.h
+++ b/media_driver/linux/common/ddi/media_libva_common.h
@@ -427,6 +427,8 @@ struct DDI_MEDIA_CONTEXT
     PDDI_MEDIA_HEAP     pMfeCtxHeap;
     uint32_t            uiNumMfes;
 
+    bool                cpLibWasLoaded;
+
     // display info
     uint32_t            uiDisplayWidth;
     uint32_t            uiDisplayHeight;


### PR DESCRIPTION
While debugging an issue, I noticed that we go inside the if in [1] which indicates an invalid condition. The problem is that DdiMedia_Terminate() unconditionally unloads CP lib, even when loading it fails. My proposed solution is to keep track of whether the CP lib was loaded on DdiMedia__Initialize() in order to decide if it needs to be unloaded on DdiMedia_Terminate().

[1] https://github.com/intel/media-driver/blob/7b4f9c93c8a0825ce1e8d9ab45d06f9e887a7150/media_driver/linux/common/cp/shared/cplib_utils.cpp#L136-L140