### PR TITLE
[Decode] Separate VAContextParameterUpdateBufferType from default branch

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_base.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_base.cpp
@@ -1019,6 +1019,14 @@ VAStatus DdiMediaDecode::CreateBuffer(
             buf->pData      = (uint8_t*)MOS_AllocAndZeroMemory(size * numElements);
             buf->format     = Media_Format_CPU;
             break;
+#if VA_CHECK_VERSION(1, 10, 0)
+        case VAContextParameterUpdateBufferType:
+        {
+            buf->pData      = (uint8_t*)MOS_AllocAndZeroMemory(size * numElements);
+            buf->format     = Media_Format_CPU;
+            break;
+        }
+#endif
         default:
             va = m_ddiDecodeCtx->pCpDdiInterface->CreateBuffer(type, buf, size, numElements);
             if (va  == VA_STATUS_ERROR_UNSUPPORTED_BUFFERTYPE)


### PR DESCRIPTION
For dynamic gpu session priority feature, due to add the log message in the
default branch, so separate the type from default branch.

Signed-off-by: Wang Dylan <dylan.wang@intel.com>