### PR TITLE
Fix debug builds

### DIFF
--- a/media_driver/media_softlet/agnostic/Xe_R/Xe_HP_Base/renderhal/renderhal_xe_hp_base.cpp
+++ b/media_driver/media_softlet/agnostic/Xe_R/Xe_HP_Base/renderhal/renderhal_xe_hp_base.cpp
@@ -105,7 +105,7 @@ MOS_STATUS XRenderHal_Interface_Xe_Hp_Base::SetupSurfaceState(
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pStateHeap);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pHwSizes);
     MHW_RENDERHAL_CHK_NULL(pRenderHal->pMhwStateHeap);
-    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= 0 && pRenderHalSurface->Rotation < 8);
+    MHW_RENDERHAL_ASSERT(pRenderHalSurface->Rotation >= MHW_ROTATION_IDENTITY && pRenderHalSurface->Rotation <= MHW_ROTATE_90_MIRROR_HORIZONTAL);
     //-----------------------------------------
 
     dwSurfaceSize = pRenderHal->pHwSizes->dwSizeSurfaceState;

--- a/media_softlet/agnostic/common/codec/hal/codechal_debug.cpp
+++ b/media_softlet/agnostic/common/codec/hal/codechal_debug.cpp
@@ -794,14 +794,9 @@ MOS_STATUS CodechalDebugInterface::DumpRgbDataOnYUVSurface(
         m_osInterface->pfnUnlockResource(m_osInterface, &surface->OsResource);
     }
 
-    if (&(tmpRgbSurface->OsResource))
-    {
-        m_osInterface->pfnFreeResource(m_osInterface, &(tmpRgbSurface->OsResource));
-    }
-    if (tmpRgbSurface)
-    {
-        MOS_Delete(tmpRgbSurface);
-    }
+    m_osInterface->pfnFreeResource(m_osInterface, &(tmpRgbSurface->OsResource));
+    MOS_Delete(tmpRgbSurface);
+
     return MOS_STATUS_SUCCESS;
 }
 

--- a/media_softlet/agnostic/common/os/mos_utilities_next.cpp
+++ b/media_softlet/agnostic/common/os/mos_utilities_next.cpp
@@ -400,7 +400,7 @@ void *MosUtilities::MosReallocMemory(
     size_t     newSize)
 #endif // MOS_MESSAGES_ENABLED
 {
-    void *oldPtr = nullptr;
+    uintptr_t oldPtr = reinterpret_cast<uintptr_t>(nullptr);
     void *newPtr = nullptr;
 
 #if (_DEBUG || _RELEASE_INTERNAL)
@@ -410,14 +410,14 @@ void *MosUtilities::MosReallocMemory(
     }
 #endif
 
-    oldPtr = ptr;
+    oldPtr = reinterpret_cast<uintptr_t>(ptr);
     newPtr = realloc(ptr, newSize);
 
     MOS_OS_ASSERT(newPtr != nullptr);
 
-    if (newPtr != oldPtr)
+    if (newPtr != reinterpret_cast<void*>(oldPtr))
     {
-        if (oldPtr != nullptr)
+        if (oldPtr != reinterpret_cast<uintptr_t>(nullptr))
         {
             MosAtomicDecrement(&m_mosMemAllocCounter);
             MOS_MEMNINJA_FREE_MESSAGE(oldPtr, functionName, filename, line);


### PR DESCRIPTION
Both clang and gcc fail creating debug builds.

This fix addresses the following compile warnings/errors:
```
comparison of constant 8 with expression of type 'MHW_ROTATION' (aka '_MHW_ROTATION') is always true
```
```
pointer ‘oldPtr’ may be used after ‘void* realloc(void*, size_t)’
```
```
the address of ‘MOS_SURFACE::OsResource’ will never be NULL
```
This fixes issue #1490 