### PR TITLE
[Decode] Add the surface format check for jpeg decode

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_jpeg.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_jpeg.h
@@ -71,6 +71,8 @@ public:
 
     virtual VAStatus SetDecodeParams() override;
 
+    virtual MOS_FORMAT GetFormat() override;
+
     virtual void ContextInit(
         int32_t picWidth,
         int32_t picHeight) override;


### PR DESCRIPTION
App can only create the render surface with the format that is consistent with Codec bitstream

fixes #1124

Signed-off-by: Xu, Zhengguo <zhengguo.xu@intel.com>