### PR TITLE
Stop using PWRITE

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_base.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_base.cpp
@@ -1096,13 +1096,10 @@ VAStatus DdiMediaDecode::CreateBuffer(
 
     if( true == buf->bCFlushReq )
     {
-        mos_bo_subdata(buf->bo, buf->uiOffset, size * numElements, data);
+        mos_bo_wait_rendering(buf->bo);
     }
-    else
-    {
-        status = MOS_SecureMemcpy((void *)(buf->pData + buf->uiOffset), size * numElements, data, size * numElements);
-        DDI_CHK_CONDITION((status != MOS_STATUS_SUCCESS), "DDI:Failed to copy buffer data!", VA_STATUS_ERROR_OPERATION_FAILED);
-    }
+    status = MOS_SecureMemcpy((void *)(buf->pData + buf->uiOffset), size * numElements, data, size * numElements);
+    DDI_CHK_CONDITION((status != MOS_STATUS_SUCCESS), "DDI:Failed to copy buffer data!", VA_STATUS_ERROR_OPERATION_FAILED);
     return va;
 
 CleanUpandReturn:

--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vp8.cpp
@@ -264,21 +264,12 @@ VAStatus DdiDecodeVP8::ParseProbabilityData(
 {
     if (vp8ProbDataBuff->pData && probInputBuf)
     {
-        MOS_LINUX_BO *boDes = nullptr;
-        boDes               = vp8ProbDataBuff->bo;
-
-        mos_bo_wait_rendering(boDes);
-        if (0 == mos_bo_subdata(boDes,
-                     0,
-                     sizeof(CODECHAL_VP8_COEFFPROB_DATA),
-                     probInputBuf))
-        {
-            return VA_STATUS_SUCCESS;
-        }
-        else
-        {
-            return VA_STATUS_ERROR_INVALID_PARAMETER;
-        }
+        mos_bo_wait_rendering(vp8ProbDataBuff->bo);
+        MOS_SecureMemcpy(vp8ProbDataBuff->pData,
+                         sizeof(CODECHAL_VP8_COEFFPROB_DATA),
+                         probInputBuf,
+                         sizeof(CODECHAL_VP8_COEFFPROB_DATA));
+        return VA_STATUS_SUCCESS;
     }
     else
     {

--- a/media_driver/linux/common/os/i915/include/mos_bufmgr.h
+++ b/media_driver/linux/common/os/i915/include/mos_bufmgr.h
@@ -159,10 +159,6 @@ void mos_bo_unreference(struct mos_linux_bo *bo);
 int mos_bo_map(struct mos_linux_bo *bo, int write_enable);
 int mos_bo_unmap(struct mos_linux_bo *bo);
 
-int mos_bo_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, const void *data);
-int mos_bo_get_subdata(struct mos_linux_bo *bo, unsigned long offset,
-                 unsigned long size, void *data);
 void mos_bo_wait_rendering(struct mos_linux_bo *bo);
 
 void mos_bufmgr_set_debug(struct mos_bufmgr *bufmgr, int enable_debug);
@@ -404,8 +400,6 @@ drm_export void mos_gem_bo_unreference_final(struct mos_linux_bo *bo, time_t tim
 drm_export int mos_gem_bo_map(struct mos_linux_bo *bo, int write_enable);
 drm_export int map_gtt(struct mos_linux_bo *bo);
 drm_export int mos_gem_bo_unmap(struct mos_linux_bo *bo);
-drm_export int mos_gem_bo_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, const void *data);
 
 drm_export bool mos_gem_bo_is_softpin(struct mos_linux_bo *bo);
 drm_export bool mos_gem_bo_is_exec_object_async(struct mos_linux_bo *bo);

--- a/media_driver/linux/common/os/i915/include/mos_bufmgr_priv.h
+++ b/media_driver/linux/common/os/i915/include/mos_bufmgr_priv.h
@@ -122,24 +122,6 @@ struct mos_bufmgr {
     int (*bo_unmap) (struct mos_linux_bo *bo);
 
     /**
-     * Write data into an object.
-     *
-     * This is an optional function, if missing,
-     * drm_intel_bo will map/memcpy/unmap.
-     */
-    int (*bo_subdata) (struct mos_linux_bo *bo, unsigned long offset,
-               unsigned long size, const void *data);
-
-    /**
-     * Read data from an object
-     *
-     * This is an optional function, if missing,
-     * drm_intel_bo will map/memcpy/unmap.
-     */
-    int (*bo_get_subdata) (struct mos_linux_bo *bo, unsigned long offset,
-                   unsigned long size, void *data);
-
-    /**
      * Waits for rendering to an object by the GPU to have completed.
      *
      * This is not required for any access to the BO by bo_map,

--- a/media_driver/linux/common/os/i915/mos_bufmgr.c
+++ b/media_driver/linux/common/os/i915/mos_bufmgr.c
@@ -1912,37 +1912,6 @@ int mos_gem_bo_get_fake_offset(struct mos_linux_bo *bo)
     return ret;
 }
 
-drm_export int
-mos_gem_bo_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, const void *data)
-{
-    struct mos_bufmgr_gem *bufmgr_gem = (struct mos_bufmgr_gem *) bo->bufmgr;
-    struct mos_bo_gem *bo_gem = (struct mos_bo_gem *) bo;
-    struct drm_i915_gem_pwrite pwrite;
-    int ret;
-
-    if (bo_gem->is_userptr)
-        return -EINVAL;
-
-    memclear(pwrite);
-    pwrite.handle = bo_gem->gem_handle;
-    pwrite.offset = offset;
-    pwrite.size = size;
-    pwrite.data_ptr = (uint64_t) (uintptr_t) data;
-
-    ret = drmIoctl(bufmgr_gem->fd,
-               DRM_IOCTL_I915_GEM_PWRITE,
-               &pwrite);
-    if (ret != 0) {
-        ret = -errno;
-        MOS_DBG("%s:%d: Error writing data to buffer %d: (%d %d) %s .\n",
-            __FILE__, __LINE__, bo_gem->gem_handle, (int)offset,
-            (int)size, strerror(errno));
-    }
-
-    return ret;
-}
-
 static int
 mos_gem_get_pipe_from_crtc_id(struct mos_bufmgr *bufmgr, int crtc_id)
 {
@@ -1966,36 +1935,6 @@ mos_gem_get_pipe_from_crtc_id(struct mos_bufmgr *bufmgr, int crtc_id)
     }
 
     return get_pipe_from_crtc_id.pipe;
-}
-
-static int
-mos_gem_bo_get_subdata(struct mos_linux_bo *bo, unsigned long offset,
-                 unsigned long size, void *data)
-{
-    struct mos_bufmgr_gem *bufmgr_gem = (struct mos_bufmgr_gem *) bo->bufmgr;
-    struct mos_bo_gem *bo_gem = (struct mos_bo_gem *) bo;
-    struct drm_i915_gem_pread pread;
-    int ret;
-
-    if (bo_gem->is_userptr)
-        return -EINVAL;
-
-    memclear(pread);
-    pread.handle = bo_gem->gem_handle;
-    pread.offset = offset;
-    pread.size = size;
-    pread.data_ptr = (uint64_t) (uintptr_t) data;
-    ret = drmIoctl(bufmgr_gem->fd,
-               DRM_IOCTL_I915_GEM_PREAD,
-               &pread);
-    if (ret != 0) {
-        ret = -errno;
-        MOS_DBG("%s:%d: Error reading data from buffer %d: (%d %d) %s .\n",
-            __FILE__, __LINE__, bo_gem->gem_handle, (int)offset,
-            (int)size, strerror(errno));
-    }
-
-    return ret;
 }
 
 /** Waits for all GPU rendering with the object to have completed. */
@@ -4003,8 +3942,6 @@ mos_bufmgr_gem_init(int fd, int batch_size)
     bufmgr_gem->bufmgr.bo_unreference = mos_gem_bo_unreference;
     bufmgr_gem->bufmgr.bo_map = mos_gem_bo_map;
     bufmgr_gem->bufmgr.bo_unmap = mos_gem_bo_unmap;
-    bufmgr_gem->bufmgr.bo_subdata = mos_gem_bo_subdata;
-    bufmgr_gem->bufmgr.bo_get_subdata = mos_gem_bo_get_subdata;
     bufmgr_gem->bufmgr.bo_wait_rendering = mos_gem_bo_wait_rendering;
     bufmgr_gem->bufmgr.bo_pad_to_size = mos_gem_bo_pad_to_size;
     bufmgr_gem->bufmgr.bo_emit_reloc = mos_gem_bo_emit_reloc;

--- a/media_driver/linux/common/os/i915/mos_bufmgr_api.c
+++ b/media_driver/linux/common/os/i915/mos_bufmgr_api.c
@@ -125,36 +125,6 @@ mos_bo_unmap(struct mos_linux_bo *buf)
     return buf->bufmgr->bo_unmap(buf);
 }
 
-int
-mos_bo_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, const void *data)
-{
-    return bo->bufmgr->bo_subdata(bo, offset, size, data);
-}
-
-int
-mos_bo_get_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, void *data)
-{
-    int ret;
-    if (bo->bufmgr->bo_get_subdata)
-        return bo->bufmgr->bo_get_subdata(bo, offset, size, data);
-
-    if (size == 0 || data == nullptr)
-        return 0;
-
-    ret = mos_bo_map(bo, 0);
-    if (ret)
-        return ret;
-#ifdef __cplusplus
-    memcpy(data, (unsigned char *)bo->virt + offset, size);
-#else
-    memcpy(data, (unsigned char *)bo->virtual + offset, size);
-#endif
-    mos_bo_unmap(bo);
-    return 0;
-}
-
 void
 mos_bo_wait_rendering(struct mos_linux_bo *bo)
 {

--- a/media_driver/linux/ult/libdrm_mock/mos_bufmgr_api_mock.c
+++ b/media_driver/linux/ult/libdrm_mock/mos_bufmgr_api_mock.c
@@ -110,36 +110,6 @@ mos_bo_unmap(struct mos_linux_bo *buf)
     return buf->bufmgr->bo_unmap(buf);
 }
 
-int
-mos_bo_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, const void *data)
-{
-    return bo->bufmgr->bo_subdata(bo, offset, size, data);
-}
-
-int
-mos_bo_get_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, void *data)
-{
-    int ret;
-    if (bo->bufmgr->bo_get_subdata)
-        return bo->bufmgr->bo_get_subdata(bo, offset, size, data);
-
-    if (size == 0 || data == nullptr)
-        return 0;
-
-    ret = mos_bo_map(bo, 0);
-    if (ret)
-        return ret;
-#ifdef __cplusplus
-    memcpy(data, (unsigned char *)bo->virt + offset, size);
-#else
-    memcpy(data, (unsigned char *)bo->virtual + offset, size);
-#endif
-    mos_bo_unmap(bo);
-    return 0;
-}
-
 void
 mos_bo_wait_rendering(struct mos_linux_bo *bo)
 {

--- a/media_driver/linux/ult/libdrm_mock/mos_bufmgr_mock.c
+++ b/media_driver/linux/ult/libdrm_mock/mos_bufmgr_mock.c
@@ -1982,42 +1982,6 @@ int mos_gem_bo_get_fake_offset(struct mos_linux_bo *bo)
     return ret;
 }
 
