### PR TITLE
[Encode] Fixed VP9 444 frame header

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libvpx_vp9.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libvpx_vp9.cpp
@@ -97,9 +97,9 @@ void write_bitdepth_colorspace_sampling(uint32_t codecProfile,
         (codecProfile == VP9_PROFILE_3))
     {
         /* sub_sampling_x/y */
-        /* Currently the sub_sampling_x = 0, sub_sampling_y = 1 */
+        /* Currently the sub_sampling_x = 0, sub_sampling_y = 0 */
         vp9_wb_write_bit(wb, 0);
-        vp9_wb_write_bit(wb, 1);
+        vp9_wb_write_bit(wb, 0);
         vp9_wb_write_bit(wb, 0); // unused
     }
 }


### PR DESCRIPTION
According VP9 spec section 7.2.2 color config semantics,
both subsampling_x and subsampling_y should be 0 for YUV444.
Only YUV440 subsampling_x=0 and subsampling_y=1.

fixes #1074

Signed-off-by: Lim Siew Hoon <siew.hoon.lim@intel.com>