### PR TITLE
Increase patchlist buffer for MI_STORE_DATA_IMM_CMD

### DIFF
--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_hcp_g12_X.cpp
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_hcp_g12_X.cpp
@@ -713,7 +713,7 @@ MOS_STATUS MhwVdboxHcpInterfaceG12::GetHcpStateCommandSize(
                     4 * PATCH_LIST_COMMAND(MI_ATOMIC_CMD) +
                     2 * PATCH_LIST_COMMAND(MI_CONDITIONAL_BATCH_BUFFER_END_CMD) +
                     3 * PATCH_LIST_COMMAND(MI_SEMAPHORE_WAIT_CMD) +
-                    3 * PATCH_LIST_COMMAND(MI_STORE_DATA_IMM_CMD) +
+                    18 * PATCH_LIST_COMMAND(MI_STORE_DATA_IMM_CMD) +
                     2 * PATCH_LIST_COMMAND(MI_FLUSH_DW_CMD) +
                     2 * PATCH_LIST_COMMAND(MI_STORE_REGISTER_MEM_CMD);
 


### PR DESCRIPTION
[Decode] increase patchlist buffer for MI_STORE_DATA_IMM_CMD

For real scalibility case, 15 MI_STORE_DATA_IMM_CMDs are added for BE
sync, but Patchlist size is not added.