### PR TITLE
Fix reads from uninitialized memory.

### DIFF
--- a/cmrtlib/linux/hardware/drm_device.h
+++ b/cmrtlib/linux/hardware/drm_device.h
@@ -584,6 +584,7 @@ static int parse_separate_sysfs_files(int maj, int min,
 
     snprintf(resourcename, sizeof(resourcename), "%s/resource", pci_path);
 
+    memset(drivername, 0, sizeof(drivername));
     if (readlink(driverpath, drivername, PATH_MAX) < 0)
     {
         /* Some devices might not be bound to a driver */
@@ -950,6 +951,7 @@ static int drmParseSubsystemType(int maj, int min)
     snprintf(path, PATH_MAX, "/sys/dev/char/%d:%d/device/subsystem",
         maj, min);
 
+    memset(link, 0, sizeof(link));
     if (readlink(path, link, PATH_MAX) < 0)
         return -errno;
 


### PR DESCRIPTION
This fixes issue #1507 

readlink() will not place a terminating 0, which means that we cannot use unintialized memory as a destination.

NOTE: it is not sufficient to write a null-string to the buffer, because that only sets the first character to 0. Every byte in the destination string should be 0, so that when readlink() has written content, it is always null-terminated.
