### PR TITLE
replace the reconstruct surface to be variant

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.cpp
@@ -506,9 +506,22 @@ VAStatus DdiEncodeHevc::ParsePicParams(
 
     PCODEC_HEVC_ENCODE_SEQUENCE_PARAMS hevcSeqParams = (PCODEC_HEVC_ENCODE_SEQUENCE_PARAMS)((uint8_t *)m_encodeCtx->pSeqParams);
 
+    DDI_MEDIA_SURFACE *surface;
     if(picParams->decoded_curr_pic.picture_id != VA_INVALID_SURFACE)
     {
-        DDI_CHK_RET(RegisterRTSurfaces(&(m_encodeCtx->RTtbl), DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->decoded_curr_pic.picture_id)), "RegisterRTSurfaces failed!");
+        surface = DdiMedia_GetSurfaceFromVASurfaceID(mediaCtx, picParams->decoded_curr_pic.picture_id);
+
+        if(m_encodeCtx->vaProfile == VAProfileHEVCMain444
+        || m_encodeCtx->vaProfile == VAProfileHEVCMain444_10
+        || m_encodeCtx->vaProfile == VAProfileHEVCMain444_12
+        || m_encodeCtx->vaProfile == VAProfileHEVCMain422_10
+        || m_encodeCtx->vaProfile == VAProfileHEVCMain422_12
+        || m_encodeCtx->vaProfile == VAProfileHEVCSccMain444
+        || m_encodeCtx->vaProfile == VAProfileHEVCSccMain444_10)
+        {
+            surface = DdiMedia_ReplaceSurfaceWithVariant(surface, m_encodeCtx->vaEntrypoint);
+        }
+        DDI_CHK_RET(RegisterRTSurfaces(&(m_encodeCtx->RTtbl),surface), "RegisterRTSurfaces failed!");
     }
 
     // Curr Recon Pic
@@ -753,7 +766,6 @@ VAStatus DdiEncodeHevc::ParseSlcParams(
             hevcSlcParams->chroma_offset[1][i][1]       = MOS_CLAMP_MIN_MAX(vaEncSlcParamsHEVC->chroma_offset_l1[i][1], minChromaOffset, maxChromaOffset);
             hevcSlcParams->delta_chroma_weight[1][i][1] = vaEncSlcParamsHEVC->delta_chroma_weight_l1[i][1];
         }
