### PR TITLE
Enable WaDisableGmmLibOffsetInDeriveImage for JSL/EHL

### DIFF
--- a/media_driver/linux/gen11/ddi/media_sku_wa_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_sku_wa_g11.cpp
@@ -385,6 +385,10 @@ static bool InitEhlMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrTileY, 1);
 
     MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
+    
+    /*Software workaround to disable the UV offset calculation by gmmlib
+      CPU blt call will add/remove padding on the platform*/
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
 
     return true;
 }


### PR DESCRIPTION
Enables the software workaround to disable calculation of the UV
offset by gmmlib. An incorrect UV offset was by returned  gmmlib
in vaDeriveImage() which casues the shift in the color planes(UV).
This was observed during a chromecast session in mirror mode on ChromeOS
with H264 encode.