### PR TITLE
fix uninitialized value in hevc/avc encoder 

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_avc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_avc.cpp
@@ -1427,6 +1427,9 @@ CodechalEncodeAvcEnc::CodechalEncodeAvcEnc(
     {
         m_useCmScalingKernel = 1;
     }
+    CODECHAL_DEBUG_TOOL(
+        m_mmcUserFeatureUpdated = false;
+    )
 }
 
 CodechalEncodeAvcEnc::~CodechalEncodeAvcEnc()

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_hevc_base.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_hevc_base.cpp
@@ -844,7 +844,7 @@ MOS_STATUS CodechalEncodeHevcBase::SetSequenceStructs()
     // Get row store cache params: as all the needed information is got here
     if (m_hcpInterface->IsRowStoreCachingSupported())
     {
-        MHW_VDBOX_ROWSTORE_PARAMS rowstoreParams;
+        MHW_VDBOX_ROWSTORE_PARAMS rowstoreParams = {};
         rowstoreParams.Mode = m_mode;
         rowstoreParams.dwPicWidth = m_frameWidth;
                 rowstoreParams.ucChromaFormat   = m_chromaFormat;
@@ -2822,6 +2822,7 @@ CodechalEncodeHevcBase::CodechalEncodeHevcBase(
     MOS_ZeroMemory(&m_s32XMeMvDataBuffer, sizeof(m_s32XMeMvDataBuffer));
     MOS_ZeroMemory(&m_s4XMeDistortionBuffer, sizeof(m_s4XMeDistortionBuffer));
     MOS_ZeroMemory(&m_mbQpDataSurface, sizeof(m_mbQpDataSurface));
+    MOS_ZeroMemory(&m_resPakcuLevelStreamoutData, sizeof(m_resPakcuLevelStreamoutData));
 
     m_fieldScalingOutputInterleaved = false;
     m_interlacedFieldDisabled = true;


### PR DESCRIPTION
test: command:
valgrind ffmpeg -hwaccel vaapi -hwaccel_output_fsormat vaapi -i test.264 -c:v hevc_vaapi -vframes 30 test.mp4 -y
valgrind ffmpeg -hwaccel vaapi -hwaccel_output_fsormat vaapi -i test.264 -c:v h264_vaapi -vframes 30 test.mp4 -y

you will see following errors like this:
=23516==    at 0xAAD6B3A: MhwVdboxMfxInterfaceG9<mhw_vdbox_mfx_g9_kbl>::GetRowstoreCachingAddrs(_MHW_VDBOX_ROWSTORE_PARAMS*) (mhw_vdbox_mfx_g9_X.h:251)
==23516==    by 0xA5FEDC2: CodechalHwInterface::SetRowstoreCachingOffsets(_MHW_VDBOX_ROWSTORE_PARAMS*) (codechal_hw.cpp:123)
==23516==    by 0xA78B296: CodechalEncodeHevcBase::SetSequenceStructs() (codechal_encode_hevc_base.cpp:853)
==23516==    by 0xA79FC31: CodechalEncHevcState::SetSequenceStructs() (codechal_encode_hevc.cpp:154)
==23516==    by 0xA9A39E9: CodechalEncHevcStateG9::SetSequenceStructs() (codechal_encode_hevc_g9.cpp:3131)
==23516==    by 0xAAC066B: CodechalEncHevcStateG9Kbl::SetSequenceStructs() (codechal_encode_hevc_g9_kbl.cpp:224)
==23516==    by 0xA7909CE: CodechalEncodeHevcBase::InitializePicture(EncoderParams const&) (codechal_encode_hevc_base.cpp:2250)
==23516==    by 0xA7A6D82: CodechalEncHevcState::InitializePicture(EncoderParams const&) (codechal_encode_hevc.cpp:1606)
==23516==    by 0xA702025: CodechalEncoderState::ExecuteEnc(EncoderParams*) (codechal_encoder_base.cpp:4432)
==23516==    by 0xA6F12E1: CodechalEncoderState::Execute(void*) (codechal_encoder_base.cpp:610)
==23516==    by 0xAF8EA5F: DdiEncodeHevc::EncodeInCodecHal(unsigned int) (media_ddi_encode_hevc.cpp:393)
==23516==    by 0xAF498F0: DdiEncodeBase::EndPicture(VADriverContext*, unsigned int) (media_ddi_encode_base.cpp:77)
