### PR TITLE
[AVC VDEnc] Fix target usage mapping issue for free media driver

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -552,31 +552,19 @@ VAStatus DdiEncodeAvc::ParseMiscParamQualityLevel(void *data)
 
     m_encodeCtx->targetUsage = (uint8_t)vaEncMiscParamQualityLevel->quality_level;
     uint8_t qualityUpperBoundary = TARGETUSAGE_BEST_SPEED;
-#ifdef _FULL_OPEN_SOURCE
-    if (!GFX_IS_PRODUCT(m_encodeCtx->pMediaCtx->platform, IGFX_ICELAKE_LP))
-        qualityUpperBoundary = 5;
-#endif
+
     // check if TU setting is valid, otherwise change to default
     if ((m_encodeCtx->targetUsage > qualityUpperBoundary) || (0 == m_encodeCtx->targetUsage))
     {
         m_encodeCtx->targetUsage = TARGETUSAGE_RT_SPEED;
         DDI_ASSERTMESSAGE("Quality Level setting from application is not correct, should be in (0,%d].", qualityUpperBoundary);
-        return VA_STATUS_SUCCESS;
     }
 
 #ifdef _FULL_OPEN_SOURCE
-    if (!GFX_IS_PRODUCT(m_encodeCtx->pMediaCtx->platform, IGFX_ICELAKE_LP))
+    if (!GFX_IS_PRODUCT(m_encodeCtx->pMediaCtx->platform, IGFX_ICELAKE_LP) && m_encodeCtx->targetUsage <= 2)
     {
-        if (m_encodeCtx->targetUsage >= 1 && m_encodeCtx->targetUsage <= 2)
-        {
-            m_encodeCtx->targetUsage = 4;
-        }
-        else if (m_encodeCtx->targetUsage >= 3 &&m_encodeCtx->targetUsage <= 5)
-        {
-            m_encodeCtx->targetUsage = 7;
-        }
+        m_encodeCtx->targetUsage = 4;
     }
-
 #endif
 
     return VA_STATUS_SUCCESS;

--- a/media_driver/linux/common/vp/ddi/media_libva_vp.c
+++ b/media_driver/linux/common/vp/ddi/media_libva_vp.c
@@ -2022,44 +2022,16 @@ VAStatus DdiVp_GetColorSpace(PVPHAL_SURFACE pVpHalSurf, VAProcColorStandardType 
 /////////////////////////////////////////////////////////////////////////////////////////////
 VPHAL_CSPACE DdiVp_GetColorSpaceFromMediaFormat(DDI_MEDIA_FORMAT format)
 {
-    VPHAL_CSPACE ColorSpace = CSpace_None;
+    MOS_FORMAT mosFormat = VpGetFormatFromMediaFormat(format);
 
-    switch (format)
+    if (IS_RGB_FORMAT(mosFormat))
     {
-    case Media_Format_X8R8G8B8:
-    case Media_Format_CPU:
-    case Media_Format_R5G6B5:
-    case Media_Format_R8G8B8:
-    case Media_Format_A8R8G8B8:
-    case Media_Format_R10G10B10A2:
-    case Media_Format_B10G10R10A2:
-        ColorSpace = CSpace_sRGB;
-        break;
-    case Media_Format_YUY2:
-    case Media_Format_UYVY:
-    case Media_Format_YV12:
-    case Media_Format_IYUV:
-    case Media_Format_NV12:
-    case Media_Format_NV21:
-    case Media_Format_422H:
-    case Media_Format_422V:
-    case Media_Format_P010:
-    case Media_Format_IMC3:
-    case Media_Format_AYUV:
-    case Media_Format_Y210:
-    case Media_Format_Y410:
-    case Media_Format_P016:
-    case Media_Format_Y216:
-    case Media_Format_Y416:
-        ColorSpace = CSpace_BT601;
-        break;
-    default:
-        VP_DDI_ASSERTMESSAGE("Get ColorSpace from media format: unknown format.");
-        ColorSpace = CSpace_None;
-        break;
+        return CSpace_sRGB;
     }
-
-    return ColorSpace;
+    else
+    {
+        return CSpace_BT601;
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Correct the mapping of target useage for free driver. Fixed #768.