### PR TITLE
[VP] Doc update: Composition path does not support BT2020 color space

### DIFF
--- a/docs/media_features.md
+++ b/docs/media_features.md
@@ -103,5 +103,6 @@
 
 * \* For SFC path, there are NOT real 16bit, SFC precision is 12bit; For kernel path, we support real 16bit.
 * TGL/DG1/SG1 capable of max resolution: 16K; ICL/JSL/EHL/SKL/BXT/KBL/BDW capable of max resolution: 4k.
+* Composition path does not support conversion from BT2020 RGB to BT2020 YUV, BT2020->BT601/BT709, BT601/BT709 -> BT2020. So if some formats, RGB444 planar for example, are only supported by compositon path, make sure the color space isn't BT2020.
 
 ##### Resolution definition: 2k=2048x2048, 4k=4096x4096, 8k=8192x8192, 16k=16384x16384


### PR DESCRIPTION
Composition path does not support conversion from BT2020 RGB to BT2020
YUV, BT2020->BT601/BT709, BT601/BT709 -> BT2020.
https://github.com/intel/media-driver/blob/16ca483d3c7ae5fed2c4a2339f615d2a0887adfd/media_driver/agnostic/common/vp/hal/vphal_render_composite.cpp#L6523

Related issues: https://github.com/intel/media-driver/issues/1280 and https://github.com/intel/media-driver/issues/1225
Signed off by: jay.yang@intel.com