### PR TITLE
fix stack buffer read access overflow issue.

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decode_scalability.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_scalability.cpp
@@ -30,6 +30,7 @@
 #include "mos_util_user_interface.h"
 #include "mos_solo_generic.h"
 #include "mos_os_virtualengine_next.h"
+#include "codechal_decode_scalability_g12.h"
 
 //!
 //! \brief    calculate secondary cmd buffer index
@@ -1368,7 +1369,7 @@ MOS_STATUS CodechalDecodeScalability_ConstructParmsForGpuCtxCreation(
     CodechalSetting *                          codecHalSetting)
 {
     PMOS_INTERFACE                           pOsInterface;
-    CODECHAL_DECODE_SCALABILITY_INIT_PARAMS  initParams;
+    CODECHAL_DECODE_SCALABILITY_INIT_PARAMS_G12  initParams;
     MOS_STATUS                               eStatus = MOS_STATUS_SUCCESS;
 
     CODECHAL_DECODE_FUNCTION_ENTER;


### PR DESCRIPTION
CODECHAL_DECODE_SCALABILITY_INIT_PARAMS_G12 is used in CodecHalDecodeScalability_DecidePipeNum_G12,
so use CODECHAL_DECODE_SCALABILITY_INIT_PARAMS_G12 instead of CODECHAL_DECODE_SCALABILITY_INIT_PARAMS
to avoid access overflow.