### PR TITLE
Fix typo issue (resouces->resources)

### DIFF
--- a/media_driver/agnostic/common/cm/cm_device_rt_base.cpp
+++ b/media_driver/agnostic/common/cm/cm_device_rt_base.cpp
@@ -199,7 +199,7 @@ void CmDeviceRTBase::DestructCommon()
 #endif
 
     // Solve resource release dependency issue
-    // Flush Queue to make sure no task internal and connected resouces left.
+    // Flush Queue to make sure no task internal and connected resources left.
     m_criticalSectionQueue.Acquire();
     for (auto iter = m_queue.begin(); iter != m_queue.end(); iter++)
     {

--- a/media_driver/agnostic/common/os/mos_commandbuffer.h
+++ b/media_driver/agnostic/common/os/mos_commandbuffer.h
@@ -135,7 +135,7 @@ protected:
     //! \brief    Gpu context binded to
     GpuContext*       m_gpuContext       = nullptr;
 
-    //! \brief    Graphics resouce for command buffer
+    //! \brief    Graphics resource for command buffer
     GraphicsResource* m_graphicsResource = nullptr;
 
     //! \brief    Lock address for cpu side usage

--- a/media_driver/agnostic/common/os/mos_graphicsresource.h
+++ b/media_driver/agnostic/common/os/mos_graphicsresource.h
@@ -339,7 +339,7 @@ public:
     virtual bool IsEqual(GraphicsResource* toCompare) = 0;
 
     //!
-    //! \brief  Check whether the current graphic resouce is valid
+    //! \brief  Check whether the current graphic resource is valid
     //! \return Returns true if the two resources are equal and false otherwise.
     //!
     virtual bool IsValid() = 0;
@@ -391,7 +391,7 @@ public:
 
 protected:
     //!
-    //! \brief  Global graphic resouce counter
+    //! \brief  Global graphic resource counter
     //!
     static uint32_t m_memAllocCounterGfx;
 

--- a/media_driver/agnostic/common/os/mos_interface.h
+++ b/media_driver/agnostic/common/os/mos_interface.h
@@ -844,7 +844,7 @@ public:
     //! \return   MOS_STATUS
     //!           Return MOS_STATUS_SUCCESS if successful, otherwise failed
     //!
-    static MOS_STATUS GetReservedFromResouce(MOS_RESOURCE_HANDLE resource, uint32_t &val);
+    static MOS_STATUS GetReservedFromResource(MOS_RESOURCE_HANDLE resource, uint32_t &val);
 
     //!
     //! \brief    Get Reserved info from Stream
@@ -983,7 +983,7 @@ public:
     //!           bit definition in MOS_GFXRES_FREE_FLAGS
     //!
     //! \return   uint32_t
-    //!           OS resouce deallc flags
+    //!           OS resource deallc flags
     //!
     static uint32_t ConvertHalFreeFlagsToOsFreeFlags(
         uint32_t halFreeFlag

--- a/media_driver/agnostic/common/vp/hal/vphal_render_vebox_denoise.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_vebox_denoise.cpp
@@ -156,7 +156,7 @@ void VphalHVSDenoiser::InitKernelParams(void *kernelBinary, const int32_t kerneB
     m_kernelBinarySize      = kerneBinarySize;
 }
 
-void VphalHVSDenoiser::AllocateResouces(const uint32_t width, const uint32_t height)
+void VphalHVSDenoiser::AllocateResources(const uint32_t width, const uint32_t height)
 {
     uint32_t size         = width * height;
 
@@ -197,7 +197,7 @@ MOS_STATUS VphalHVSDenoiser::Render(const PVPHAL_SURFACE pSrcSuface)
         VPHAL_RENDER_CHK_NULL_RETURN(m_cmContext);
 
         m_hvsDenoise = MOS_New(HVSDenoise, m_renderHal, m_kernelBinary, m_kernelBinarySize, m_cmContext);
-        AllocateResouces(m_denoiseBufferInBytes, 1);
+        AllocateResources(m_denoiseBufferInBytes, 1);
 
         VPHAL_RENDER_NORMALMESSAGE("[0x%x] Init HVSDenoise[0x%x] and Allocate necessary resource!", this, m_hvsDenoise);
     }

--- a/media_driver/agnostic/common/vp/hal/vphal_render_vebox_denoise.h
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_vebox_denoise.h
@@ -77,7 +77,7 @@ public:
     }
 
 private:
-    void AllocateResouces(const uint32_t width, const uint32_t height);
+    void AllocateResources(const uint32_t width, const uint32_t height);
     void FreeResources();
 
     EventManager*                m_eventManager            = nullptr;

--- a/media_driver/agnostic/gen12/hw/mhw_state_heap_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/mhw_state_heap_hwcmd_g12_X.h
@@ -352,7 +352,7 @@ public:
                 uint32_t                 Reserved78                                       : __CODEGEN_BITFIELD(14, 15)    ; //!< Reserved
                 uint32_t                 Height                                           : __CODEGEN_BITFIELD(16, 29)    ; //!< Height
                 uint32_t                 Reserved94                                       : __CODEGEN_BITFIELD(30, 30)    ; //!< Reserved
-                uint32_t                 DepthStencilResouce                              : __CODEGEN_BITFIELD(31, 31)    ; //!< Depth/Stencil Resouce
+                uint32_t                 DepthStencilResource                              : __CODEGEN_BITFIELD(31, 31)    ; //!< Depth/Stencil Resource
             };
             uint32_t                     Value;
         } DW2;

