### PR TITLE
media_libva: return ATTR_NOT_SUPPORTED in CreateSurfaces

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -2606,7 +2606,7 @@ DdiMedia_CreateSurfaces2(
                 break;
             default:
                 DDI_ASSERTMESSAGE("Unsupported type.");
-                break;
+                return VA_STATUS_ERROR_ATTR_NOT_SUPPORTED;
             }
         }
     }


### PR DESCRIPTION
If the attribute isn't supported, return ATTR_NOT_SUPPORTED instead
of silently ignoring it.