### PR TITLE
add new level definition for MPEG2 encode

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_mpeg2.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_mpeg2.cpp
@@ -50,6 +50,7 @@ enum ProfileIdc
 //!
 enum LevelIdc
 {
+    levelHighP       = 2,
     levelHigh        = 4,
     levelHigh1440    = 6,
     levelMain        = 8,
@@ -1713,6 +1714,7 @@ MOS_STATUS CodechalEncodeMpeg2::CheckProfileAndLevel()
         case levelHigh1440:
         case levelMain:
         case levelLow:
+        case levelHighP:
             break;
         default:
             return eStatus;


### PR DESCRIPTION
new extension is added , 1080p@60, the level is highP,
the value is 2. so need to add a new check

Fixes #1201

Signed-off-by: XinfengZhang <carl.zhang@intel.com>