--- a/media_driver/linux/common/os/mos_graphicsresource_specific.h
+++ b/media_driver/linux/common/os/mos_graphicsresource_specific.h
@@ -102,7 +102,7 @@ public:
     void Free(OsContext* osContextPtr, uint32_t  freeFlag = 0);
 
     //!
-    //! \brief  Check whether the specific graphic resouces is equal to the current one
+    //! \brief  Check whether the specific graphic resources is equal to the current one
     //! \param  [in] toCompare
     //!         ptr to the graphics resource to be compared with 
     //! \return Returns true if the two resources are equal and false otherwise.
@@ -110,7 +110,7 @@ public:
     bool IsEqual(GraphicsResource* toCompare);
 
     //!
-    //! \brief  Check whether the current graphic resouce is valid
+    //! \brief  Check whether the current graphic resource is valid
     //! \return Returns true if a resource is valid and false otherwise.
     //!
     bool IsValid();

--- a/media_driver/linux/common/os/mos_interface.cpp
+++ b/media_driver/linux/common/os/mos_interface.cpp
@@ -1279,7 +1279,7 @@ uint8_t MosInterface::GetCachePolicyL1Config(
     return 0;
 }
 
-MOS_STATUS MosInterface::GetReservedFromResouce(MOS_RESOURCE_HANDLE resource, uint32_t &val)
+MOS_STATUS MosInterface::GetReservedFromResource(MOS_RESOURCE_HANDLE resource, uint32_t &val)
 {
     return MOS_STATUS_UNIMPLEMENTED;
 }

--- a/media_driver/linux/common/os/mos_os_specific.c
+++ b/media_driver/linux/common/os/mos_os_specific.c
@@ -3592,7 +3592,7 @@ MOS_STATUS Mos_Specific_RegisterResource (
     pResources = pOsGpuContext->pResources;
     if( nullptr == pResources)
     {
-        MOS_OS_ASSERTMESSAGE("pResouce is NULL.");
+        MOS_OS_ASSERTMESSAGE("pResource is NULL.");
         return MOS_STATUS_SUCCESS;
     }
     for (uiAllocation = 0;

--- a/media_driver/media_driver_next/agnostic/gen12/codec/hal/dec/av1/features/decode_av1_filmgrain_feature_g12.cpp
+++ b/media_driver/media_driver_next/agnostic/gen12/codec/hal/dec/av1/features/decode_av1_filmgrain_feature_g12.cpp
@@ -1146,7 +1146,7 @@ MOS_STATUS Av1DecodeFilmGrainG12::AllocateFixedSizeSurfaces()
         resourceInternalReadWriteCache, lockableVideoMem);
     DECODE_CHK_NULL(m_gaussianSequenceSurface);
 
-    auto data = (int16_t *)m_allocator->LockResouceForWrite(&m_gaussianSequenceSurface->OsResource);
+    auto data = (int16_t *)m_allocator->LockResourceForWrite(&m_gaussianSequenceSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 2048 * sizeof(int16_t), defaultGaussianSequence, 2048 * sizeof(int16_t));
 
@@ -1515,7 +1515,7 @@ MOS_STATUS Av1DecodeFilmGrainG12::SetFrameStates(
     // Y coefficients surface as input of RegressPhase1
     m_yCoefficientsSurface = m_yCoefficientsSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_yCoefficientsSurface);
-    auto data = (int16_t *)m_allocator->LockResouceForWrite(&m_yCoefficientsSurface->OsResource);
+    auto data = (int16_t *)m_allocator->LockResourceForWrite(&m_yCoefficientsSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 24 * sizeof(int16_t), coeffY, 24 * sizeof(int16_t));
 
@@ -1530,40 +1530,40 @@ MOS_STATUS Av1DecodeFilmGrainG12::SetFrameStates(
     //Y/U/V coefficients surfaces as input of RegressPhase2
     m_yCoeffSurface = m_yCoeffSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_yCoeffSurface);
-    data = (int16_t *)m_allocator->LockResouceForWrite(&m_yCoeffSurface->OsResource);
+    data = (int16_t *)m_allocator->LockResourceForWrite(&m_yCoeffSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 24 * sizeof(int16_t), coeffY, 24 * sizeof(int16_t));
 
     m_uCoeffSurface = m_uCoeffSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_uCoeffSurface);
