### PR TITLE
Fix duplicate media_libva_interface_next include

### DIFF
--- a/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
@@ -35,7 +35,6 @@
 #include "mos_utilities.h"
 #include "media_interfaces_mmd.h"
 #include "media_libva_caps.h"
-#include "media_libva_putsurface_linux.h"
 #include "media_ddi_prot.h"
 #include "media_interfaces_hwinfo_device.h"
 


### PR DESCRIPTION
Remove a duplicate #include media_libva_putsurface_linux.h. This
include is already wrapped with #if !defined(ANDROID) && defined(X11_FOUND)
a few lines prior.

Example build errors from Chrome OS.
```
  FAILED: media_driver/CMakeFiles/iHD_drv_video_OBJ.dir/__/media_softlet/linux/common/ddi/media_libva_interface_next.cpp.o
  In file included from media_softlet/linux/common/ddi/media_libva_interface_next.cpp:38:
  media_driver/linux/common/ddi/media_libva_putsurface_linux.h:31:10: fatal error: 'va/va_dricommon.h' file not found
```

Signed-off-by: Ed Baker <edward.baker@intel.com>