-drm_export int
-mos_gem_bo_subdata(struct mos_linux_bo *bo, unsigned long offset,
-             unsigned long size, const void *data)
-{
-    struct mos_bufmgr_gem *bufmgr_gem = (struct mos_bufmgr_gem *) bo->bufmgr;
-    struct mos_bo_gem *bo_gem = (struct mos_bo_gem *) bo;
-    struct drm_i915_gem_pwrite pwrite;
-    int ret;
-
-    if (bo_gem->is_userptr)
-        return -EINVAL;
-
-    memclear(pwrite);
-    pwrite.handle = bo_gem->gem_handle;
-    pwrite.offset = offset;
-    pwrite.size = size;
-    pwrite.data_ptr = (uint64_t) (uintptr_t) data;
-    if(GetDrmMode())
-    {
-        //As we discard the gem_handle, so we cannot mock it in drmIoctl.If we use a map for gem_handle, then we can mock drmIoctl.
-        memcpy((unsigned char *)bo_gem->mem_virtual+offset, data, size);
-        return 0;
-    }
-    ret = drmIoctl(bufmgr_gem->fd,
-               DRM_IOCTL_I915_GEM_PWRITE,
-               &pwrite);
-    if (ret != 0) {
-        ret = -errno;
-        MOS_DBG("%s:%d: Error writing data to buffer %d: (%d %d) %s .\n",
-            __FILE__, __LINE__, bo_gem->gem_handle, (int)offset,
-            (int)size, strerror(errno));
-    }
-
-    return ret;
-}
-
 static int
 mos_gem_get_pipe_from_crtc_id(struct mos_bufmgr *bufmgr, int crtc_id)
 {
@@ -2041,36 +2005,6 @@ mos_gem_get_pipe_from_crtc_id(struct mos_bufmgr *bufmgr, int crtc_id)
     }
 
     return get_pipe_from_crtc_id.pipe;