-
         for (uint32_t i = 0; i < numMaxRefFrame; i++)
         {
             if(i >  hevcSlcParams->num_ref_idx_l0_active_minus1)

--- a/media_driver/linux/common/ddi/media_libva_common.cpp
+++ b/media_driver/linux/common/ddi/media_libva_common.cpp
@@ -419,6 +419,90 @@ PDDI_MEDIA_SURFACE DdiMedia_ReplaceSurfaceWithNewFormat(PDDI_MEDIA_SURFACE surfa
     return dstSurface;
 }
 
+PDDI_MEDIA_SURFACE DdiMedia_ReplaceSurfaceWithVariant(PDDI_MEDIA_SURFACE surface, VAEntrypoint entrypoint)
+{
+    DDI_CHK_NULL(surface, "nullptr surface", nullptr);
+
+    PDDI_MEDIA_CONTEXT mediaCtx = surface->pMediaCtx;
+    uint32_t aligned_width, aligned_height;
+    DDI_MEDIA_FORMAT aligned_format;
+
+    //check some conditions
+    if(surface->uiVariantFlag)
+    {
+        return surface;
+    }
+
+    VASurfaceID vaID = DdiMedia_GetVASurfaceIDFromSurface(surface);
+    if(VA_INVALID_SURFACE == vaID)
+    {
+        return nullptr;
+    }
+    PDDI_MEDIA_SURFACE_HEAP_ELEMENT  surfaceElement = (PDDI_MEDIA_SURFACE_HEAP_ELEMENT)surface->pMediaCtx->pSurfaceHeap->pHeapBase;
+    if (nullptr == surfaceElement)
+    {
+        return nullptr;
+    }
+    surfaceElement += vaID;
+    aligned_format = surface->format;
+    switch (surface->format)
+    {
+        case Media_Format_AYUV:
+            aligned_width = MOS_ALIGN_CEIL(surface->iWidth, 128);
+            aligned_height = MOS_ALIGN_CEIL(surface->iHeight * 3 / 4, 64);
+            break;
+        case Media_Format_Y410:
+            aligned_width = MOS_ALIGN_CEIL(surface->iWidth, 64);
+            aligned_height = MOS_ALIGN_CEIL(surface->iHeight * 3 / 2, 64);
+            break;
+        case Media_Format_Y216:
+        case Media_Format_Y210:
+        case Media_Format_YUY2:
+            aligned_width = (surface->iWidth + 1) >> 1;
+            aligned_height = surface->iHeight * 2;
+            break;
+        case Media_Format_P010:
+            aligned_height = surface->iHeight;
+            aligned_width = surface->iWidth;
+            if(entrypoint == VAEntrypointEncSlice)
+            {
+                aligned_width = surface->iWidth * 2;
+                aligned_format = Media_Format_NV12;
+            }
+            else
+            {
+                aligned_format = Media_Format_P016;
+            }
+            break;
+        default:
+            return surface;
+       }
+
+    //create new dst surface and copy the structure
+    PDDI_MEDIA_SURFACE dstSurface = (DDI_MEDIA_SURFACE *)MOS_AllocAndZeroMemory(sizeof(DDI_MEDIA_SURFACE));
+
+    MOS_SecureMemcpy(dstSurface,sizeof(DDI_MEDIA_SURFACE),surface,sizeof(DDI_MEDIA_SURFACE));
+    DDI_CHK_NULL(dstSurface, "nullptr dstSurface", nullptr);
+
+    dstSurface->uiVariantFlag = 1;
+    dstSurface->format = aligned_format;
+    dstSurface->iWidth = aligned_width;
+    dstSurface->iHeight = aligned_height;
+   //CreateNewSurface
+    if(DdiMediaUtil_CreateSurface(dstSurface,mediaCtx) != VA_STATUS_SUCCESS)
+    {
+        MOS_FreeMemory(dstSurface);
+        return surface;
+    }
+    //replace the surface
+    surfaceElement->pSurface = dstSurface;
+    //FreeSurface
+    DdiMediaUtil_FreeSurface(surface);
+    MOS_FreeMemory(surface);
+
+    return dstSurface;
+}
+
 DDI_MEDIA_BUFFER* DdiMedia_GetBufferFromVABufferID (PDDI_MEDIA_CONTEXT mediaCtx, VABufferID bufferID)
 {
     uint32_t                       i = 0;

--- a/media_driver/linux/common/ddi/media_libva_common.h
+++ b/media_driver/linux/common/ddi/media_libva_common.h
@@ -300,6 +300,8 @@ typedef struct _DDI_MEDIA_SURFACE
     uint8_t                 *pSystemShadow;           // Shadow surface in system memory
 
     uint32_t                uiMapFlag;
+
+    uint32_t                uiVariantFlag;
 } DDI_MEDIA_SURFACE, *PDDI_MEDIA_SURFACE;
 
 typedef struct _DDI_MEDIA_BUFFER
@@ -561,7 +563,6 @@ void* DdiMedia_GetContextFromContextID (VADriverContextP ctx, VAContextID vaCtxI
 //!
 DDI_MEDIA_SURFACE* DdiMedia_GetSurfaceFromVASurfaceID (PDDI_MEDIA_CONTEXT mediaCtx, VASurfaceID surfaceID);
 
-
 //!
 //! \brief  replace the surface with given format
 //!
@@ -574,6 +575,17 @@ DDI_MEDIA_SURFACE* DdiMedia_GetSurfaceFromVASurfaceID (PDDI_MEDIA_CONTEXT mediaC
 //!     Pointer to new ddi media surface
 //!
 PDDI_MEDIA_SURFACE DdiMedia_ReplaceSurfaceWithNewFormat(PDDI_MEDIA_SURFACE surface, DDI_MEDIA_FORMAT expectedFormat);
+
+//!
+//! \brief  replace the surface with correlation variant format
+//!
+//! \param  [in] surface
+//!     Pointer to the old surface
+//!
+//! \return DDI_MEDIA_SURFACE*
+//!     Pointer to new ddi media surface
+//!
+PDDI_MEDIA_SURFACE DdiMedia_ReplaceSurfaceWithVariant(PDDI_MEDIA_SURFACE surface, VAEntrypoint entrypoint);
 
 //!
 //! \brief  Get VA surface ID  from surface


### PR DESCRIPTION
replace the reconstruct surface to be variant surface for HEVC REXT encoding
it could make the difference between recon/raw to be transparent to application
pay attention , the surface should be not read or write.

it is part of #915  to facilitate the test separately 
Signed-off-by: XinfengZhang <carl.zhang@intel.com>