### PR TITLE
Fix renderhal and MOS-specific compile errors.

### DIFF
--- a/media_driver/agnostic/gen10/renderhal/renderhal_g10.cpp
+++ b/media_driver/agnostic/gen10/renderhal/renderhal_g10.cpp
@@ -133,7 +133,8 @@ MOS_STATUS XRenderHal_Interface_g10::SetupSurfaceState (
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pStateHeap);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pHwSizes);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pMhwStateHeap);
-    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 && pRenderHalSurface->Rotation < 8);
+    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 &&
+                         pRenderHalSurface->Rotation <= MHW_ROTATE_90_MIRROR_HORIZONTAL);
     //-----------------------------------------
 
     dwSurfaceSize = pRenderHal->pHwSizes->dwSizeSurfaceState;

--- a/media_driver/agnostic/gen11/renderhal/renderhal_g11.cpp
+++ b/media_driver/agnostic/gen11/renderhal/renderhal_g11.cpp
@@ -134,7 +134,8 @@ MOS_STATUS XRenderHal_Interface_g11::SetupSurfaceState (
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pStateHeap);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pHwSizes);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pMhwStateHeap);
-    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 && pRenderHalSurface->Rotation < 8);
+    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 &&
+                         pRenderHalSurface->Rotation <= MHW_ROTATE_90_MIRROR_HORIZONTAL);
     //-----------------------------------------
 
     dwSurfaceSize = pRenderHal->pHwSizes->dwSizeSurfaceState;

--- a/media_driver/agnostic/gen12/renderhal/renderhal_g12.cpp
+++ b/media_driver/agnostic/gen12/renderhal/renderhal_g12.cpp
@@ -142,7 +142,8 @@ MOS_STATUS XRenderHal_Interface_g12::SetupSurfaceState (
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pStateHeap);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pHwSizes);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pMhwStateHeap);
-    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 && pRenderHalSurface->Rotation < 8);
+    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 &&
+                         pRenderHalSurface->Rotation <= MHW_ROTATE_90_MIRROR_HORIZONTAL);
     //-----------------------------------------
 
     dwSurfaceSize = pRenderHal->pHwSizes->dwSizeSurfaceState;

--- a/media_driver/agnostic/gen9/renderhal/renderhal_g9.cpp
+++ b/media_driver/agnostic/gen9/renderhal/renderhal_g9.cpp
@@ -135,7 +135,8 @@ MOS_STATUS XRenderHal_Interface_g9::SetupSurfaceState (
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pStateHeap);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pHwSizes);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pMhwStateHeap);
-    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 && pRenderHalSurface->Rotation < 8);
+    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 &&
+                         pRenderHalSurface->Rotation <= MHW_ROTATE_90_MIRROR_HORIZONTAL);
     //-----------------------------------------
 
     dwSurfaceSize = pRenderHal->pHwSizes->dwSizeSurfaceState;

--- a/media_driver/linux/common/os/mos_os_specific.c
+++ b/media_driver/linux/common/os/mos_os_specific.c
@@ -1818,10 +1818,12 @@ MOS_STATUS Mos_DestroyInterface(PMOS_INTERFACE pOsInterface)
         perStreamParameters->WaTable.reset();
         Mos_Specific_ClearGpuContext(perStreamParameters);
 
+#ifndef ANDROID
         if (perStreamParameters->bKMDHasVCS2)
         {
             DestroyIPC(perStreamParameters);
         }
+#endif
 
         if (perStreamParameters->contextOffsetList.size())
         {


### PR DESCRIPTION
mos_os_specific.c: "DestroyIPC(perStreamParameters)" is undefined when IPC
                   is disabled after applying 0002-Disable-IPC-usage.patch

renderhal_gxx.cpp: Result of comparison of constant 8 in expression
                   "pRenderHalSurface->Rotation < 8" will always be true.
                   Replace the constant with a predefined enumerated type.

Signed-off-by: Michele Lim <michele.lim@intel.com>