### PR TITLE
[Media Common] [VP] Remove unused include fixes #1549

### DIFF
--- a/media_softlet/linux/common/vp/ddi/ddi_vp_functions.cpp
+++ b/media_softlet/linux/common/vp/ddi/ddi_vp_functions.cpp
@@ -23,7 +23,6 @@
 //! \file     ddi_vp_functions.cpp
 //! \brief    ddi vp functions implementaion.
 //!
-#include <va/va_dricommon.h>
 #include "ddi_vp_functions.h"
 #include "media_libva_util_next.h"
 #include "media_libva_common_next.h"


### PR DESCRIPTION
[Media Common] [VP] dont include va_dricommon.h on non X11 builds

<va/va_dricommon.h> is unavailable and not in non-X11 libva 2.16.0

- Fixes #1549 

tested with GBM build. 

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>