-    data = (int16_t *)m_allocator->LockResouceForWrite(&m_uCoeffSurface->OsResource);
+    data = (int16_t *)m_allocator->LockResourceForWrite(&m_uCoeffSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 25 * sizeof(int16_t), coeffU, 25 * sizeof(int16_t));
 
     m_vCoeffSurface = m_vCoeffSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_vCoeffSurface);
-    data = (int16_t *)m_allocator->LockResouceForWrite(&m_vCoeffSurface->OsResource);
+    data = (int16_t *)m_allocator->LockResourceForWrite(&m_vCoeffSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 25 * sizeof(int16_t), coeffV, 25 * sizeof(int16_t));
 
     // Scaling LUTs surfaces
     m_yGammaLUTSurface = m_yGammaLUTSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_yGammaLUTSurface);
-    data = (int16_t *)m_allocator->LockResouceForWrite(&m_yGammaLUTSurface->OsResource);
+    data = (int16_t *)m_allocator->LockResourceForWrite(&m_yGammaLUTSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 256 * sizeof(int16_t), m_scalingLutY, 256 * sizeof(int16_t));
     data[256] = m_scalingLutY[255];
 
     m_uGammaLUTSurface = m_uGammaLUTSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_uGammaLUTSurface);
-    data = (int16_t *)m_allocator->LockResouceForWrite(&m_uGammaLUTSurface->OsResource);
+    data = (int16_t *)m_allocator->LockResourceForWrite(&m_uGammaLUTSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 256 * sizeof(int16_t), m_scalingLutCb, 256 * sizeof(int16_t));
     data[256] = m_scalingLutCb[255];
 
     m_vGammaLUTSurface = m_vGammaLUTSurfaceArray->Fetch();
     DECODE_CHK_NULL(m_vGammaLUTSurface);
-    data = (int16_t *)m_allocator->LockResouceForWrite(&m_vGammaLUTSurface->OsResource);
+    data = (int16_t *)m_allocator->LockResourceForWrite(&m_vGammaLUTSurface->OsResource);
     DECODE_CHK_NULL(data);
     MOS_SecureMemcpy(data, 256 * sizeof(int16_t), m_scalingLutCr, 256 * sizeof(int16_t));
     data[256] = m_scalingLutCr[255];

--- a/media_driver/media_driver_next/agnostic/gen12/codec/hal/dec/av1/packet/decode_av1_packet_g12.cpp
+++ b/media_driver/media_driver_next/agnostic/gen12/codec/hal/dec/av1/packet/decode_av1_packet_g12.cpp
@@ -137,7 +137,7 @@ namespace decode
                 if (m_batchBuf != nullptr)
                 {
                     ResourceAutoLock resLock(m_allocator, &m_batchBuf->OsResource);
-                    uint8_t *batchBufBase = (uint8_t *)resLock.LockResouceForWrite();
+                    uint8_t *batchBufBase = (uint8_t *)resLock.LockResourceForWrite();
                     DECODE_CHK_STATUS(InitPicLevelCmdBuffer(*m_batchBuf, batchBufBase));
                     DECODE_CHK_STATUS(m_picturePkt->Execute(m_picCmdBuffer));
                     DECODE_CHK_STATUS(m_miInterface->AddMiBatchBufferEnd(&m_picCmdBuffer, nullptr));

--- a/media_softlet/agnostic/common/codec/hal/dec/av1/features/decode_av1_basic_feature.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/av1/features/decode_av1_basic_feature.cpp
@@ -767,7 +767,7 @@ namespace decode
                     resourceInternalRead, lockableVideoMem);
                 DECODE_CHK_NULL(m_tmpCdfBuffers[index]);
 
