### PR TITLE
media_libva: avoid segmentation fault

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -1938,16 +1938,16 @@ static VAStatus DdiMedia_Terminate (
     mediaCtx->SkuTable.reset();
     mediaCtx->WaTable.reset();
 
-    // release media driver context, ctx creation is behind the mos_utilities_init
-    // If free earilier than MOS_utilities_close, memnja count error.
-    MOS_FreeMemory(mediaCtx);
-
-    ctx->pDriverData = nullptr;
     if (mediaCtx->cpLibWasLoaded)
     {
         CPLibUtils::UnloadCPLib(ctx);
     }
 
+    // release media driver context, ctx creation is behind the mos_utilities_init
+    // If free earilier than MOS_utilities_close, memnja count error.
+    MOS_FreeMemory(mediaCtx);
+
+    ctx->pDriverData = nullptr;
     DdiMediaUtil_UnLockMutex(&GlobalMutex);
 
     return VA_STATUS_SUCCESS;


### PR DESCRIPTION
Without this fix, the media context is still used after freed.
