### PR TITLE
fix build error with gcc-4.9

### DIFF
--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/encode_vp9_hpu.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/encode_vp9_hpu.h
@@ -146,7 +146,7 @@ protected:
     MOS_RESOURCE m_resProbabilityCounterBuffer           = {0};                  //!< Probability counter buffer
     MOS_RESOURCE m_resHucProbDmemBuffer[CODECHAL_ENCODE_RECYCLED_BUFFER_NUM][3]; //!< VDENC HuC Prob DMEM buffer
     MOS_RESOURCE m_resHucProbOutputBuffer                = {0};                  //!< HuC Prob output buffer
-    MOS_RESOURCE m_resProbBuffer[CODEC_VP9_NUM_CONTEXTS] = {0};                  //!< Probability buffer
+    MOS_RESOURCE m_resProbBuffer[CODEC_VP9_NUM_CONTEXTS] = { {0} };                  //!< Probability buffer
 
     mutable bool m_isLastPass = false;
 MEDIA_CLASS_DEFINE_END(encode__Vp9EncodeHpu)

--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/encode_vp9_pak.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/encode_vp9_pak.h
@@ -351,7 +351,7 @@ protected:
     MOS_RESOURCE m_resVdencPictureState2ndLevelBatchBufferWrite[CODECHAL_VP9_ENCODE_RECYCLED_BUFFER_NUM];
 
     // Vdenc/Pak resources
-    MOS_RESOURCE m_resHucPakInsertUncompressedHeaderReadBuffer[CODECHAL_ENCODE_RECYCLED_BUFFER_NUM]  = {0};  //!< Huc VP9 pak insert uncompressed header read buffer
+    MOS_RESOURCE m_resHucPakInsertUncompressedHeaderReadBuffer[CODECHAL_ENCODE_RECYCLED_BUFFER_NUM]  = { {0} };  //!< Huc VP9 pak insert uncompressed header read buffer
     MOS_RESOURCE m_resHucPakInsertUncompressedHeaderWriteBuffer                                      = {0};  //!< Huc VP9 pak insert uncompressed header write buffer
 
     MOS_RESOURCE m_resCompressedHeaderBuffer   = {0};  //!< Compressed heander buffer

--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/encode_vp9_segmentation.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/encode_vp9_segmentation.h
@@ -463,7 +463,7 @@ protected:
     // Segmentation resources
     bool        m_segmentMapProvided  = false;  //!< Flag to indicate APP's segmentation map provided or not
     bool        m_segmentMapAllocated = false;
-    MOS_SURFACE m_mbSegmentMapSurface = {0};
+    MOS_SURFACE m_mbSegmentMapSurface = { {0} };
 
     uint32_t *m_mapBuffer          = nullptr; //!< Use for re-map recreate map buffer
     uint32_t  m_segStreamInHeight  = 0;

--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/encode_vp9_vdenc_packet.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/encode_vp9_vdenc_packet.h
@@ -579,11 +579,11 @@ protected:
     PMOS_RESOURCE m_resVdencPakObjCmdStreamOutBuffer = nullptr;  //!< Resource of Vdenc Pak object command stream out buffer
     MOS_RESOURCE  m_resPakcuLevelStreamoutData       = {0};      //!< PAK CU level Ssreamout data buffer
 
-    MOS_SURFACE m_output16X16InterModes = {0};
+    MOS_SURFACE m_output16X16InterModes = { {0} };
     // ME
-    MOS_SURFACE m_4xMeMvDataBuffer     = {0};  //!< 4x ME MV data buffer
-    MOS_SURFACE m_4xMeDistortionBuffer = {0};  //!< 4x ME distortion buffer
-    MOS_SURFACE m_16xMeMvDataBuffer    = {0};  //!< 16x ME MV data buffer
+    MOS_SURFACE m_4xMeMvDataBuffer     = { {0} };  //!< 4x ME MV data buffer
+    MOS_SURFACE m_4xMeDistortionBuffer = { {0} };  //!< 4x ME distortion buffer
+    MOS_SURFACE m_16xMeMvDataBuffer    = { {0} };  //!< 16x ME MV data buffer
 
     MOS_RESOURCE m_resVdencIntraRowStoreScratchBuffer     = {0};  //!< VDENC Intra row store scratch buffer
     MOS_RESOURCE m_resHvcTileRowStoreBuffer               = {0};  //!< HVC tile row store buffer


### PR DESCRIPTION
gcc-4.9 does not like {0}:

error: array must be initialized with a brace-enclosed initializer