### PR TITLE
media_libva: don't support VAConfigAttribEncJPEG for non-VAProfileJPE…

### DIFF
--- a/media_driver/linux/Xe_M/ddi/media_libva_caps_dg2.cpp
+++ b/media_driver/linux/Xe_M/ddi/media_libva_caps_dg2.cpp
@@ -622,17 +622,20 @@ VAStatus MediaLibvaCapsDG2::CreateEncAttributes(
         VAConfigAttribMaxPictureHeight, &attrib.value);
     (*attribList)[attrib.type] = attrib.value;
 
-    attrib.type = VAConfigAttribEncJPEG;
-    attrib.value =
-        ((JPEG_MAX_QUANT_TABLE << 14)       | // max_num_quantization_tables : 3
-         (JPEG_MAX_NUM_HUFF_TABLE_INDEX << 11)   | // max_num_huffman_tables : 3
-         (1 << 7)                    | // max_num_scans : 4
-         (jpegNumComponent << 4));              // max_num_components : 3
-    // arithmatic_coding_mode = 0
-    // progressive_dct_mode = 0
-    // non_interleaved_mode = 0
-    // differential_mode = 0
-    (*attribList)[attrib.type] = attrib.value;
+    if (profile == VAProfileJPEGBaseline)
+    {
+        attrib.type = VAConfigAttribEncJPEG;
+        attrib.value =
+            ((JPEG_MAX_QUANT_TABLE << 14)       | // max_num_quantization_tables : 3
+             (JPEG_MAX_NUM_HUFF_TABLE_INDEX << 11)   | // max_num_huffman_tables : 3
+             (1 << 7)                    | // max_num_scans : 4
+             (jpegNumComponent << 4));              // max_num_components : 3
+        // arithmatic_coding_mode = 0
+        // progressive_dct_mode = 0
+        // non_interleaved_mode = 0
+        // differential_mode = 0
+        (*attribList)[attrib.type] = attrib.value;
+    }
 
     attrib.type = VAConfigAttribEncQualityRange;
     if (profile == VAProfileJPEGBaseline)

--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -661,18 +661,21 @@ VAStatus MediaLibvaCaps::CreateEncAttributes(
     }
     (*attribList)[attrib.type] = attrib.value;
 
-    attrib.type = VAConfigAttribEncJPEG;
-    VAConfigAttribValEncJPEG jpegAttribVal;
-    jpegAttribVal.bits.arithmatic_coding_mode = 0;
-    jpegAttribVal.bits.progressive_dct_mode = 0;
-    jpegAttribVal.bits.non_interleaved_mode = 0;
-    jpegAttribVal.bits.differential_mode = 0;
-    jpegAttribVal.bits.max_num_components = jpegNumComponent;
-    jpegAttribVal.bits.max_num_scans = 1;
-    jpegAttribVal.bits.max_num_huffman_tables = JPEG_MAX_NUM_HUFF_TABLE_INDEX;
-    jpegAttribVal.bits.max_num_quantization_tables = JPEG_MAX_QUANT_TABLE;
-    attrib.value = jpegAttribVal.value;
-    (*attribList)[attrib.type] = attrib.value;
+    if (profile == VAProfileJPEGBaseline)
+    {
+        attrib.type = VAConfigAttribEncJPEG;
+        VAConfigAttribValEncJPEG jpegAttribVal;
+        jpegAttribVal.bits.arithmatic_coding_mode = 0;
+        jpegAttribVal.bits.progressive_dct_mode = 0;
+        jpegAttribVal.bits.non_interleaved_mode = 0;
+        jpegAttribVal.bits.differential_mode = 0;
+        jpegAttribVal.bits.max_num_components = jpegNumComponent;
+        jpegAttribVal.bits.max_num_scans = 1;
+        jpegAttribVal.bits.max_num_huffman_tables = JPEG_MAX_NUM_HUFF_TABLE_INDEX;
+        jpegAttribVal.bits.max_num_quantization_tables = JPEG_MAX_QUANT_TABLE;
+        attrib.value = jpegAttribVal.value;
+        (*attribList)[attrib.type] = attrib.value;
+    }
 
     attrib.type = VAConfigAttribEncQualityRange;
     if (profile == VAProfileJPEGBaseline)

--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -1748,17 +1748,20 @@ VAStatus MediaLibvaCapsG12::CreateEncAttributes(
         VAConfigAttribMaxPictureHeight, &attrib.value);
     (*attribList)[attrib.type] = attrib.value;
 
-    attrib.type = VAConfigAttribEncJPEG;
-    attrib.value =
-        ((JPEG_MAX_QUANT_TABLE << 14)       | // max_num_quantization_tables : 3
-         (JPEG_MAX_NUM_HUFF_TABLE_INDEX << 11)   | // max_num_huffman_tables : 3
-         (1 << 7)                    | // max_num_scans : 4
-         (jpegNumComponent << 4));              // max_num_components : 3
-    // arithmatic_coding_mode = 0
-    // progressive_dct_mode = 0
-    // non_interleaved_mode = 0
-    // differential_mode = 0
-    (*attribList)[attrib.type] = attrib.value;
+    if (profile == VAProfileJPEGBaseline)
+    {
+        attrib.type = VAConfigAttribEncJPEG;
+        attrib.value =
+            ((JPEG_MAX_QUANT_TABLE << 14)       | // max_num_quantization_tables : 3
+             (JPEG_MAX_NUM_HUFF_TABLE_INDEX << 11)   | // max_num_huffman_tables : 3
+             (1 << 7)                    | // max_num_scans : 4
+             (jpegNumComponent << 4));              // max_num_components : 3
+        // arithmatic_coding_mode = 0
+        // progressive_dct_mode = 0
+        // non_interleaved_mode = 0
+        // differential_mode = 0
+        (*attribList)[attrib.type] = attrib.value;
+    }
 
     attrib.type = VAConfigAttribEncQualityRange;
     if (profile == VAProfileJPEGBaseline)


### PR DESCRIPTION
…GBaseline

Otherwise 'vainfo -a' shows VAConfigAttribEncJPEG for
non-VAProfileJPEGBaseline, which will mislead user.

E.g.

VAProfileHEVCMain444_10/VAEntrypointEncSliceLP
[...]
    VAConfigAttribEncJPEG                  : rithmatic_coding_mode=0
                                             progressive_dct_mode=0
                                             non_interleaved_mode=0
                                             differential_mode=0
                                             differential_mode=0
                                             max_num_components=3
                                             max_num_scans=1
                                             max_num_huffman_tables=2
                                             max_num_quantization_tables=3