### PR TITLE
Enable WaAlignYUVResourceToLCU to JSL systems

### DIFF
--- a/media_driver/linux/gen11/ddi/media_sysinfo_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_sysinfo_g11.cpp
@@ -200,6 +200,9 @@ static bool InitEhlShadowWa(struct GfxDeviceInfo *devInfo,
     waTable->WaDisregardPlatformChecks          = 1;
     waTable->Wa4kAlignUVOffsetNV12LinearSurface = 1;
 
+    //source and recon surfaces need to be aligned to the LCU size
+    waTable->WaAlignYUVResourceToLCU = 1;
+
     return true;
 }
 


### PR DESCRIPTION
Workaround WaAlignYUVResourceToLCU is required on Gen11 and Gen12
systems. However, it was missed for EHL so, we were seeing difference in
surface size for JSL vs TGL. This patch ensures that there is no
difference in surface size between TGL and JSL.

Signed-off-by: Sushma Venkatesh Reddy <sushma.venkatesh.reddy@intel.com>