### PR TITLE
media-libva: Add export AYUV color in vaExportSurfaceHandle

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -6823,6 +6823,8 @@ static uint32_t DdiMedia_GetDrmFormatOfSeparatePlane(uint32_t fourcc, int plane)
             return DRM_FORMAT_VYUY;
         case VA_FOURCC_UYVY:
             return DRM_FORMAT_UYVY;
+        case VA_FOURCC_AYUV:
+            return DRM_FORMAT_AYUV;
         case VA_FOURCC_Y210:
             return DRM_FORMAT_Y210;
         case VA_FOURCC_Y216:


### PR DESCRIPTION
when VA_EXPORT_SURFACE_COMPOSED_LAYERS is not set.

Example:
gst-launch-1.0 videotestsrc ! msdkvpp \
'video/x-raw(memory:DMABuf)',format=VUYA ! glimagesink

fixes #1114

Signed-off-by: Lim Siew Hoon <siew.hoon.lim@intel.com>