### PR TITLE
[Media Common] Fix include when building with -DGEN8=OFF

### DIFF
--- a/media_driver/agnostic/gen12/cm/cm_hal_g12.h
+++ b/media_driver/agnostic/gen12/cm/cm_hal_g12.h
@@ -28,7 +28,6 @@
 #define _CM_HAL_G12_H_
 
 #include "cm_hal.h"
-#include "mhw_render_hwcmd_g8_X.h"
 
 #define CM_NUM_HW_POLYPHASE_TABLES_G12         17
 #define CM_NUM_HW_POLYPHASE_EXTRA_TABLES_G12   15


### PR DESCRIPTION
This commit address the following compilation error when building with
cmake -DGEN8=OFF. Partially fixes #1065.
    
media-driver/media_driver/agnostic/gen12/cm/cm_hal_g12.h:32:10:
fatal error: mhw_render_hwcmd_g8_X.h: No such file or directory