### PR TITLE
Fix cmake warnings

### DIFF
--- a/media_driver/agnostic/common/vp/media_srcs.cmake
+++ b/media_driver/agnostic/common/vp/media_srcs.cmake
@@ -20,4 +20,3 @@
 
 media_include_subdirectory(hal)
 media_include_subdirectory(kdll)
-media_include_subdirectory(kernel)

--- a/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
+++ b/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
@@ -18,8 +18,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-media_include_subdirectory(mmd)
-
 set(TMP_HEADERS_
     ${CMAKE_CURRENT_LIST_DIR}/media_interfaces_mhw_next.h
     ${CMAKE_CURRENT_LIST_DIR}/media_interfaces_mcpy_next.h


### PR DESCRIPTION
Fixed #1520
Remove redundant contents in cmake file, because these old source folders have been removed after refactor.
Signed-off-by: Gu, Lihao lihao.gu@intel.com