### PR TITLE
Enable HDR Tone Mapping on all Gen9.5 KBL/CFL

### DIFF
--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -373,17 +373,14 @@ static bool InitKblMediaSku(struct GfxDeviceInfo *devInfo,
     else if (devInfo->eGTType == GTTYPE_GT2)
     {
         MEDIA_WR_SKU(skuTable, FtrGT2, 1);
-        MEDIA_WR_SKU(skuTable, FtrHDR, 1);
     }
     else if (devInfo->eGTType == GTTYPE_GT3)
     {
         MEDIA_WR_SKU(skuTable, FtrGT3, 1);
-        MEDIA_WR_SKU(skuTable, FtrHDR, 1);
     }
     else if (devInfo->eGTType == GTTYPE_GT4)
     {
         MEDIA_WR_SKU(skuTable, FtrGT4, 1);
-        MEDIA_WR_SKU(skuTable, FtrHDR, 1);
     }
     else
     {
@@ -414,6 +411,8 @@ static bool InitKblMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrVpP010Output, 1);
 
     MEDIA_WR_SKU(skuTable, FtrPerCtxtPreemptionGranularityControl, 1);
+
+    MEDIA_WR_SKU(skuTable, FtrHDR, 1);
 
     return true;
 }


### PR DESCRIPTION
- Enable HDR Tone Mapping on all Gen9.5 KBL/CFL
this was restricted to GT2+, now it is also allowed to run on GT1 such as UHD610.

```
[Parsed_tonemap_vaapi_0 @ 0x55ac68c12440] Failed to start picture processing: 1 (operation failed).
Error while filtering: Input/output error
```
Resolves an [error ](https://www.reddit.com/r/jellyfin/comments/rwecck/unable_to_get_hdr_tonemapping_intel_qsv_working/)in `tonemap_vaapi` ffmpeg filter.