### PR TITLE
[VP] Fix 2pass CSC PROCAMP not work issue

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
@@ -2502,7 +2502,8 @@ void VPHAL_VEBOX_STATE::VeboxSetRenderingFlags(
                                         pSrc->ColorSpace != pRenderTarget->ColorSpace);
 
     pRenderData->bProcamp           = ((IS_VPHAL_OUTPUT_PIPE_VEBOX(pRenderData) ||
-                                        IS_VPHAL_OUTPUT_PIPE_SFC(pRenderData))  &&
+                                        IS_VPHAL_OUTPUT_PIPE_SFC(pRenderData)   ||
+                                        pRenderData->b2PassesCSC)               && // 2pass CSC goes into VEBOX + render. In this case, need to anable procamp.
                                         pSrc->pProcampParams                    &&
                                         pSrc->pProcampParams->bEnabled);
 


### PR DESCRIPTION
Enable PROCAMP when 2pass CSC is also enabled.
Fixes: #1138
Signed off by: jay.yang@intel.com