-                auto data = (uint16_t *)m_allocator->LockResouceForWrite(&m_tmpCdfBuffers[index]->OsResource);
+                auto data = (uint16_t *)m_allocator->LockResourceForWrite(&m_tmpCdfBuffers[index]->OsResource);
                 DECODE_CHK_NULL(data);
 
                 // reset all CDF tables to default values

--- a/media_softlet/agnostic/common/codec/hal/dec/av1/packet/decode_av1_picture_packet.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/av1/packet/decode_av1_picture_packet.cpp
@@ -1402,7 +1402,7 @@ namespace decode{
             m_resDataBufferForDummyWL= m_allocator->AllocateBuffer(
                 140, "BsBuffer for inserted Dummy WL", resourceInputBitstream, lockableVideoMem); //140 Bytes
             DECODE_CHK_NULL(m_resDataBufferForDummyWL);
-            auto data = (uint8_t *)m_allocator->LockResouceForWrite(&m_resDataBufferForDummyWL->OsResource);
+            auto data = (uint8_t *)m_allocator->LockResourceForWrite(&m_resDataBufferForDummyWL->OsResource);
             DECODE_CHK_NULL(data);
 
             uint32_t bsBuffer[] =

--- a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/decode_allocator.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/decode_allocator.cpp
@@ -21,7 +21,7 @@
 */
 //!
 //! \file     decode_allocator.cpp
-//! \brief    Defines the interface for decode resouce allocate
+//! \brief    Defines the interface for decode resource allocate
 //! \details  decode allocator will allocate and destory buffers, the caller
 //!           can use directly
 //!
@@ -243,7 +243,7 @@ void* DecodeAllocator::Lock(MOS_RESOURCE* resource, MOS_LOCK_PARAMS* lockFlag)
     return m_allocator->Lock(resource, lockFlag);
 }
 
-void* DecodeAllocator::LockResouceForWrite(MOS_RESOURCE* resource)
+void* DecodeAllocator::LockResourceForWrite(MOS_RESOURCE* resource)
 {
     MOS_LOCK_PARAMS lockFlags;
     MOS_ZeroMemory(&lockFlags, sizeof(MOS_LOCK_PARAMS));
@@ -255,7 +255,7 @@ void* DecodeAllocator::LockResouceForWrite(MOS_RESOURCE* resource)
     return m_allocator->Lock(resource, &lockFlags);
 }
 
-void* DecodeAllocator::LockResouceWithNoOverwrite(MOS_RESOURCE* resource)
+void* DecodeAllocator::LockResourceWithNoOverwrite(MOS_RESOURCE* resource)
 {
     MOS_LOCK_PARAMS lockFlags;
     MOS_ZeroMemory(&lockFlags, sizeof(MOS_LOCK_PARAMS));
@@ -268,7 +268,7 @@ void* DecodeAllocator::LockResouceWithNoOverwrite(MOS_RESOURCE* resource)
     return m_allocator->Lock(resource, &lockFlags);
 }
 
-void* DecodeAllocator::LockResouceForRead(MOS_RESOURCE* resource)
+void* DecodeAllocator::LockResourceForRead(MOS_RESOURCE* resource)
 {
     MOS_LOCK_PARAMS lockFlags;
     MOS_ZeroMemory(&lockFlags, sizeof(MOS_LOCK_PARAMS));
@@ -280,7 +280,7 @@ void* DecodeAllocator::LockResouceForRead(MOS_RESOURCE* resource)
     return m_allocator->Lock(resource, &lockFlags);
 }
 
