### PR TITLE
set the picture flag to be invalid frame if the ref frame is invalid

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.cpp
@@ -2209,6 +2209,7 @@ void DdiEncodeAvc::GetSlcRefIdx(CODEC_PICTURE *picReference, CODEC_PICTURE *slcR
         if (i == CODEC_MAX_NUM_REF_FRAME)
         {
             slcReference->FrameIdx = CODEC_AVC_NUM_UNCOMPRESSED_SURFACE;
+            slcReference->PicFlags = PICTURE_INVALID;
         }
     }
 }


### PR DESCRIPTION
fixes #1189

Signed-off-by: XinfengZhang <carl.zhang@intel.com>