### PR TITLE
[Encode] GLK enable VP8

### DIFF
--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -103,6 +103,8 @@ static struct LinuxCodecInfo glkCodecInfo =
     .hevc10Decoding     = 1,
     .vp9b10Decoding     = 1,
     .hevc10Encoding     = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
+    .hevc12Encoding     = 0,
+    .vp8Encoding        = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
 };
 
 static bool InitSklMediaSku(struct GfxDeviceInfo *devInfo,
@@ -482,6 +484,9 @@ static bool InitGlkMediaSku(struct GfxDeviceInfo *devInfo,
         MEDIA_WR_SKU(skuTable, FtrIntelVP9VLDProfile0Decoding8bit420, codecInfo->vp9Decoding);
         MEDIA_WR_SKU(skuTable, FtrVP9VLD10bProfile2Decoding, codecInfo->vp9b10Decoding);
         MEDIA_WR_SKU(skuTable, FtrIntelVP9VLDProfile2Decoding10bit420, codecInfo->vp9b10Decoding);
+
+        /* VP8 enc */
+        MEDIA_WR_SKU(skuTable, FtrEncodeVP8, codecInfo->vp8Encoding);
     }
 
     MEDIA_WR_SKU(skuTable, FtrEnableMediaKernels, drvInfo->hasHuc);

--- a/media_driver/media_interface/media_interfaces_m9_glk/media_interfaces_g9_glk.cpp
+++ b/media_driver/media_interface/media_interfaces_m9_glk/media_interfaces_g9_glk.cpp
@@ -318,6 +318,23 @@ MOS_STATUS CodechalInterfacesG9Glk::Initialize(
         }
         else
 #endif
+#ifdef _VP8_ENCODE_SUPPORTED
+        if (info->Mode == CODECHAL_ENCODE_MODE_VP8)
+        {
+            // Setup encode interface functions
+            encoder = MOS_New(Encode::Vp8, hwInterface, debugInterface, info);
+            if (encoder == nullptr)
+            {
+                CODECHAL_PUBLIC_ASSERTMESSAGE("VP8 Encode allocation failed!");
+                return MOS_STATUS_INVALID_PARAMETER;
+            }
+            else
+            {
+                m_codechalDevice = encoder;
+            }
+        }
+        else
+#endif
         {
             CODECHAL_PUBLIC_ASSERTMESSAGE("Unsupported encode function requested.");
             return MOS_STATUS_INVALID_PARAMETER;

--- a/media_driver/media_interface/media_interfaces_m9_glk/media_interfaces_g9_glk.h
+++ b/media_driver/media_interface/media_interfaces_m9_glk/media_interfaces_g9_glk.h
@@ -41,6 +41,9 @@
 #ifdef _AVC_ENCODE_VDENC_SUPPORTED
 #include "codechal_vdenc_avc_g9_kbl.h"
 #endif
+#ifdef _VP8_ENCODE_SUPPORTED
+#include "codechal_encode_vp8_g9.h"
+#endif
 #include "codechal_decode_nv12top010_g9_glk.h"
 #include "cm_hal_g9.h"
 #include "vphal_g9_glk.h"
@@ -85,6 +88,9 @@ public:
 #endif
 #ifdef _AVC_ENCODE_VDENC_SUPPORTED
     using AvcVdenc = CodechalVdencAvcStateG9Kbl;
+#endif
+#ifdef _VP8_ENCODE_SUPPORTED
+    using Vp8 = CodechalEncodeVp8G9;
 #endif
 };
 


### PR DESCRIPTION
Enable VP8 encode for Gemini Lake. Interface code was inherited from
KBL paths. Resolves #1313.