### PR TITLE
Fix loss of AYUV format in vaQuerySurfaceAttributes.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.h
+++ b/media_driver/linux/common/ddi/media_libva.h
@@ -62,7 +62,7 @@
 #endif
 #define DDI_CODEC_GEN_MAX_ATTRIBS_TYPE             4    //VAConfigAttribRTFormat,    VAConfigAttribRateControl,    VAConfigAttribDecSliceMode,    VAConfigAttribEncPackedHeaders
 
-#define DDI_CODEC_GEN_MAX_SURFACE_ATTRIBUTES       24
+#define DDI_CODEC_GEN_MAX_SURFACE_ATTRIBUTES       25
 #define DDI_CODEC_GEN_STR_VENDOR                   "Intel iHD driver for Intel(R) Gen Graphics - " MEDIA_VERSION " (" MEDIA_VERSION_DETAILS ")"
 
 #define DDI_CODEC_GET_VTABLE(ctx)                  (ctx->vtable)

--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -85,7 +85,8 @@ const uint32_t MediaLibvaCaps::m_vpSurfaceAttr[m_numVpSurfaceAttr] =
     VA_FOURCC_A2R10G10B10,
     VA_FOURCC_A2B10G10R10,
     VA_FOURCC_X2R10G10B10,
-    VA_FOURCC_X2B10G10R10
+    VA_FOURCC_X2B10G10R10,
+    VA_FOURCC_AYUV
 };
 
 const uint32_t MediaLibvaCaps::m_jpegSurfaceAttr[m_numJpegSurfaceAttr] =
@@ -3375,6 +3376,7 @@ GMM_RESOURCE_FORMAT MediaLibvaCaps::ConvertMediaFmtToGmmFmt(
         case Media_Format_BGRP       : return GMM_FORMAT_BGRP;
         case Media_Format_NV12       : return GMM_FORMAT_NV12_TYPE;
         case Media_Format_NV21       : return GMM_FORMAT_NV21_TYPE;
+        case Media_Format_AYUV       : return GMM_FORMAT_AYUV_TYPE;
         case Media_Format_YUY2       : return GMM_FORMAT_YUY2;
         case Media_Format_UYVY       : return GMM_FORMAT_UYVY;
         case Media_Format_YV12       : return GMM_FORMAT_YV12_TYPE;
@@ -3390,18 +3392,16 @@ GMM_RESOURCE_FORMAT MediaLibvaCaps::ConvertMediaFmtToGmmFmt(
         case Media_Format_P010       : return GMM_FORMAT_P010_TYPE;
         case Media_Format_P012       : return GMM_FORMAT_P016_TYPE;
         case Media_Format_P016       : return GMM_FORMAT_P016_TYPE;
-#if VA_CHECK_VERSION(1, 9, 0)
-        case Media_Format_Y212       : return GMM_FORMAT_Y212_TYPE;
-#endif
         case Media_Format_Y216       : return GMM_FORMAT_Y216_TYPE;
-#if VA_CHECK_VERSION(1, 9, 0)
-        case Media_Format_Y412       : return GMM_FORMAT_Y412_TYPE;
-#endif
         case Media_Format_Y416       : return GMM_FORMAT_Y416_TYPE;
         case Media_Format_R10G10B10A2: return GMM_FORMAT_R10G10B10A2_UNORM_TYPE;
         case Media_Format_B10G10R10A2: return GMM_FORMAT_B10G10R10A2_UNORM_TYPE;
         case Media_Format_R10G10B10X2: return GMM_FORMAT_R10G10B10A2_UNORM_TYPE;
         case Media_Format_B10G10R10X2: return GMM_FORMAT_B10G10R10A2_UNORM_TYPE;
+#if VA_CHECK_VERSION(1, 9, 0)
+        case Media_Format_Y212       : return GMM_FORMAT_Y212_TYPE;
+        case Media_Format_Y412       : return GMM_FORMAT_Y412_TYPE;
+#endif
         default                      : return GMM_FORMAT_INVALID;
     }
 }

--- a/media_driver/linux/common/ddi/media_libva_caps.h
+++ b/media_driver/linux/common/ddi/media_libva_caps.h
@@ -772,7 +772,7 @@ protected:
 
     static const uint16_t m_maxProfiles = 17; //!< Maximum number of supported profiles
     static const uint16_t m_maxProfileEntries = 64; //!< Maximum number of supported profile & entrypoint combinations
-    static const uint32_t m_numVpSurfaceAttr = 17; //!< Number of VP surface attributes
+    static const uint32_t m_numVpSurfaceAttr = 18; //!< Number of VP surface attributes
     static const uint32_t m_numJpegSurfaceAttr = 7; //!< Number of JPEG surface attributes
     static const uint32_t m_numJpegEncSurfaceAttr = 4; //!< Number of JPEG encode surface attributes
     static const uint16_t m_maxEntrypoints = 7; //!<  Maximum number of supported entrypoints


### PR DESCRIPTION
Fixing https://github.com/intel/media-driver/issues/1047
Previous fix https://github.com/intel/media-driver/pull/1084  caused regression.
Re-fix this issue.
Signed off by: jay.yang@intel.com