### PR TITLE
Return zero subpicture formats

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -5696,9 +5696,11 @@ VAStatus DdiMedia_QuerySubpictureFormats(
     DDI_UNUSED(ctx);
     DDI_UNUSED(format_list);
     DDI_UNUSED(flags);
-    DDI_UNUSED(num_formats);
 
     DDI_FUNCTION_ENTER();
+
+    DDI_CHK_NULL(num_formats, "nullptr num_formats", VA_STATUS_ERROR_INVALID_PARAMETER);
+    *num_formats = 0;
 
     return VA_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Without this, querying capabilities (e.g. with vadumpcaps) will find as many uninitialised format entries as it asks for.

Before:
```
$ vadumpcaps --subpicture-formats
{
    "build_version": {
        "major": 1,
        "minor": 14,
        "micro": 0,
    },
    "driver_version": {
        "major": 1,
        "minor": 14,
    },
    "driver_vendor": "Intel iHD driver for Intel(R) Gen Graphics - 22.2.0 (4485349d8)",
    "subpicture_formats": [
        {
            "pixel_format": "",
            "byte_order": "unknown",
            "bits_per_pixel": 0,
            "flags": [
            ],
        },
        {
            "pixel_format": "",
            "byte_order": "unknown",
            "bits_per_pixel": 0,
            "flags": [
            ],
        },
        {
            "pixel_format": "",
            "byte_order": "unknown",
            "bits_per_pixel": 0,
            "flags": [
            ],
        },
        {
            "pixel_format": "",
            "byte_order": "unknown",
            "bits_per_pixel": 0,
            "flags": [
            ],
        },
    ],
},
```
After:
```
$ ./vadumpcaps --subpicture-formats
{
    "build_version": {
        "major": 1,
        "minor": 14,
        "micro": 0,
    },
    "driver_version": {
        "major": 1,
        "minor": 14,
    },
    "driver_vendor": "Intel iHD driver for Intel(R) Gen Graphics - 22.2.0 (4485349d8)",
    "subpicture_formats": [
    ],
},
```