### PR TITLE
Decoder: VP9: GEN9: Disable HPR VP9 mode switch to avoid GPU hang

### DIFF
--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_hcp_g9_kbl.cpp
+++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_hcp_g9_kbl.cpp
@@ -275,6 +275,10 @@ MOS_STATUS MhwVdboxHcpInterfaceG9Kbl::AddHcpPipeModeSelectCmd(
 
     m_cpInterface->SetProtectionSettingsForMfxPipeModeSelect((uint32_t *)cmd);
 
+    // Without having the HprVp9ModeSwitchEco disabled, the gen9 devices
+    // cause gpu to hang while decoding tiled 4k vp9 streams
+    cmd->DW4.HprVp9ModeSwitchEcoDisable = 1;
+
     cmd->DW1.PakPipelineStreamoutEnable = params->bStreamOutEnabled;
     cmd->DW1.AdvancedRateControlEnable = params->bAdvancedRateControlEnable;
 


### PR DESCRIPTION
Without having the HprVp9ModeSwitchEco disabled, the gen9 devices
cause gpu to hang while decoding tiled 4k vp9 streams for a
longer period. This particular chicken bit has been set in the
legacy i965 driver to avoid random gpu hangs.

Fixes #974