-void* DecodeAllocator::LockResouceForRead(MOS_BUFFER* buffer)
+void* DecodeAllocator::LockResourceForRead(MOS_BUFFER* buffer)
 {
     MOS_LOCK_PARAMS lockFlags;
     MOS_ZeroMemory(&lockFlags, sizeof(MOS_LOCK_PARAMS));

--- a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/decode_allocator.h
+++ b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/decode_allocator.h
@@ -21,7 +21,7 @@
 */
 //!
 //! \file     decode_allocator.h
-//! \brief    Defines the interface for decode resouce allocate
+//! \brief    Defines the interface for decode resource allocate
 //! \details  decode allocator will allocate and destory buffers, the caller
 //!           can use directly
 //!
@@ -344,7 +344,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceForWrite(MOS_RESOURCE *resource);
+    void* LockResourceForWrite(MOS_RESOURCE *resource);
 
     //!
     //! \brief  Lock resource with no overwrite flag
@@ -353,7 +353,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceWithNoOverwrite(MOS_RESOURCE *resource);
+    void* LockResourceWithNoOverwrite(MOS_RESOURCE *resource);
 
     //!
     //! \brief  Lock resource only for reading
@@ -362,7 +362,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceForRead(MOS_RESOURCE *resource);
+    void* LockResourceForRead(MOS_RESOURCE *resource);
 
     //!
     //! \brief  Lock resource only for reading
@@ -371,7 +371,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceForRead(MOS_BUFFER* buffer);
+    void* LockResourceForRead(MOS_BUFFER* buffer);
 
     //!
     //! \brief  Lock batch buffer

--- a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/decode_resource_auto_lock.h
+++ b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/decode_resource_auto_lock.h
@@ -55,32 +55,32 @@ public:
         }
     }
 
-    void* LockResouceForWrite()
+    void* LockResourceForWrite()
     {
         if (m_allocator == nullptr || m_resource == nullptr)
         {
             return nullptr;
         }
-        return m_allocator->LockResouceForWrite(m_resource);
+        return m_allocator->LockResourceForWrite(m_resource);
     }
 
-    void* LockResouceWithNoOverwrite()
+    void* LockResourceWithNoOverwrite()
     {
         if (m_allocator == nullptr || m_resource == nullptr)
         {
             return nullptr;
         }
 
-        return m_allocator->LockResouceWithNoOverwrite(m_resource);
+        return m_allocator->LockResourceWithNoOverwrite(m_resource);
     }
 
-    void* LockResouceForRead()
+    void* LockResourceForRead()
     {
         if (m_allocator == nullptr || m_resource == nullptr)
         {
             return nullptr;
         }
-        return m_allocator->LockResouceForRead(m_resource);
+        return m_allocator->LockResourceForRead(m_resource);
     }
 
 private:

--- a/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/decode_status_report.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/decode_status_report.cpp
@@ -54,7 +54,7 @@ namespace decode {
         m_completedCountBuf = &(m_statusBufMfx->OsResource);
 
         DECODE_CHK_STATUS(m_allocator->SkipResourceSync(m_statusBufMfx));
-        uint8_t *data = (uint8_t *)m_allocator->LockResouceForRead(m_statusBufMfx);
+        uint8_t *data = (uint8_t *)m_allocator->LockResourceForRead(m_statusBufMfx);
         DECODE_CHK_NULL(data);
 
         // Decode status located at the beginging of the status buffer, following with complete count
@@ -67,7 +67,7 @@ namespace decode {
                 m_statusBufSizeRcs * m_statusNum, "StatusQueryBufferRcs", resourceInternalWrite, lockableSystemMem, true, 0, true);
 
             DECODE_CHK_STATUS(m_allocator->SkipResourceSync(m_statusBufRcs));
-            m_dataStatusRcs = (uint8_t *)m_allocator->LockResouceForRead(m_statusBufRcs);
+            m_dataStatusRcs = (uint8_t *)m_allocator->LockResourceForRead(m_statusBufRcs);
             DECODE_CHK_NULL(m_dataStatusRcs);
         }
 

--- a/media_softlet/agnostic/common/os/mos_commandbuffer_next.h
+++ b/media_softlet/agnostic/common/os/mos_commandbuffer_next.h
@@ -243,7 +243,7 @@ protected:
     //! \brief    Last native Gpu context handle
     GPU_CONTEXT_HANDLE    m_lastNativeGpuContextHandle = MOS_GPU_CONTEXT_INVALID_HANDLE;
 
-    //! \brief    Graphics resouce for command buffer
+    //! \brief    Graphics resource for command buffer
     GraphicsResourceNext* m_graphicsResource = nullptr;
 
     //! \brief    Lock address for cpu side usage

