### PR TITLE
Encode - Display assert message before returning error

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_base.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_base.cpp
@@ -284,7 +284,7 @@ VAStatus DdiEncodeBase::StatusReport(
         }
         else if (CODECHAL_STATUS_ERROR == encodeStatusReport[0].CodecStatus)
         {
-            DDI_NORMALMESSAGE("Encoding failure due to HW issue");
+            DDI_ASSERTMESSAGE("Encoding failure due to HW issue");
             m_encodeCtx->BufMgr.pCodedBufferSegment->buf  = DdiMediaUtil_LockBuffer(mediaBuf, MOS_LOCKFLAG_READONLY);
             m_encodeCtx->BufMgr.pCodedBufferSegment->size = 0;
             m_encodeCtx->BufMgr.pCodedBufferSegment->status |= VA_CODED_BUF_STATUS_BAD_BITSTREAM;


### PR DESCRIPTION
While checking igd logs for encode failure debug, normal message was
printed and then VA_STATUS_ERROR_ENCODING_ERROR was returned, so it was
misleading. Critical failure before returning error will be good.

Signed-off-by: Sushma Venkatesh Reddy <sushma08reddy@gmail.com>