### PR TITLE
ADL-N Support : Added the cmake options GEN12_ADLN 

### DIFF
--- a/media_driver/cmake/linux/media_gen_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_gen_flags_linux.cmake
@@ -81,6 +81,10 @@ cmake_dependent_option(GEN12_ADLP
     "Enabled ADLP support (Gen12)" ON
     "GEN12_TGLLP" OFF)
 
+cmake_dependent_option(GEN12_ADLN
+    "Enabled ADLN support (Gen12)" ON
+    "GEN12_TGLLP" OFF)
+
 cmake_dependent_option(Xe_M
     "Enabled support for Xehp_sdv+ platforms" ON
     "ENABLE_PRODUCTION_KMD" OFF)
@@ -182,6 +186,10 @@ endif()
 
 if(GEN12_ADLP)
     add_definitions(-DIGFX_GEN12_ADLP_SUPPORTED)
+endif()
+
+if(GEN12_ADLN)
+    add_definitions(-DIGFX_GEN12_ADLN_SUPPORTED)
 endif()
 
 if(DG2)


### PR DESCRIPTION
Added missing cmake option GEN12_ADLN for ADL-N SoCs 
