### PR TITLE
Correct the calculation method of maxTileNumber for Gen12 VP9

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
@@ -4634,7 +4634,7 @@ MOS_STATUS CodechalVdencVp9StateG12::Initialize(CodechalSetting * settings)
     maxRows = MOS_MIN(maxRows, 4);
 
     //Max tile numbers = max of number tiles for single pipe or max muber of tiles for scalable pipes
-    m_maxTileNumber = MOS_MAX((MOS_ALIGN_CEIL(m_frameWidth, CODECHAL_ENCODE_VP9_MIN_TILE_SIZE_WIDTH) / CODECHAL_ENCODE_VP9_MIN_TILE_SIZE_WIDTH), m_numVdbox * maxRows);
+    m_maxTileNumber = MOS_MAX((MOS_ALIGN_CEIL(m_frameWidth, CODECHAL_ENCODE_VP9_MIN_TILE_SIZE_WIDTH) / CODECHAL_ENCODE_VP9_MIN_TILE_SIZE_WIDTH), m_numVdbox) * maxRows;
 
     m_numPipe = m_numVdbox;
 


### PR DESCRIPTION
Previously, the calculation of maxTileNumber is wrong on Gen12 VP9, this will cause crash when input 4x4 tiles. Fixes #1314