### PR TITLE
Add checking for avoid mismatched size of HEVC slice parameter.

### DIFF
--- a/media_driver/linux/gen11/codec/ddi/media_ddi_decode_hevc_g11.cpp
+++ b/media_driver/linux/gen11/codec/ddi/media_ddi_decode_hevc_g11.cpp
@@ -705,10 +705,16 @@ VAStatus DdiDecodeHEVCG11::AllocSliceControlBuffer(
     bufMgr     = &(m_ddiDecodeCtx->BufMgr);
     availSize = m_sliceCtrlBufNum - bufMgr->dwNumSliceControl;
 
+    if(buf->uiNumElements < 1 || buf->iSize < 1)
+        return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
     if(m_ddiDecodeCtx->bShortFormatInUse)
     {
         if(availSize < buf->uiNumElements)
         {
+            if (buf->iSize / buf->uiNumElements != sizeof(VASliceParameterBufferBase))
+                return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
             newSize   = sizeof(VASliceParameterBufferBase) * (m_sliceCtrlBufNum - availSize + buf->uiNumElements);
             bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufBaseHEVC = (VASliceParameterBufferBase *)realloc(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufBaseHEVC, newSize);
             if(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufBaseHEVC == nullptr)
@@ -727,6 +733,9 @@ VAStatus DdiDecodeHEVCG11::AllocSliceControlBuffer(
         {
             if(availSize < buf->uiNumElements)
             {
+                if (buf->iSize / buf->uiNumElements != sizeof(VASliceParameterBufferHEVC))
+                    return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
                 newSize   = sizeof(VASliceParameterBufferHEVC) * (m_sliceCtrlBufNum - availSize + buf->uiNumElements);
                 bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVC = (VASliceParameterBufferHEVC *)realloc(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVC, newSize);
                 if(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVC == nullptr)
@@ -743,6 +752,9 @@ VAStatus DdiDecodeHEVCG11::AllocSliceControlBuffer(
         {
             if(availSize < buf->uiNumElements)
             {
+                if (buf->iSize / buf->uiNumElements != sizeof(VASliceParameterBufferHEVCExtension))
+                    return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
                 newSize   = sizeof(VASliceParameterBufferHEVCExtension) * (m_sliceCtrlBufNum - availSize + buf->uiNumElements);
                 bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVCRext= (VASliceParameterBufferHEVCExtension*)realloc(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVCRext, newSize);
                 if(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVCRext== nullptr)

--- a/media_driver/linux/gen12/codec/ddi/media_ddi_decode_hevc_g12.cpp
+++ b/media_driver/linux/gen12/codec/ddi/media_ddi_decode_hevc_g12.cpp
@@ -815,10 +815,16 @@ VAStatus DdiDecodeHEVCG12::AllocSliceControlBuffer(
     bufMgr     = &(m_ddiDecodeCtx->BufMgr);
     availSize = m_sliceCtrlBufNum - bufMgr->dwNumSliceControl;
 
+    if(buf->uiNumElements < 1 || buf->iSize < 1)
+        return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
     if(m_ddiDecodeCtx->bShortFormatInUse)
     {
         if(availSize < buf->uiNumElements)
         {
+            if (buf->iSize / buf->uiNumElements != sizeof(VASliceParameterBufferBase))
+                return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
             newSize   = sizeof(VASliceParameterBufferBase) * (m_sliceCtrlBufNum - availSize + buf->uiNumElements);
             bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufBaseHEVC = (VASliceParameterBufferBase *)realloc(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufBaseHEVC, newSize);
             if(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufBaseHEVC == nullptr)
@@ -837,6 +843,9 @@ VAStatus DdiDecodeHEVCG12::AllocSliceControlBuffer(
         {
             if(availSize < buf->uiNumElements)
             {
+                if (buf->iSize / buf->uiNumElements != sizeof(VASliceParameterBufferHEVC))
+                    return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
                 newSize   = sizeof(VASliceParameterBufferHEVC) * (m_sliceCtrlBufNum - availSize + buf->uiNumElements);
                 bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVC = (VASliceParameterBufferHEVC *)realloc(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVC, newSize);
                 if(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVC == nullptr)
@@ -853,6 +862,9 @@ VAStatus DdiDecodeHEVCG12::AllocSliceControlBuffer(
         {
             if(availSize < buf->uiNumElements)
             {
+                if (buf->iSize / buf->uiNumElements != sizeof(VASliceParameterBufferHEVCExtension))
+                    return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
                 newSize   = sizeof(VASliceParameterBufferHEVCExtension) * (m_sliceCtrlBufNum - availSize + buf->uiNumElements);
                 bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVCRext= (VASliceParameterBufferHEVCExtension*)realloc(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVCRext, newSize);
                 if(bufMgr->Codec_Param.Codec_Param_HEVC.pVASliceParaBufHEVCRext== nullptr)


### PR DESCRIPTION
Fixes #822.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>