### PR TITLE
Add Alder Lake S PCI ID for the i9-12950HX mobile processor

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sysinfo_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sysinfo_g12.cpp
@@ -377,6 +377,9 @@ static bool adlsGt1Device4682 = DeviceInfoFactory<GfxDeviceInfo>::
 static bool adlsGt1Device4683 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x4683, &adlsGt1fInfo);
 
+static bool adlsGt1Device4688 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0x4688, &adlsGt1Info);
+
 static bool adlsGt1Device4690 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0x4690, &adlsGt1Info);
 


### PR DESCRIPTION
Fixes media driver compatibility with the i9-12950HX mobile processor.

Based off of this mesa commit: https://gitlab.freedesktop.org/mesa/mesa/-/commit/df5b14969f9869f363bcc8b2a564c85aaa481597

More info: https://bugs.launchpad.net/ubuntu/+source/mesa/+bug/1955566/comments/0