### PR TITLE
media: don't advertise AV1 decoding if the platform doesn't support it

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -75,6 +75,12 @@ static bool InitTglMediaSku(struct GfxDeviceInfo *devInfo,
     {
         LinuxCodecInfo *codecInfo = &tglCodecInfo;
 
+        if (devInfo->productFamily == IGFX_TIGERLAKE_LP &&
+            drvInfo->devRev == 0) {
+            codecInfo->adv0Decoding = 0;
+            codecInfo->adv1Decoding = 0;
+        }
+
         MEDIA_WR_SKU(skuTable, FtrAVCVLDLongDecoding, codecInfo->avcDecoding);
         MEDIA_WR_SKU(skuTable, FtrMPEG2VLDDecoding, codecInfo->mpeg2Decoding);
         MEDIA_WR_SKU(skuTable, FtrIntelVP8VLDDecoding, codecInfo->vp8Decoding);


### PR DESCRIPTION
Otherwise user will be misled by the output of vainfo on Linux

Change-Id: I039fdea492db884a53d24ae8966c619c714e7a96