### PR TITLE
vaDeriveImage: Enable WaDisableGmmLibOffsetInDeriveImage for JSL/EHL

### DIFF
--- a/media_driver/linux/gen11/ddi/media_sku_wa_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_sku_wa_g11.cpp
@@ -413,6 +413,9 @@ static bool InitEhlMediaWa(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
 
+    /*Software workaround to disable the UV offset calculation by gmmlib
+      CPU blt call will add/remove padding on the platform*/
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 


### PR DESCRIPTION
Enables the software workaround to disable calculation of the UV
offset by gmmlib. An incorrect UV offset was by returned  gmmlib
in vaDeriveImage which casues the shift in the color planes(UV).
This was observed during a chromecast session in mirror mode on ChromeOS
with H264 encode.