### PR TITLE
Added HDR10 Tone Mapping capability report.

### DIFF
--- a/media_driver/linux/Xe_M/ddi/media_sku_wa_xe.cpp
+++ b/media_driver/linux/Xe_M/ddi/media_sku_wa_xe.cpp
@@ -811,6 +811,8 @@ static bool InitDg2MediaSku(struct GfxDeviceInfo *devInfo,
         MEDIA_WR_SKU(skuTable, FtrMediaTile64, 1);
     }
 
+    MEDIA_WR_SKU(skuTable, FtrHDR, 1);
+
     return true;
 }
 

--- a/media_driver/linux/common/vp/ddi/media_libva_vp.c
+++ b/media_driver/linux/common/vp/ddi/media_libva_vp.c
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2009-2020, Intel Corporation
+* Copyright (c) 2009-2022, Intel Corporation
 *
 * Permission is hereby granted, free of charge, to any person obtaining a
 * copy of this software and associated documentation files (the "Software"),
@@ -4486,33 +4486,36 @@ DdiVp_QueryVideoProcFilterCaps (
         {
             if (mediaDrvCtx)
             {
-                uExistCapsNum = 1;
-                *num_filter_caps = uExistCapsNum;
-                if (uQueryFlag == QUERY_CAPS_ATTRIBUTE)
+                if (MEDIA_IS_SKU(&mediaDrvCtx->SkuTable, FtrHDR))
                 {
-                    VAProcFilterCapHighDynamicRange *HdrTmCap = (VAProcFilterCapHighDynamicRange *)filter_caps;
-
-                    if (uQueryCapsNum < uExistCapsNum)
+                    uExistCapsNum = 1;
+                    *num_filter_caps = uExistCapsNum;
+                    if (uQueryFlag == QUERY_CAPS_ATTRIBUTE)
                     {
-                        return VA_STATUS_ERROR_MAX_NUM_EXCEEDED;
-                    }
+                        VAProcFilterCapHighDynamicRange *HdrTmCap = (VAProcFilterCapHighDynamicRange *)filter_caps;
 
-                    if (HdrTmCap)
-                    {
-                        HdrTmCap->metadata_type = VAProcHighDynamicRangeMetadataHDR10;
-                        HdrTmCap->caps_flag = VA_TONE_MAPPING_HDR_TO_HDR | VA_TONE_MAPPING_HDR_TO_SDR | VA_TONE_MAPPING_HDR_TO_EDR;
+                        if (uQueryCapsNum < uExistCapsNum)
+                        {
+                            return VA_STATUS_ERROR_MAX_NUM_EXCEEDED;
+                        }
+
+                        if (HdrTmCap)
+                        {
+                            HdrTmCap->metadata_type = VAProcHighDynamicRangeMetadataHDR10;
+                            HdrTmCap->caps_flag = VA_TONE_MAPPING_HDR_TO_HDR | VA_TONE_MAPPING_HDR_TO_SDR | VA_TONE_MAPPING_HDR_TO_EDR;
+                        }
                     }
                 }
                 else
                 {
-                    VP_DDI_NORMALMESSAGE("VAProcFilterHighDynamicRangeToneMapping uQueryFlag != QUERY_CAPS_ATTRIBUTE.\n");
-                    return VA_STATUS_ERROR_INVALID_VALUE;
+                    uExistCapsNum = 0;
+                    *num_filter_caps = uExistCapsNum;
                 }
             }
             else
             {
-                VP_DDI_NORMALMESSAGE("Other platforms except ICL can not support VAProcFilterHighDynamicRangeToneMapping.\n");
-                return VA_STATUS_ERROR_INVALID_VALUE;
+                VP_DDI_ASSERTMESSAGE("mediaDrvCtx is null pointer.\n");
+                return VA_STATUS_ERROR_INVALID_CONTEXT;
             }
             break;
         }

--- a/media_driver/linux/gen11/ddi/media_sku_wa_g11.cpp
+++ b/media_driver/linux/gen11/ddi/media_sku_wa_g11.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020, Intel Corporation
+* Copyright (c) 2020-2022, Intel Corporation
 *
 * Permission is hereby granted, free of charge, to any person obtaining a
 * copy of this software and associated documentation files (the "Software"),
@@ -189,6 +189,8 @@ static bool InitIclMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrTileY, 1);
 
     MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
+
+    MEDIA_WR_SKU(skuTable, FtrHDR, 1);
 
     return true;
 }

--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -290,6 +290,8 @@ static bool InitTglMediaSku(struct GfxDeviceInfo *devInfo,
         MEDIA_WR_SKU(skuTable, FtrCompressibleSurfaceDefault, 1);
     }
 
+    MEDIA_WR_SKU(skuTable, FtrHDR, 1);
+
     return true;
 }
 


### PR DESCRIPTION
HDR10 Tone Mapping (HDR to HDR, HDR to SDR, HDR to EDR as of now) will be supported on the below platforms.
1. KBL GT2/GT3/GT4;
2. GLK (this is a specific requests, perf can not be guarantee due to limited EUs);
3. ICL;
4. TGL/ADL/DG1;
5. DG2;

Signed-off-by: Furong Zhang <furong.zhang@intel.com>