### PR TITLE
Modify mos_gem_bo_clear_relocs in i915_production/mos_bufmgr.c

### DIFF
--- a/media_driver/linux/common/os/i915_production/mos_bufmgr.c
+++ b/media_driver/linux/common/os/i915_production/mos_bufmgr.c
@@ -2715,6 +2715,8 @@ mos_gem_bo_clear_relocs(struct mos_linux_bo *bo, int start)
         struct mos_bo_gem *target_bo_gem = (struct mos_bo_gem *) bo_gem->reloc_target_info[i].bo;
         if (&target_bo_gem->bo != bo) {
             bo_gem->reloc_tree_fences -= target_bo_gem->reloc_tree_fences;
+            target_bo_gem->used_as_reloc_target = false;
+            target_bo_gem->reloc_count = 0;
             mos_gem_bo_unreference_locked_timed(&target_bo_gem->bo,
                                   time.tv_sec);
         }


### PR DESCRIPTION
Fix av1 decode segment fault when calling function mos_gem_bo_process_reloc2
in media-driver/media_driver/linux/common/os/i915_production/mos_bufmgr.c

Signed-off-by: Zhang Yuankun <yuankunx.zhang@intel.com>