### PR TITLE
Add mem_types when querying surface attributes

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1207,6 +1207,7 @@ VAStatus MediaLibvaCapsG12::AddEncSurfaceAttributes(
         attribList[numAttribs].value.type = VAGenericValueTypeInteger;
         attribList[numAttribs].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
         attribList[numAttribs].value.value.i = VA_SURFACE_ATTRIB_MEM_TYPE_VA |
+            VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME |
             VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2;
         numAttribs++;
     }
@@ -1613,6 +1614,7 @@ VAStatus MediaLibvaCapsG12::QuerySurfaceAttributes(
         attribs[i].value.type = VAGenericValueTypeInteger;
         attribs[i].flags = VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE;
         attribs[i].value.value.i = VA_SURFACE_ATTRIB_MEM_TYPE_VA |
+            VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME |
             VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2;
         i++;
     }


### PR DESCRIPTION
Add mem_types VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME for decode
and encode when querying surface attributes on Gen12.

Signed-off-by: Zhang Yuankun <yuankunx.zhang@intel.com>