### PR TITLE
[Decode] enable intensity compensation for vc1 decoding

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_ddi_decode_vc1.cpp
+++ b/media_driver/linux/common/codec/ddi/media_ddi_decode_vc1.cpp
@@ -349,7 +349,7 @@ VAStatus DdiDecodeVC1::ParsePicParams(
     if (picParam->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation)
     {
         codecPicParam->mv_fields.UnifiedMvMode = (picParam->mv_fields.bits.mv_mode2 + 1) & 0x3;
-        ;
+        codecPicParam->picture_fields.intensity_compensation = 1;
     }
     else
     {


### PR DESCRIPTION
Enable intensity compensation to avoid the artifact for B frame decoding
Fixes #752