### PR TITLE
[Media Common] Fix non-X11 build

### DIFF
--- a/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
@@ -35,7 +35,6 @@
 #include "mos_utilities.h"
 #include "media_interfaces_mmd.h"
 #include "media_libva_caps.h"
-#include "media_libva_putsurface_linux.h"
 #include "media_ddi_prot.h"
 
 MEDIA_MUTEX_T MediaLibvaInterfaceNext::m_GlobalMutex = MEDIA_MUTEX_INITIALIZER;


### PR DESCRIPTION
media_libva_putsurface_linux.h is already included in
https://github.com/intel/media-driver/blob/master/media_softlet/linux/common/ddi/media_libva_interface_next.cpp#L29

which is guarded by defined(X11_FOUND).

Removing this superflous line fixed non-X11 builds:

In file included from intel-mediadriver-6c183bf8d5c002549a486e4730bbafec04fc1fc8/media_softlet/linux/common/ddi/media_libva_interface_next.cpp:38:0:
intel-mediadriver-6c183bf8d5c002549a486e4730bbafec04fc1fc8/media_driver/linux/common/ddi/media_libva_putsurface_linux.h:31:29: fatal error: va/va_dricommon.h: No such file or directory
 #include <va/va_dricommon.h>

because va/va_dricommon.h is only present when libva was built with X11
support:
https://github.com/intel/libva/blob/master/va/x11/Makefile.am#L41