### PR TITLE
[TGL] Disable E2E Compression for HW revisions 0 to 2

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -254,7 +254,7 @@ static bool InitTglMediaSku(struct GfxDeviceInfo *devInfo,
         MEDIA_WR_SKU(skuTable, FtrE2ECompression, 0);
     }
 
-    if (drvInfo->devRev == 0)
+    if (drvInfo->devRev <= 2)
     {
         MEDIA_WR_SKU(skuTable, FtrE2ECompression, 0);
     }


### PR DESCRIPTION
E2E compression is currently disabled for HW revision 0. See [1].
The kernel commit in [2] indicates that media decompression is not
available for steppings A0-C0.

If we test the latest iHD with the latest drm-tip on a B-stepping,
for example, we would see corrupted video frames on the display
by default.

This commit fixes this default behavior by disabling E2E compression
until media decompression is available.

This fixes https://github.com/intel/media-driver/issues/1029.

[1] https://github.com/intel/media-driver/blob/d457d66da7065e5116f818e4bca2d6ea4b841422/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp#L257
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dbff5a8db9c630f61a892ab41a283445e01270f5