### PR TITLE
[VP] Fix loss of Y210 and Y410 format in vaQuerySurfaceAttributes.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.h
+++ b/media_driver/linux/common/ddi/media_libva.h
@@ -65,7 +65,7 @@
 #endif
 #define DDI_CODEC_GEN_MAX_ATTRIBS_TYPE             4    //VAConfigAttribRTFormat,    VAConfigAttribRateControl,    VAConfigAttribDecSliceMode,    VAConfigAttribEncPackedHeaders
 
-#define DDI_CODEC_GEN_MAX_SURFACE_ATTRIBUTES       25
+#define DDI_CODEC_GEN_MAX_SURFACE_ATTRIBUTES       27
 #define DDI_CODEC_GEN_STR_VENDOR                   "Intel iHD driver for Intel(R) Gen Graphics - " MEDIA_VERSION " (" MEDIA_VERSION_DETAILS ")"
 
 #define DDI_CODEC_GET_VTABLE(ctx)                  (ctx->vtable)

--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -83,14 +83,16 @@ const uint32_t MediaLibvaCaps::m_vpSurfaceAttr[m_numVpSurfaceAttr] =
     VA_FOURCC('R', 'G', 'B', 'P'),
     VA_FOURCC('R', 'G', 'B', 'X'),
     VA_FOURCC('P', '0', '1', '0'),
-    VA_FOURCC('R','G','2', '4'),
+    VA_FOURCC('R', 'G', '2', '4'),
     VA_FOURCC_ARGB,
     VA_FOURCC_ABGR,
     VA_FOURCC_A2R10G10B10,
     VA_FOURCC_A2B10G10R10,
     VA_FOURCC_X2R10G10B10,
     VA_FOURCC_X2B10G10R10,
-    VA_FOURCC_AYUV
+    VA_FOURCC_AYUV,
+    VA_FOURCC_Y210,
+    VA_FOURCC_Y410
 };
 
 const uint32_t MediaLibvaCaps::m_jpegSurfaceAttr[m_numJpegSurfaceAttr] =

--- a/media_driver/linux/common/ddi/media_libva_caps.h
+++ b/media_driver/linux/common/ddi/media_libva_caps.h
@@ -778,7 +778,7 @@ protected:
 #endif
     static const uint16_t m_maxProfiles = 17; //!< Maximum number of supported profiles
     static const uint16_t m_maxProfileEntries = 64; //!< Maximum number of supported profile & entrypoint combinations
-    static const uint32_t m_numVpSurfaceAttr = 18; //!< Number of VP surface attributes
+    static const uint32_t m_numVpSurfaceAttr = 20; //!< Number of VP surface attributes
     static const uint32_t m_numJpegSurfaceAttr = 7; //!< Number of JPEG surface attributes
     static const uint32_t m_numJpegEncSurfaceAttr = 4; //!< Number of JPEG encode surface attributes
     static const uint16_t m_maxEntrypoints = 7; //!<  Maximum number of supported entrypoints


### PR DESCRIPTION
Fix loss of Y210 and Y410 format in vaQuerySurfaceAttributes.

Signed-off-by: Yuankun Zhang <yuankunx.zhang@intel.com>