### PR TITLE
Add NV12 format for HEVCSccMain444 based on the standard.

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1147,6 +1147,12 @@ VAStatus MediaLibvaCapsG12::QuerySurfaceAttributes(
             attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
             attribs[i].value.value.i = VA_FOURCC_Y410;
             i++;
+
+            attribs[i].type = VASurfaceAttribPixelFormat;
+            attribs[i].value.type = VAGenericValueTypeInteger;
+            attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+            attribs[i].value.value.i = VA_FOURCC('N', 'V', '1', '2');
+            i++;
         } else if (profile == VAProfileHEVCSccMain444_10)
         {
             attribs[i].type = VASurfaceAttribPixelFormat;


### PR DESCRIPTION
Fixes #999.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>