### PR TITLE
 [Vp9 Encode] Add a judgment condition for getting seqParams->TargetUsage

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_vp9.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_vp9.cpp
@@ -233,7 +233,8 @@ VAStatus DdiEncodeVp9::EncodeInCodecHal(uint32_t numSlices)
         seqParams->RateControlMethod = RATECONTROL_CQL;
     }
 
-    seqParams->TargetUsage = vp9TargetUsage;
+    if (m_encodeCtx->bNewSeq)
+        seqParams->TargetUsage = vp9TargetUsage;
 
     /* If the segmentation is not enabled, the SegData will be reset */
     if (vp9PicParam->PicFlags.fields.segmentation_enabled == 0)


### PR DESCRIPTION
If middleware doesn't submit sequence parameters, we should
consider that the current frame and the previous frame are
in the same sequence. We should keep the value of
seqParams->TargetUsage in these two frames unchanged.

Related-to:HSD-1509428874

Signed-off-by: Zhang Yuankun <yuankunx.zhang@intel.com>