### PR TITLE
Add build options to disable SSE intrinsics usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ cmake_dependent_option( BUILD_KERNELS
 option (BUILD_CMRTLIB "Build and Install cmrtlib together with media driver" ON)
 
 option (ENABLE_PRODUCTION_KMD "Enable Production KMD header files" OFF)
+option (ENABLE_X86_INTRINSICS "Enable x86 intrinsics" ON)
+if(ENABLE_X86_INTRINSICS)
+    add_definitions(-DIGFX_ENABLE_X86_INTRINSICS)
+endif()
 
 include(GNUInstallDirs)
 

--- a/media_driver/agnostic/common/cm/cm_mem.cpp
+++ b/media_driver/agnostic/common/cm/cm_mem.cpp
@@ -38,15 +38,21 @@ typedef void(*t_CmFastMemCopyWC)( void* dst,   const void* src, const size_t byt
 void CmFastMemCopy( void* dst, const void* src, const size_t bytes )
 {
     static const bool is_SSE2_available = (GetCpuInstructionLevel() >= CPU_INSTRUCTION_LEVEL_SSE2);
+#ifdef IGFX_ENABLE_X86_INTRINSICS
     static const t_CmFastMemCopy CmFastMemCopy_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopy);
-
+#else
+    static const t_CmFastMemCopy CmFastMemCopy_impl = CM_FAST_MEM_COPY_CPU_INIT_C(CmFastMemCopy);
+#endif
     CmFastMemCopy_impl(dst, src, bytes);
 }
 
 void CmFastMemCopyWC( void* dst, const void* src, const size_t bytes )
 {
     static const bool is_SSE2_available = (GetCpuInstructionLevel() >= CPU_INSTRUCTION_LEVEL_SSE2);
+#ifdef IGFX_ENABLE_X86_INTRINSICS
     static const t_CmFastMemCopyWC CmFastMemCopyWC_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopyWC);
-
+#else
+    static const t_CmFastMemCopyWC CmFastMemCopyWC_impl = CM_FAST_MEM_COPY_CPU_INIT_C(CmFastMemCopyWC);
+#endif
     CmFastMemCopyWC_impl(dst, src, bytes);
 }

--- a/media_driver/agnostic/common/cm/cm_mem.h
+++ b/media_driver/agnostic/common/cm/cm_mem.h
@@ -24,10 +24,11 @@
 //! \brief     Contains CM memory function definitions 
 //!
 #pragma once
-
+#ifdef IGFX_ENABLE_X86_INTRINSICS
 #include <mmintrin.h>
 #include <xmmintrin.h>
 #include <emmintrin.h>
+#endif
 #include "cm_debug.h"
 #include "mos_utilities.h"
 
@@ -42,8 +43,11 @@ enum CPU_INSTRUCTION_LEVEL
     CPU_INSTRUCTION_LEVEL_SSE4_1,
     NUM_CPU_INSTRUCTION_LEVELS
 };
-
+#ifdef IGFX_ENABLE_X86_INTRINSICS
 typedef __m128              DQWORD;         // 128-bits,   16-bytes
+#else
+typedef unsigned __int128           DQWORD;
+#endif
 typedef uint32_t            PREFETCH[8];    //             32-bytes
 typedef uint32_t            CACHELINE[8];   //             32-bytes
 typedef uint16_t            DHWORD[32];     // 512-bits,   64-bytes
@@ -68,6 +72,7 @@ void CmFastMemCopyWC( void* dst,   const void* src, const size_t bytes );
 
 inline void Prefetch( const void* ptr );
 