--- a/media_softlet/agnostic/common/os/mos_graphicsresource_next.h
+++ b/media_softlet/agnostic/common/os/mos_graphicsresource_next.h
@@ -335,7 +335,7 @@ public:
     virtual bool IsEqual(GraphicsResourceNext* toCompare) = 0;
 
     //!
-    //! \brief  Check whether the current graphic resouce is valid
+    //! \brief  Check whether the current graphic resource is valid
     //! \return Returns true if the two resources are equal and false otherwise.
     //!
     virtual bool IsValid() = 0;
@@ -387,7 +387,7 @@ public:
 
 protected:
     //!
-    //! \brief  Global graphic resouce counter
+    //! \brief  Global graphic resource counter
     //!
     static uint32_t m_memAllocCounterGfx;
 

--- a/media_softlet/agnostic/common/os/mos_utilities_next.h
+++ b/media_softlet/agnostic/common/os/mos_utilities_next.h
@@ -1230,12 +1230,12 @@ public:
         uint32_t   mSec);
 
     //!
-    //! \brief    Initialize reg related resouces
+    //! \brief    Initialize reg related resources
     //!
     static MOS_STATUS MosInitializeReg();
 
     //!
-    //! \brief    Uninitialize reg related resouces
+    //! \brief    Uninitialize reg related resources
     //!
     static MOS_STATUS MosUninitializeReg();
     //!

--- a/media_softlet/agnostic/common/shared/bufferMgr/media_allocator.cpp
+++ b/media_softlet/agnostic/common/shared/bufferMgr/media_allocator.cpp
@@ -21,7 +21,7 @@
 */
 //!
 //! \file     media_allocator.cpp
-//! \brief    Defines the common interface for media resouce manage
+//! \brief    Defines the common interface for media resource manage
 //! \details  Media allocator will allocate and destory buffers, the caller
 //!           can use directly
 //!

--- a/media_softlet/agnostic/common/shared/bufferMgr/media_allocator.h
+++ b/media_softlet/agnostic/common/shared/bufferMgr/media_allocator.h
@@ -21,7 +21,7 @@
 */
 //!
 //! \file     media_allocator.h
-//! \brief    Defines the common interface for media resouce manage
+//! \brief    Defines the common interface for media resource manage
 //! \details  Media allocator will allocate and destory buffers, each component
 //!           is recommended to inherits and implement it's owner allocator
 //!

--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
+++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
@@ -21,7 +21,7 @@
 */
 //!
 //! \file     vp_allocator.cpp
-//! \brief    Defines the interface for vp resouce allocate
+//! \brief    Defines the interface for vp resource allocate
 //! \details  vp allocator will allocate and destory buffers, the caller
 //!           can use directly
 //!
@@ -483,7 +483,7 @@ void* VpAllocator::Lock(MOS_RESOURCE* resource, MOS_LOCK_PARAMS *lockFlag)
     return m_allocator->Lock(resource, lockFlag);
 }
 
-void* VpAllocator::LockResouceForWrite(MOS_RESOURCE *resource)
+void* VpAllocator::LockResourceForWrite(MOS_RESOURCE *resource)
 {
     VP_FUNC_CALL();
     MOS_LOCK_PARAMS lockFlags;
@@ -496,7 +496,7 @@ void* VpAllocator::LockResouceForWrite(MOS_RESOURCE *resource)
     return m_allocator->Lock(resource, &lockFlags);
 }
 
-void* VpAllocator::LockResouceWithNoOverwrite(MOS_RESOURCE *resource)
+void* VpAllocator::LockResourceWithNoOverwrite(MOS_RESOURCE *resource)
 {
     VP_FUNC_CALL();
     MOS_LOCK_PARAMS lockFlags;
@@ -510,7 +510,7 @@ void* VpAllocator::LockResouceWithNoOverwrite(MOS_RESOURCE *resource)
     return m_allocator->Lock(resource, &lockFlags);
 }
 
