### PR TITLE
[Encode] Removing 422 RTFormat support from VP9 VDEnc in TGL

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.h
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.h
@@ -54,7 +54,7 @@ public:
              VA_RT_FORMAT_RGB32_10BPP | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV422_10},
             {VP9, Vdenc, VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV420_10BPP |
              VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_RGB32 |
-             VA_RT_FORMAT_RGB32_10BPP | VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV422_10},
+             VA_RT_FORMAT_RGB32_10BPP},
         };
         m_encodeFormatTable = (struct EncodeFormatTable*)(&encodeFormatTableTGL[0]);
         m_encodeFormatCount = sizeof(encodeFormatTableTGL)/sizeof(struct EncodeFormatTable);


### PR DESCRIPTION
This change will remove 422 RTFormats support from TGL to fix incorrect surface configuration.