### PR TITLE
fix build error with gcc-4.9

### DIFF
--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_vdenc_const_settings.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_vdenc_const_settings.h
@@ -115,7 +115,7 @@ struct HevcVdencArbSettings  // adaptive region boot settings
     const std::array<
         uint16_t,
         8>
-        m_rowOffsetsForBoost = {0, 3, 5, 2, 7, 4, 1, 6};
+        m_rowOffsetsForBoost = {{0, 3, 5, 2, 7, 4, 1, 6}};
 };
 
 struct HevcVdencFeatureSettings : VdencFeatureSettings

--- a/media_softlet/agnostic/common/codec/hal/enc/shared/features/encode_tile.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/shared/features/encode_tile.h
@@ -503,7 +503,7 @@ protected:
     uint32_t          m_tileLevelBatchSize    = 0;    //!< Size of the 2rd level batch buffer for each tile
     uint32_t          m_numTileBatchAllocated[m_codecHalNumTileLevelBatchBuffers] ={0};    //!< The number of allocated batch buffer for tiles
     uint32_t          m_tileBatchBufferIndex = 0;     //!< Current index for tile batch buffer of same frame, updated per frame
-    PMHW_BATCH_BUFFER m_tileLevelBatchBuffer[m_codecHalNumTileLevelBatchBuffers][EncodeBasicFeature::m_vdencBrcPassNum] = {0};  //!< Tile level batch buffer for each tile
+    PMHW_BATCH_BUFFER m_tileLevelBatchBuffer[m_codecHalNumTileLevelBatchBuffers][EncodeBasicFeature::m_vdencBrcPassNum] = {{0}};  //!< Tile level batch buffer for each tile
     MOS_RESOURCE      m_resTileBasedStatisticsBuffer[EncodeBasicFeature::m_uncompressedSurfaceNum] = {};
     MOS_RESOURCE      m_resHuCPakAggregatedFrameStatsBuffer = {};
     MOS_RESOURCE      m_tileRecordBuffer[EncodeBasicFeature::m_uncompressedSurfaceNum] = {};


### PR DESCRIPTION
Fixes these errors:

media_softlet/agnostic/common/codec/hal/enc/shared/features/encode_tile.h:506:125: error: array must be initialized with a brace-enclosed initializer
     PMHW_BATCH_BUFFER m_tileLevelBatchBuffer[m_codecHalNumTileLevelBatchBuffers][EncodeBasicFeature::m_vdencBrcPassNum] = {0};  //!< Tile level batch buffer for each tile

media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_vdenc_const_settings.h:118:55: error: array must be initialized with a brace-enclosed initializer
         m_rowOffsetsForBoost = {0, 3, 5, 2, 7, 4, 1, 6};