### PR TITLE
Avoid incorrect error reporting for LDB when HierarchicalFlag > 0

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_encode_hevc.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_hevc.cpp
@@ -1520,7 +1520,7 @@ MOS_STATUS CodechalEncHevcState::GetFrameBrcLevel()
         // LDB
         if (m_pictureCodingType == I_TYPE)
         {
-            if (m_hevcPicParams->HierarchLevelPlus1 == 0)
+            if (m_hevcSeqParams->HierarchicalFlag > 0 || m_hevcPicParams->HierarchLevelPlus1 == 0)
             {
                 m_currFrameBrcLevel = HEVC_BRC_FRAME_TYPE_I;
             }


### PR DESCRIPTION
When HierarchicalFlag > 0 for I frame LDB, will ignore the vaule of HierarchLevelPlus1. For compatibility purpose, we keep m_hevcPicParams->HierarchLevelPlus1 == 0 here. Fixes #1395