### PR TITLE
[vpp] add Format_AYUV to IS_YUV_FORMAT(format)

### DIFF
--- a/media_driver/agnostic/common/os/mos_resource_defs.h
+++ b/media_driver/agnostic/common/os/mos_resource_defs.h
@@ -310,7 +310,8 @@ C_ASSERT(Format_Count == 103); //!< When adding, update assert & vphal_solo_scen
           ( IS_PL2_FORMAT(format)       || \
             IS_PL3_FORMAT(format)       || \
             IS_PA_FORMAT(format)        || \
-            (format == Format_400P))
+            (format == Format_400P)     || \
+            (format == Format_AYUV))
 
 #define CASE_YUV_FORMAT  \
     CASE_PL2_FORMAT:     \


### PR DESCRIPTION
    ffmpeg-vaapi convert AYUV to other formats need
    to determine whether the input format is YUV or RGB.
    So I add Format_AYUV to IS_YUV_FORMAT(format)
    to make sure that AYUV is treated as YUV.

Signed-off-by: Zhang yuankun <yuankunx.zhang@intel.com>