### PR TITLE
Zero params struct before setting/passing to AddMiStoreRegiterMemCmd

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decode_scalability.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_scalability.cpp
@@ -1901,6 +1901,7 @@ MOS_STATUS CodecHalDecodeScalability_ReadCSEngineIDReg(
         pDecodeStatusBuf->m_csEngineIdOffset + sizeof(uint32_t)* ucPhaseIndex +
         sizeof(uint32_t)* 2;
 
+    MOS_ZeroMemory(&StoreRegParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     StoreRegParams.presStoreBuffer  = &pDecodeStatusBuf->m_statusBuffer;
     StoreRegParams.dwOffset         = dwOffset;
     StoreRegParams.dwRegister       = pMmioRegisters->csEngineIdOffset;

--- a/media_driver/agnostic/common/codec/hal/codechal_decoder.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_decoder.cpp
@@ -1539,6 +1539,7 @@ MOS_STATUS CodechalDecode::EndStatusReport(
         sizeof(uint32_t) * 2;
 
     MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
+    MOS_ZeroMemory(&regParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     regParams.presStoreBuffer   = &m_decodeStatusBuf.m_statusBuffer;
     regParams.dwOffset          = errStatusOffset;
     regParams.dwRegister        = ((m_standard == CODECHAL_HEVC || m_standard == CODECHAL_VP9) && mmioRegistersHcp) ?

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_vp8.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_vp8.cpp
@@ -4027,6 +4027,7 @@ MOS_STATUS CodechalEncodeVp8::ReadImageStatus(PMOS_COMMAND_BUFFER cmdBuffer)
         (encodeStatusBuf->wCurrIndex * m_encodeStatusBuf.dwReportSize) +
         sizeof(uint32_t) * 2;  // pEncodeStatus is offset by 2 DWs in the resource
 
+    MOS_ZeroMemory(&miStoreRegMemParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     miStoreRegMemParams.presStoreBuffer = &encodeStatusBuf->resStatusBuffer;
     miStoreRegMemParams.dwOffset = baseOffset + encodeStatusBuf->dwImageStatusMaskOffset;
     miStoreRegMemParams.dwRegister = mmioRegisters->mfcVP8ImageStatusMaskRegOffset;
@@ -4072,6 +4073,7 @@ MOS_STATUS CodechalEncodeVp8::ReadMfcStatus(PMOS_COMMAND_BUFFER cmdBuffer)
     MOS_ZeroMemory(&flushDwParams, sizeof(flushDwParams));
     CODECHAL_ENCODE_CHK_STATUS_RETURN(commonMiInterface->AddMiFlushDwCmd(cmdBuffer, &flushDwParams));
 
+    MOS_ZeroMemory(&miStoreRegMemParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     miStoreRegMemParams.presStoreBuffer = &encodeStatusBuf->resStatusBuffer;
     miStoreRegMemParams.dwOffset = baseOffset + encodeStatusBuf->dwBSByteCountOffset;
     miStoreRegMemParams.dwRegister = mmioRegisters->mfcVP8BitstreamBytecountFrameRegOffset;

--- a/media_driver/agnostic/gen11/codec/hal/codechal_decode_hevc_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_decode_hevc_g11.cpp
@@ -546,11 +546,12 @@ MOS_STATUS CodechalDecodeHevcG11::EndStatusReport(
     auto mmioRegistersMfx = m_mfxInterface->GetMmioRegisters(m_vdboxIndex);
     uint32_t currIndex = m_decodeStatusBuf.m_currIndex;
 
-    MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
-
     //Frame CRC
     if (m_reportFrameCrc)
     {
+        MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
+        MOS_ZeroMemory(&regParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
+
         uint32_t frameCrcOffset =
             currIndex * sizeof(CodechalDecodeStatus) +
             m_decodeStatusBuf.m_decFrameCrcOffset +
@@ -626,6 +627,7 @@ MOS_STATUS CodechalDecodeHevcG11::EndStatusReportForFE(
         sizeof(uint32_t) * 2;
 
     MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
+    MOS_ZeroMemory(&regParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     regParams.presStoreBuffer = &m_decodeStatusBuf.m_statusBuffer;
     regParams.dwOffset = errStatusOffset;
     regParams.dwRegister = mmioRegistersHcp ?

--- a/media_driver/agnostic/gen11/codec/hal/codechal_decode_vp9_g11.cpp
+++ b/media_driver/agnostic/gen11/codec/hal/codechal_decode_vp9_g11.cpp
@@ -256,11 +256,12 @@ MOS_STATUS CodechalDecodeVp9G11::EndStatusReport(
     auto mmioRegistersMfx = m_mfxInterface->GetMmioRegisters(m_vdboxIndex);
     uint32_t currIndex = m_decodeStatusBuf.m_currIndex;
 
-    MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
-
     //Frame CRC
     if (m_reportFrameCrc)
     {
+        MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
+        MOS_ZeroMemory(&regParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
+
         uint32_t frameCrcOffset =
             currIndex * sizeof(CodechalDecodeStatus) +
             m_decodeStatusBuf.m_decFrameCrcOffset +
@@ -336,6 +337,7 @@ MOS_STATUS CodechalDecodeVp9G11::EndStatusReportForFE(
         sizeof(uint32_t) * 2;
 
     MHW_MI_STORE_REGISTER_MEM_PARAMS regParams;
+    MOS_ZeroMemory(&regParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     regParams.presStoreBuffer = &m_decodeStatusBuf.m_statusBuffer;
     regParams.dwOffset = errStatusOffset;
     regParams.dwRegister = mmioRegistersHcp ?

--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_scalability_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_scalability_g12.cpp
@@ -894,6 +894,7 @@ MOS_STATUS CodecHalDecodeScalability_ReadCSEngineIDReg_G12(
         pDecodeStatusBuf->m_csEngineIdOffset + sizeof(uint32_t)* ucPhaseIndex +
         sizeof(uint32_t) * 2;
 
+    MOS_ZeroMemory(&StoreRegParams, sizeof(MHW_MI_STORE_REGISTER_MEM_PARAMS));
     StoreRegParams.presStoreBuffer = &pDecodeStatusBuf->m_statusBuffer;
     StoreRegParams.dwOffset = dwOffset;
     StoreRegParams.dwRegister = pMmioRegisters->csEngineIdOffset;


### PR DESCRIPTION
AddMiStoreRegisterMemCmd can use the dwOption member of
MHW_MI_STORE_REGISTER_MEM_PARAMS which is usually uninitialized. The standard
pattern seems to be zeroing the struct before using it. valgrind spotted a few
of these, but I searched around for all of the similar cases that I could find.