### PR TITLE
[Decode] Report the correct profile for AV1 decode

### DIFF
--- a/media_driver/linux/gen12/codec/ddi/media_ddi_decode_av1_g12.cpp
+++ b/media_driver/linux/gen12/codec/ddi/media_ddi_decode_av1_g12.cpp
@@ -441,6 +441,11 @@ VAStatus DdiDecodeAV1::SetDecodeParams()
         filmGrainProcParams.m_outputSurface = &outputSurface;
     }
 
+    if (Av1PicParams->m_bitDepthIdx == 1)
+    {
+        m_codechalSettings->lumaChromaDepth |= CODECHAL_LUMA_CHROMA_DEPTH_10_BITS;
+    }
+
     return VA_STATUS_SUCCESS;
 }
 
@@ -730,10 +735,6 @@ VAStatus DdiDecodeAV1::CodecHalInit(
     m_codechalSettings->intelEntrypointInUse = false;
 
     m_codechalSettings->lumaChromaDepth = CODECHAL_LUMA_CHROMA_DEPTH_8_BITS;
-    if (m_ddiDecodeAttr->profile == (VAProfile)VAProfileAV1Profile1)
-    {
-        m_codechalSettings->lumaChromaDepth |= CODECHAL_LUMA_CHROMA_DEPTH_10_BITS;
-    }
 
     m_codechalSettings->shortFormatInUse = m_ddiDecodeCtx->bShortFormatInUse;
 

--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1032,7 +1032,7 @@ VAStatus MediaLibvaCapsG12::QuerySurfaceAttributes(
     }
     else if (entrypoint == VAEntrypointVLD)    /* vld */
     {
-        if (profile == VAProfileHEVCMain10 || profile == VAProfileVP9Profile2 || profile == VAProfileAV1Profile1)
+        if (profile == VAProfileHEVCMain10 || profile == VAProfileVP9Profile2)
         {
             attribs[i].type = VASurfaceAttribPixelFormat;
             attribs[i].value.type = VAGenericValueTypeInteger;
@@ -1054,6 +1054,20 @@ VAStatus MediaLibvaCapsG12::QuerySurfaceAttributes(
                 attribs[i].value.value.i = VA_FOURCC_P016;
                 i++;
             }
+        }
+        else if (profile == VAProfileAV1Profile0)
+        {
+            attribs[i].type = VASurfaceAttribPixelFormat;
+            attribs[i].value.type = VAGenericValueTypeInteger;
+            attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+            attribs[i].value.value.i = VA_FOURCC('N', 'V', '1', '2');
+            i++;
+
+            attribs[i].type = VASurfaceAttribPixelFormat;
+            attribs[i].value.type = VAGenericValueTypeInteger;
+            attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
+            attribs[i].value.value.i = VA_FOURCC_P010;
+            i++;
         }
         else if(profile == VAProfileHEVCMain12)
         {
@@ -2027,7 +2041,7 @@ VAStatus MediaLibvaCapsG12::CreateDecAttributes(
             | VA_RT_FORMAT_YUV422_12
             | VA_RT_FORMAT_YUV444_12;
     }
-    else if (profile == VAProfileAV1Profile0 || profile == VAProfileAV1Profile1)
+    else if (profile == VAProfileAV1Profile0)
     {
         attrib.value = VA_RT_FORMAT_YUV420 | VA_RT_FORMAT_YUV420_10BPP;
     }
@@ -2106,11 +2120,11 @@ VAStatus MediaLibvaCapsG12::CreateDecAttributes(
             attrib.value = VA_ATTRIB_NOT_SUPPORTED;
         }
     }
-    else if (profile == VAProfileAV1Profile0 ||
-            profile == VAProfileAV1Profile1)
+    else if (profile == VAProfileAV1Profile0)
     {
         attrib.value = 0;
-        if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding8bit420))
+        if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding8bit420)
+            || MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding10bit420))
         {
             attrib.value |= VA_DEC_SLICE_MODE_NORMAL | VA_DEC_SLICE_MODE_BASE;
         }
@@ -2258,7 +2272,8 @@ VAStatus MediaLibvaCapsG12::LoadAv1DecProfileEntrypoints()
 
 #if _AV1_DECODE_SUPPORTED
     AttribMap *attributeList = nullptr;
-    if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding8bit420))
+    if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding8bit420)
+        ||MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding10bit420))
     {
         status = CreateDecAttributes((VAProfile) VAProfileAV1Profile0, VAEntrypointVLD, &attributeList);
         DDI_CHK_RET(status, "Failed to initialize Caps!");
@@ -2273,20 +2288,6 @@ VAStatus MediaLibvaCapsG12::LoadAv1DecProfileEntrypoints()
                 configStartIdx, m_decConfigs.size() - configStartIdx);
     }
 
-    if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrIntelAV1VLDDecoding10bit420))
-    {
-        status = CreateDecAttributes((VAProfile) VAProfileAV1Profile1, VAEntrypointVLD, &attributeList);
-        DDI_CHK_RET(status, "Failed to initialize Caps!");
-
-        uint32_t configStartIdx = m_decConfigs.size();
-        for (int32_t i = 0; i < 2; i++)
-        {
-            AddDecConfig(m_decSliceMode[i], VA_CENC_TYPE_NONE, VA_DEC_PROCESSING_NONE);
-        }
-
-        AddProfileEntry((VAProfile) VAProfileAV1Profile1, VAEntrypointVLD, attributeList,
-                configStartIdx, m_decConfigs.size() - configStartIdx);
-    }
 #endif
     return status;
 }


### PR DESCRIPTION
Driver only supports profile0 for AV1 decode on gen12, this change is to report correct profile
for av1 420 8bit and 420 10bit.

Signed-off-by: zefuli <zefu.li@intel.com>