### PR TITLE
[VP] Write only one sync tag in Vebox command buffer

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
@@ -2071,7 +2071,7 @@ MOS_STATUS VPHAL_VEBOX_STATE::VeboxRenderVeboxCmd(
     //---------------------------------
     // Write GPU Status Tag for Tag based synchronization
     //---------------------------------
-    if (!pOsInterface->bEnableKmdMediaFrameTracking)
+    if (pOsInterface->bEnableKmdMediaFrameTracking)
     {
         VPHAL_RENDER_CHK_STATUS(VeboxSendVecsStatusTag(
             pMhwMiInterface,


### PR DESCRIPTION
In VPHAL_VEBOX_STATE::VeboxRenderVeboxCmd, there are currently
2 writes for sync tag:

1.  https://github.com/intel/media-driver/blob/8de44c97c6d221d793e54d94add19fdfeda9797e/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp#L2076
2.  https://github.com/intel/media-driver/blob/8de44c97c6d221d793e54d94add19fdfeda9797e/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp#L2093

When pOsInterface->bEnableKmdMediaFrameTracking is false, both
writes get inserted into the command buffer.  Only one of them is
needed, depending on pOsInterface->bEnableKmdMediaFrameTracking.

This fixes https://github.com/intel/media-driver/issues/1060.