-}
-
-static int
-mos_gem_bo_get_subdata(struct mos_linux_bo *bo, unsigned long offset,
-                 unsigned long size, void *data)
-{
-    struct mos_bufmgr_gem *bufmgr_gem = (struct mos_bufmgr_gem *) bo->bufmgr;
-    struct mos_bo_gem *bo_gem = (struct mos_bo_gem *) bo;
-    struct drm_i915_gem_pread pread;
-    int ret;
-
-    if (bo_gem->is_userptr)
-        return -EINVAL;
-
-    memclear(pread);
-    pread.handle = bo_gem->gem_handle;
-    pread.offset = offset;
-    pread.size = size;
-    pread.data_ptr = (uint64_t) (uintptr_t) data;
-    ret = drmIoctl(bufmgr_gem->fd,
-               DRM_IOCTL_I915_GEM_PREAD,
-               &pread);
-    if (ret != 0) {
-        ret = -errno;
-        MOS_DBG("%s:%d: Error reading data from buffer %d: (%d %d) %s .\n",
-            __FILE__, __LINE__, bo_gem->gem_handle, (int)offset,
-            (int)size, strerror(errno));
-    }
-
-    return ret;
 }
 
 /** Waits for all GPU rendering with the object to have completed. */
@@ -4084,8 +4018,6 @@ mos_bufmgr_gem_init(int fd, int batch_size)
     bufmgr_gem->bufmgr.bo_unreference = mos_gem_bo_unreference;
     bufmgr_gem->bufmgr.bo_map = mos_gem_bo_map;
     bufmgr_gem->bufmgr.bo_unmap = mos_gem_bo_unmap;
-    bufmgr_gem->bufmgr.bo_subdata = mos_gem_bo_subdata;
-    bufmgr_gem->bufmgr.bo_get_subdata = mos_gem_bo_get_subdata;
     bufmgr_gem->bufmgr.bo_wait_rendering = mos_gem_bo_wait_rendering;
     bufmgr_gem->bufmgr.bo_pad_to_size = mos_gem_bo_pad_to_size;
     bufmgr_gem->bufmgr.bo_emit_reloc = mos_gem_bo_emit_reloc;


### PR DESCRIPTION
We're attempting to remove PWRITE support from i915 for future platforms and this prepares the media driver for the move.

My attempt at media driver hacking looks correct to me but I've only compile-tested it.