+#ifdef IGFX_ENABLE_X86_INTRINSICS
 /*****************************************************************************\
 MACROS:
     EMIT_R_MR
@@ -115,6 +120,8 @@ Description:
 #define MOVNTDQA_R_MR_OFFSET(DST, SRC, OFFSET)  \
     EMIT_R_MR_OFFSET(MOVNTDQA_OP, DST, SRC, OFFSET)
 
+#endif
+
 #ifndef BIT
 #define BIT( n )    ( 1 << (n) )
 #endif
@@ -130,6 +137,7 @@ Description:
 \*****************************************************************************/
 inline void CmSafeMemSet( void* dst, const int data, const size_t bytes )
 {
+
 #if defined(_DEBUG)
     __try
 #endif
@@ -227,6 +235,8 @@ Output:
 \*****************************************************************************/
 inline CPU_INSTRUCTION_LEVEL GetCpuInstructionLevel( void )
 {
+
+#ifdef IGFX_ENABLE_X86_INTRINSICS
     int cpuInfo[4];
     memset( cpuInfo, 0, 4*sizeof(int) );
 
@@ -253,7 +263,9 @@ inline CPU_INSTRUCTION_LEVEL GetCpuInstructionLevel( void )
     {
         cpuInstructionLevel = CPU_INSTRUCTION_LEVEL_MMX;
     }
-
+#else
+    CPU_INSTRUCTION_LEVEL cpuInstructionLevel = CPU_INSTRUCTION_LEVEL_UNKNOWN;
+#endif
     return cpuInstructionLevel;
 }
 

--- a/media_driver/agnostic/common/cm/media_srcs.cmake
+++ b/media_driver/agnostic/common/cm/media_srcs.cmake
@@ -89,7 +89,6 @@ set(TMP_HEADERS_
     ${CMAKE_CURRENT_LIST_DIR}/cm_kernel_data.h
     ${CMAKE_CURRENT_LIST_DIR}/cm_log.h
     ${CMAKE_CURRENT_LIST_DIR}/cm_mem_c_impl.h
-    ${CMAKE_CURRENT_LIST_DIR}/cm_mem_sse2_impl.h
     ${CMAKE_CURRENT_LIST_DIR}/cm_mem.h
     ${CMAKE_CURRENT_LIST_DIR}/cm_mov_inst.h
     ${CMAKE_CURRENT_LIST_DIR}/cm_perf.h
@@ -137,6 +136,10 @@ set(TMP_HEADERS_
     ${CMAKE_CURRENT_LIST_DIR}/cm_wrapper.h
     ${CMAKE_CURRENT_LIST_DIR}/cm_surface_2d_rt_base.h)
 
+if(ENABLE_X86_INTRINSICS)
+set(TMP_HEADERS_ ${TMP_HEADERS_} ${CMAKE_CURRENT_LIST_DIR}/cm_mem_sse2_impl.h)
+endif()
+
 set(SOURCES_
     ${SOURCES_}
     ${TMP_SOURCES_})
@@ -153,9 +156,10 @@ set(COMMON_HEADERS_
     ${COMMON_HEADERS_}
     ${TMP_HEADERS_})
 
+if(ENABLE_X86_INTRINSICS)
 set(SOURCES_SSE2
     ${CMAKE_CURRENT_LIST_DIR}/cm_mem_sse2_impl.cpp)
-
+endif()
 source_group(CM FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
 
 media_add_curr_to_include_path()

--- a/media_driver/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_compile_flags_linux.cmake
@@ -52,7 +52,7 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -Wl,--gc-sections
 
     # -m32 or -m64
-    -m${ARCH}
+    #-m${ARCH}
 
     # Global defines
     -DLINUX=1
@@ -62,6 +62,10 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -DINTEL_NOT_PUBLIC
     -g
 )
+
+if(ENABLE_X86_INTRINSICS)
+set(MEDIA_COMPILER_FLAGS_COMMON ${MEDIA_COMPILER_FLAGS_COMMON} -m${ARCH})
+endif()
 
 if(MEDIA_BUILD_HARDENING)
     set(MEDIA_COMPILER_FLAGS_COMMON

--- a/media_driver/linux/common/cm/hal/osservice/cm_mem_os.cpp
+++ b/media_driver/linux/common/cm/hal/osservice/cm_mem_os.cpp
@@ -38,7 +38,10 @@ typedef void(*t_CmFastMemCopyFromWC)( void* dst, const void* src, const size_t b
 void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes, CPU_INSTRUCTION_LEVEL cpuInstructionLevel )
 {
     static const bool is_SSE4_available = (cpuInstructionLevel >= CPU_INSTRUCTION_LEVEL_SSE4_1);
+#ifdef IGFX_ENABLE_X86_INTRINSICS
     static const t_CmFastMemCopyFromWC CmFastMemCopyFromWC_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopyFromWC);
-
+#else
+    static const t_CmFastMemCopyFromWC CmFastMemCopyFromWC_impl = CM_FAST_MEM_COPY_CPU_INIT_C(CmFastMemCopyFromWC);
+#endif
     CmFastMemCopyFromWC_impl(dst, src, bytes);
 }

--- a/media_driver/linux/common/cm/hal/osservice/cm_mem_os.h
+++ b/media_driver/linux/common/cm/hal/osservice/cm_mem_os.h
@@ -26,9 +26,10 @@
 #pragma once
 
 #include <iostream>
+#ifdef IGFX_ENABLE_X86_INTRINSICS
 #include "cpuid.h"
 #include <smmintrin.h>
-
+#endif
 typedef uintptr_t           UINT_PTR;
 #define __fastcall
 #define __noop
@@ -120,11 +121,11 @@ Output:
 \*****************************************************************************/
 inline void GetCPUID(int cpuInfo[4], int infoType)
 {
+#ifdef IGFX_ENABLE_X86_INTRINSICS
 #ifndef NO_EXCEPTION_HANDLING
     __try
     {
 #endif //NO_EXCEPTION_HANDLING
-
     __get_cpuid(infoType, (unsigned int*)cpuInfo, (unsigned int*)cpuInfo + 1, (unsigned int*)cpuInfo + 2, (unsigned int*)cpuInfo + 3);
 
 #ifndef NO_EXCEPTION_HANDLING
@@ -135,6 +136,7 @@ inline void GetCPUID(int cpuInfo[4], int infoType)
         return;
     }
 #endif  //NO_EXCEPTION_HANDLING
+#endif
 }
 
 void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes, CPU_INSTRUCTION_LEVEL cpuInstructionLevel );

--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -115,8 +115,10 @@ set_source_files_properties(${CP_COMMON_SHARED_SOURCES_} PROPERTIES LANGUAGE "CX
 set_source_files_properties(${CP_COMMON_NEXT_SOURCES_} PROPERTIES LANGUAGE "CXX")
 set_source_files_properties(${CP_SOURCES_} PROPERTIES LANGUAGE "CXX")
 
+if(ENABLE_X86_INTRINSICS)
 set_source_files_properties(${SOURCES_SSE2} PROPERTIES LANGUAGE "CXX")
 set_source_files_properties(${SOURCES_SSE4} PROPERTIES LANGUAGE "CXX")
+endif()
 
 set (CP_SOURCES_
     ${CP_SOURCES_}
@@ -150,6 +152,7 @@ set (COMMON_SOURCES_
     ${COMMON_SOURCES_}
     ${UPDATED_SOURCES_})
 
+if(ENABLE_X86_INTRINSICS)
 add_library(${LIB_NAME}_SSE2 OBJECT ${SOURCES_SSE2})
 target_compile_options(${LIB_NAME}_SSE2 PRIVATE -msse2)
 target_include_directories(${LIB_NAME}_SSE2 BEFORE PRIVATE ${MOS_PREPEND_INCLUDE_DIRS_} ${MOS_PUBLIC_INCLUDE_DIRS_})
@@ -157,6 +160,7 @@ target_include_directories(${LIB_NAME}_SSE2 BEFORE PRIVATE ${MOS_PREPEND_INCLUDE
 add_library(${LIB_NAME}_SSE4 OBJECT ${SOURCES_SSE4})
 target_compile_options(${LIB_NAME}_SSE4 PRIVATE -msse4.1)
 target_include_directories(${LIB_NAME}_SSE4 BEFORE PRIVATE ${MOS_PREPEND_INCLUDE_DIRS_} ${MOS_PUBLIC_INCLUDE_DIRS_})
+endif()
 
 add_library(${LIB_NAME}_COMMON OBJECT ${COMMON_SOURCES_})
 set_property(TARGET ${LIB_NAME}_COMMON PROPERTY POSITION_INDEPENDENT_CODE 1)
@@ -200,6 +204,7 @@ target_include_directories(${LIB_NAME}_mos BEFORE PRIVATE
 
 ######################################################
 
+if(ENABLE_X86_INTRINSICS)
 add_library(${LIB_NAME} SHARED
     $<TARGET_OBJECTS:${LIB_NAME}_mos>
     $<TARGET_OBJECTS:${LIB_NAME}_COMMON>
@@ -208,7 +213,16 @@ add_library(${LIB_NAME} SHARED
     $<TARGET_OBJECTS:${LIB_NAME}_CP>
     $<TARGET_OBJECTS:${LIB_NAME}_SSE2>
     $<TARGET_OBJECTS:${LIB_NAME}_SSE4>)
+else()
+add_library(${LIB_NAME} SHARED
+    $<TARGET_OBJECTS:${LIB_NAME}_mos>
+    $<TARGET_OBJECTS:${LIB_NAME}_COMMON>
+    $<TARGET_OBJECTS:${LIB_NAME}_CODEC>
+    $<TARGET_OBJECTS:${LIB_NAME}_VP>
+    $<TARGET_OBJECTS:${LIB_NAME}_CP>)
+endif()
 
+if(ENABLE_X86_INTRINSICS)
 add_library(${LIB_NAME_STATIC} STATIC
     $<TARGET_OBJECTS:${LIB_NAME}_mos>
     $<TARGET_OBJECTS:${LIB_NAME}_COMMON>
@@ -217,6 +231,14 @@ add_library(${LIB_NAME_STATIC} STATIC
     $<TARGET_OBJECTS:${LIB_NAME}_CP>
     $<TARGET_OBJECTS:${LIB_NAME}_SSE2>
     $<TARGET_OBJECTS:${LIB_NAME}_SSE4>)
+else()
+add_library(${LIB_NAME_STATIC} STATIC
+    $<TARGET_OBJECTS:${LIB_NAME}_mos>
+    $<TARGET_OBJECTS:${LIB_NAME}_COMMON>
+    $<TARGET_OBJECTS:${LIB_NAME}_CODEC>
+    $<TARGET_OBJECTS:${LIB_NAME}_VP>
+    $<TARGET_OBJECTS:${LIB_NAME}_CP>)
+endif()
 
 set_target_properties(${LIB_NAME_STATIC} PROPERTIES OUTPUT_NAME ${LIB_NAME})
 

--- a/media_softlet/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_softlet/cmake/linux/media_compile_flags_linux.cmake
@@ -53,7 +53,7 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -Wl,--gc-sections
 
     # -m32 or -m64
-    -m${ARCH}
+    #-m${ARCH}
 
     # Global defines
     -DLINUX=1


### PR DESCRIPTION
cmake ../media-driver/ -DENABLE_PRODUCTION_KMD=ON -DMEDIA_BUILD_FATAL_WARNINGS=OFF -DBUILD_CMRTLIB=OFF -DENABLE_X86_INTRINSICS=OFF

Signed-off-by: XinfengZhang <carl.zhang@intel.com>