### PR TITLE
media_libva_caps_g12: create decoding attributes for SCC main 444 and main 10

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1691,14 +1691,16 @@ VAStatus MediaLibvaCapsG12::CreateDecAttributes(
     {
         // at present, latest libva have not support RGB24.
         attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_YUV400 | VA_RT_FORMAT_YUV411 | VA_RT_FORMAT_RGB16 | VA_RT_FORMAT_RGB32;
-    } else if(profile == VAProfileHEVCMain10)
+    } else if(profile == VAProfileHEVCMain10 ||
+              profile == VAProfileHEVCSccMain10)
     {
         attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV420_10;
     }
     else if(profile == VAProfileHEVCMain422_10)
     {
         attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV400 | VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV422_10;
-    } else if(profile == VAProfileHEVCMain444)
+    } else if(profile == VAProfileHEVCMain444 ||
+              profile == VAProfileHEVCSccMain444)
     {
         attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV400 | VA_RT_FORMAT_YUV444;
         (*attribList)[attrib.type] = attrib.value;


### PR DESCRIPTION
Otherwise user application cannot get the right attributes and will fail
to support SCC main 444 and main 10 decoding