### PR TITLE
[Decode] Add missing conditional check for None-Free Kernel build

### DIFF
--- a/media_driver/agnostic/Xe_M/Xe_XPM/codec/media_srcs.cmake
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/codec/media_srcs.cmake
@@ -19,4 +19,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 media_include_subdirectory(hal)
+if(ENABLE_KERNELS AND ENABLE_NONFREE_KERNELS)
 media_include_subdirectory(kernelisa)
+endif()


### PR DESCRIPTION
Fix the issue of missing contitional checking for None-Free kernel build in cmake file. Fixes #1517.