### PR TITLE
Disable ICQ mode for HEVC VDENC.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -667,7 +667,10 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
 
         if (IsHevcProfile(profile))
         {
-            attrib.value |= VA_RC_ICQ | VA_RC_VCM;
+            if (entrypoint != VAEntrypointEncSliceLP)
+                attrib.value |= VA_RC_ICQ;
+
+            attrib.value |= VA_RC_VCM;
         }
     }
     if (IsAvcProfile(profile) && (entrypoint != VAEntrypointEncSliceLP))

--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1386,7 +1386,10 @@ VAStatus MediaLibvaCapsG12::CreateEncAttributes(
 
         if (IsHevcProfile(profile))
         {
-            attrib.value |= VA_RC_ICQ | VA_RC_VCM | VA_RC_QVBR;
+            if (entrypoint != VAEntrypointEncSliceLP)
+                attrib.value |= VA_RC_ICQ;
+
+            attrib.value |= VA_RC_VCM | VA_RC_QVBR;
         }
         if (IsVp9Profile(profile))
         {


### PR DESCRIPTION
ICQ mode isn't supported by HEVC VDENC.
Fixes #618.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>