### PR TITLE
Move the implementation of GetGpuPriority and SetGpuPriority

### DIFF
--- a/media_driver/linux/common/os/mos_context_specific.cpp
+++ b/media_driver/linux/common/os/mos_context_specific.cpp
@@ -365,6 +365,14 @@ void OsContextSpecific::DestroySSEUIPC()
     }
 }
 
+void OsContextSpecific::SetSliceCount(uint32_t *pSliceCount)
+{
+    if (pSliceCount == nullptr)
+        MOS_OS_ASSERTMESSAGE("pSliceCount is NULL.");
+}
+
+#endif //#ifndef ANDROID
+
 void OsContextSpecific::GetGpuPriority(int32_t* pPriority)
 {
     uint64_t priority = 0;
@@ -381,14 +389,6 @@ void OsContextSpecific::SetGpuPriority(int32_t priority)
         MOS_OS_NORMALMESSAGE("Warning: failed to set the gpu priority, errno is %d", ret);
     }
 }
-
-void OsContextSpecific::SetSliceCount(uint32_t *pSliceCount)
-{
-    if (pSliceCount == nullptr)
-        MOS_OS_ASSERTMESSAGE("pSliceCount is NULL.");
-}
-
-#endif //#ifndef ANDROID
 
 MOS_STATUS OsContextSpecific::Init(PMOS_CONTEXT pOsDriverContext)
 {


### PR DESCRIPTION
These 2 functions are currently implemented within
a "#ifndef ANDROID" block in mos_context_specific.cpp.
When ANDROID is defined, these implementations are compiled out,
but they are still referenced by mos_os_specific.c, leading to
linking errors.

This patch simply moves the 2 functions outside of the
"#ifndef ANDROID" block so that they are always available.

This fixes https://github.com/intel/media-driver/issues/1100.