### PR TITLE
media_libva_caps_g11: Add missing Y216 GMM format support for gen11

### DIFF
--- a/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_libva_caps_g11.cpp
@@ -819,6 +819,7 @@ GMM_RESOURCE_FORMAT MediaLibvaCapsG11::ConvertMediaFmtToGmmFmt(
         case Media_Format_R10G10B10X2: return GMM_FORMAT_R10G10B10A2_UNORM_TYPE;
         case Media_Format_B10G10R10X2: return GMM_FORMAT_B10G10R10A2_UNORM_TYPE;
         case Media_Format_Y210       : return GMM_FORMAT_Y210_TYPE;
+        case Media_Format_Y216       : return GMM_FORMAT_Y216_TYPE;
         case Media_Format_AYUV       : return GMM_FORMAT_AYUV_TYPE;
         case Media_Format_Y410       : return GMM_FORMAT_Y410_TYPE;
         case Media_Format_Y416       : return GMM_FORMAT_Y416_TYPE;


### PR DESCRIPTION
Fix encoding recon surface issue for Y210.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>
