### PR TITLE
media_libva_util: Fix odd resoultion handling of yuv420 formats

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_util.cpp
+++ b/media_driver/linux/common/ddi/media_libva_util.cpp
@@ -208,6 +208,8 @@ VAStatus DdiMediaUtil_AllocateSurface(
                 !(mediaSurface->surfaceUsageHint & VA_SURFACE_ATTRIB_USAGE_HINT_VPP_WRITE))
             {
                 tileformat = I915_TILING_NONE;
+                alignedWidth = MOS_ALIGN_CEIL(width, 2);
+                alignedHeight = MOS_ALIGN_CEIL(width, 2);
                 break;
             }
         case Media_Format_RGBP:
@@ -420,7 +422,6 @@ VAStatus DdiMediaUtil_AllocateSurface(
         else if (mediaSurface->pSurfDesc->uiVaMemType == VA_SURFACE_ATTRIB_MEM_TYPE_VA)
         {
             tileformat = I915_TILING_NONE;
-            alignedHeight = height;
         } else {
             DDI_ASSERTMESSAGE("Input buffer descriptor (%d) is not supported by current driver.", mediaSurface->pSurfDesc->uiFlags);
             return VA_STATUS_ERROR_ALLOCATION_FAILED;


### PR DESCRIPTION
media_libva_util: Fix odd resolution handling of yuv420 formats
    
Ensure 2-byte width & height alignment for I420/YV12/IYUV surfaces
when there is no usage hint set for Encode or VPP write operations.
It seems the  odd resolution surface post-processing operation
(eg: nv12 to i420 conversion via vaGetImage API), causing a green
column on the right side of the video without this alignment.
    
Fixing #1037
