### PR TITLE
Correct Gen12 capability reporting for SCC bitrate control mode

### DIFF
--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -715,14 +715,6 @@ VAStatus MediaLibvaCapsG12::LoadHevcEncLpProfileEntrypoints()
     {
         uint32_t configStartIdx = m_encConfigs.size();
         AddEncConfig(VA_RC_CQP);
-        if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrEnableMediaKernels))
-        {
-            for (int32_t j = 3; j < rcModeSize; j++)
-            {
-                AddEncConfig(m_encRcMode[j]);
-                AddEncConfig(m_encRcMode[j] | VA_RC_PARALLEL);
-            }
-        }
         AddProfileEntry(VAProfileHEVCSccMain, VAEntrypointEncSliceLP, attributeList,
                 configStartIdx, m_encConfigs.size() - configStartIdx);
     }
@@ -731,14 +723,6 @@ VAStatus MediaLibvaCapsG12::LoadHevcEncLpProfileEntrypoints()
     {
         uint32_t configStartIdx = m_encConfigs.size();
         AddEncConfig(VA_RC_CQP);
-        if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrEnableMediaKernels))
-        {
-            for (int32_t j = 3; j < rcModeSize; j++)
-            {
-                AddEncConfig(m_encRcMode[j]);
-                AddEncConfig(m_encRcMode[j] | VA_RC_PARALLEL);
-            }
-        }
         AddProfileEntry(VAProfileHEVCSccMain10, VAEntrypointEncSliceLP, attributeList,
                 configStartIdx, m_encConfigs.size() - configStartIdx);
     }
@@ -747,14 +731,6 @@ VAStatus MediaLibvaCapsG12::LoadHevcEncLpProfileEntrypoints()
     {
         uint32_t configStartIdx = m_encConfigs.size();
         AddEncConfig(VA_RC_CQP);
-        if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrEnableMediaKernels))
-        {
-            for (int32_t j = 3; j < rcModeSize; j++)
-            {
-                AddEncConfig(m_encRcMode[j]);
-                AddEncConfig(m_encRcMode[j] | VA_RC_PARALLEL);
-            }
-        }
         AddProfileEntry(VAProfileHEVCSccMain444, VAEntrypointEncSliceLP, attributeList,
                 configStartIdx, m_encConfigs.size() - configStartIdx);
     }
@@ -763,14 +739,6 @@ VAStatus MediaLibvaCapsG12::LoadHevcEncLpProfileEntrypoints()
     {
         uint32_t configStartIdx = m_encConfigs.size();
         AddEncConfig(VA_RC_CQP);
-        if (MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrEnableMediaKernels))
-        {
-            for (int32_t j = 3; j < rcModeSize; j++)
-            {
-                AddEncConfig(m_encRcMode[j]);
-                AddEncConfig(m_encRcMode[j] | VA_RC_PARALLEL);
-            }
-        }
         AddProfileEntry(VAProfileHEVCSccMain444_10, VAEntrypointEncSliceLP, attributeList,
                 configStartIdx, m_encConfigs.size() - configStartIdx);
     }


### PR DESCRIPTION
1. BRC is not supported in SCC on Gen12, remove BRC for SCC profiles
2. Fixes #1400