### PR TITLE
Correct capability report for Gen12 SCC prediction direction

### DIFF
--- a/media_driver/linux/Xe_M/ddi/media_libva_caps_dg2.cpp
+++ b/media_driver/linux/Xe_M/ddi/media_libva_caps_dg2.cpp
@@ -532,7 +532,18 @@ VAStatus MediaLibvaCapsDG2::GetPlatformSpecificAttrib(VAProfile profile,
         }
         case VAConfigAttribPredictionDirection:
         {
-            *value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+            if (!IsHevcSccProfile(profile))
+            {
+                *value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+            }
+            else
+            {
+                // Here we set
+                // VAConfigAttribPredictionDirection: VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY together with
+                // VAConfigAttribEncMaxRefFrames: L0 != 0, L1 !=0
+                // to indicate SCC only supports I/low delay B
+                *value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+            }
             break;
         }
         default:
@@ -916,7 +927,18 @@ VAStatus MediaLibvaCapsDG2::CreateEncAttributes(
     if (IsHevcProfile(profile))
     {
         attrib.type = (VAConfigAttribType) VAConfigAttribPredictionDirection;
-        attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+        if (!IsHevcSccProfile(profile))
+        {
+            attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+        }
+        else
+        {
+            // Here we set
+            // VAConfigAttribPredictionDirection: VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY together with
+            // VAConfigAttribEncMaxRefFrames: L0 != 0, L1 !=0
+            // to indicate SCC only supports I/low delay B
+            attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+        }
         (*attribList)[attrib.type] = attrib.value;
     }
 

--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
@@ -518,7 +518,18 @@ VAStatus MediaLibvaCapsG12::GetPlatformSpecificAttrib(VAProfile profile,
         }
         case VAConfigAttribPredictionDirection:
         {
-            *value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+            if (!IsHevcSccProfile(profile))
+            {
+                *value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+            }
+            else
+            {
+                // Here we set
+                // VAConfigAttribPredictionDirection: VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY together with
+                // VAConfigAttribEncMaxRefFrames: L0 != 0, L1 !=0
+                // to indicate SCC only supports I/low delay B
+                *value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+            }
             break;
         }
 #if VA_CHECK_VERSION(1, 12, 0)
@@ -2099,7 +2110,18 @@ VAStatus MediaLibvaCapsG12::CreateEncAttributes(
     if (IsHevcProfile(profile))
     {
         attrib.type = (VAConfigAttribType) VAConfigAttribPredictionDirection;
-        attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+        if (!IsHevcSccProfile(profile))
+        {
+            attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_FUTURE | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+        }
+        else
+        {
+            // Here we set
+            // VAConfigAttribPredictionDirection: VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY together with
+            // VAConfigAttribEncMaxRefFrames: L0 != 0, L1 !=0
+            // to indicate SCC only supports I/low delay B
+            attrib.value = VA_PREDICTION_DIRECTION_PREVIOUS | VA_PREDICTION_DIRECTION_BI_NOT_EMPTY;
+        }
         (*attribList)[attrib.type] = attrib.value;
 #if VA_CHECK_VERSION(1, 12, 0)
         attrib.type = (VAConfigAttribType)VAConfigAttribEncHEVCFeatures;

--- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.h
+++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.h
@@ -331,6 +331,23 @@ protected:
             VADisplayAttribute *attribList,
             int32_t numAttribs) override;
 
-
+    //!
+    //! \brief    Check if the give profile is HEVC SCC
+    //!
+    //! \param    [in] profile
+    //!           Specify the VAProfile
+    //!
+    //! \return   True if the profile is a HEVC SCC profile
+    //!           False if the profile isn't a HEVC profile
+    //!
+    bool IsHevcSccProfile(VAProfile profile)
+    {
+        return (
+            (profile == VAProfileHEVCSccMain)    ||
+            (profile == VAProfileHEVCSccMain10)  ||
+            (profile == VAProfileHEVCSccMain444) ||
+            (profile == VAProfileHEVCSccMain444_10)
+           );
+    }
 };
 #endif


### PR DESCRIPTION
1. Correct the capability report for SCC prediction direction on Gen12, SCC only support I/P/Low Delay B on Gen12.
2. Fixes #1401