-void* VpAllocator::LockResouceForRead(MOS_RESOURCE *resource)
+void* VpAllocator::LockResourceForRead(MOS_RESOURCE *resource)
 {
     VP_FUNC_CALL();
     MOS_LOCK_PARAMS lockFlags;
@@ -940,7 +940,7 @@ MOS_STATUS VpAllocator::ReadSurface (
     VP_PUBLIC_ASSERT(!Mos_ResourceIsNull(&surface->OsResource));
     //----------------------------------------------
 
-    src = (uint8_t*)LockResouceForRead(&surface->OsResource);
+    src = (uint8_t*)LockResourceForRead(&surface->OsResource);
     VP_PUBLIC_CHK_NULL_RETURN(src);
 
     // Calculate Size in Bytes
@@ -998,7 +998,7 @@ MOS_STATUS VpAllocator::WriteSurface (
     VP_PUBLIC_ASSERT(!Mos_ResourceIsNull(&surface->OsResource));
     //----------------------------------------------
 
-    dst = (uint8_t*)LockResouceForWrite(&surface->OsResource);
+    dst = (uint8_t*)LockResourceForWrite(&surface->OsResource);
     VP_PUBLIC_CHK_NULL_RETURN(dst);
 
     // Calculate Size in Bytes
@@ -1059,7 +1059,7 @@ MOS_STATUS VpAllocator::WriteSurface(VP_SURFACE* vpsurface, uint32_t bpp, const 
     VP_PUBLIC_ASSERT(!Mos_ResourceIsNull(&surface->OsResource));
     //----------------------------------------------
 
-    dst = (uint8_t*)LockResouceForWrite(&surface->OsResource);
+    dst = (uint8_t*)LockResourceForWrite(&surface->OsResource);
     VP_PUBLIC_CHK_NULL_RETURN(dst);
 
     // Calculate Size in Bytes
@@ -1111,7 +1111,7 @@ MOS_STATUS VpAllocator::Write1DSurface(VP_SURFACE* vpsurface, const uint8_t* src
     VP_PUBLIC_ASSERT(!Mos_ResourceIsNull(&vpsurface->osSurface->OsResource));
 
     MOS_SURFACE* surface = vpsurface->osSurface;
-    uint8_t* dst = (uint8_t*)LockResouceForWrite(&surface->OsResource);
+    uint8_t* dst = (uint8_t*)LockResourceForWrite(&surface->OsResource);
 
     VP_PUBLIC_CHK_NULL_RETURN(dst);
 

--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.h
+++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.h
@@ -21,7 +21,7 @@
 */
 //!
 //! \file     vp_allocator.h
-//! \brief    Defines the interface for vp resouce allocate
+//! \brief    Defines the interface for vp resource allocate
 //! \details  vp allocator will allocate and destory buffers, the caller
 //!           can use directly
 //!
@@ -240,7 +240,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceForWrite(MOS_RESOURCE *resource);
+    void* LockResourceForWrite(MOS_RESOURCE *resource);
 
     //!
     //! \brief  Lock resource with no overwrite flag
@@ -249,7 +249,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceWithNoOverwrite(MOS_RESOURCE *resource);
+    void* LockResourceWithNoOverwrite(MOS_RESOURCE *resource);
 
     //!
     //! \brief  Lock resource only for reading
@@ -258,7 +258,7 @@ public:
     //! \return void*
     //!         a poniter to data
     //!
-    void* LockResouceForRead(MOS_RESOURCE *resource);
+    void* LockResourceForRead(MOS_RESOURCE *resource);
 
     //!
     //! \brief  UnLock resource

--- a/media_softlet/linux/common/os/mos_graphicsresource_specific_next.h
+++ b/media_softlet/linux/common/os/mos_graphicsresource_specific_next.h
@@ -92,7 +92,7 @@ public:
     void Free(OsContextNext* osContextPtr, uint32_t  freeFlag = 0);
 
     //!
-    //! \brief  Check whether the specific graphic resouces is equal to the current one
+    //! \brief  Check whether the specific graphic resources is equal to the current one
     //! \param  [in] toCompare
     //!         ptr to the graphics resource to be compared with 
     //! \return Returns true if the two resources are equal and false otherwise.
@@ -100,7 +100,7 @@ public:
     bool IsEqual(GraphicsResourceNext* toCompare);
 
     //!
-    //! \brief  Check whether the current graphic resouce is valid
+    //! \brief  Check whether the current graphic resource is valid
     //! \return Returns true if a resource is valid and false otherwise.
     //!
     bool IsValid();


### PR DESCRIPTION
Fix typos in function name/comments (resouces->resources).
Fixes: #1010