### PR TITLE
Put GFX_FEATURE_FILE override under cmake option.

### DIFF
--- a/media_driver/media_top_cmake.cmake
+++ b/media_driver/media_top_cmake.cmake
@@ -586,6 +586,12 @@ target_include_directories(${LIB_NAME}_mos_softlet BEFORE PRIVATE
     ${SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_}
     ${SOFTLET_MOS_EXT_INCLUDE_DIRS_}
 )
+
+option (ENABLE_CUSTOM_CONFIG_PATH "Enable overriding config location via GFX_FEATURE_FILE var" ON)
+if (ENABLE_CUSTOM_CONFIG_PATH)
+    target_compile_definitions(${LIB_NAME}_mos PUBLIC CUSTOM_CONFIG_PATH=1)
+    target_compile_definitions(${LIB_NAME}_mos_softlet PUBLIC CUSTOM_CONFIG_PATH=1)
+endif()
 ############## MOS LIB END ########################################
 
 ############## Media Driver Static and Shared Lib #################

--- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
+++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
@@ -259,6 +259,17 @@ static MOS_STATUS UserFeatureDumpDataToFile(const char *szFileName, MOS_PUF_KEYL
 \---------------------------------------------------------------------------*/
 static void UserFeatureFreeKeyList(MOS_PUF_KEYLIST pKeyList);
 
+#if CUSTOM_CONFIG_PATH
+/*----------------------------------------------------------------------------
+| Name      : CheckEnvVarOverrides
+| Purpose   : Before using feature / feature_next files, check env.
+| Arguments : 
+| Returns   : 
+| Comments  : Checks GFX_FEATURE_FILE and GFX_FEATURE_FILE_NEXT variables.
+\---------------------------------------------------------------------------*/
+static void CheckEnvVarOverrides();
+#endif
+
 private:
 
     /*----------------------------------------------------------------------------
@@ -403,6 +414,7 @@ private:
 
 public:
     static const char*          m_szUserFeatureFile;
+    static const char*          m_szUserFeatureFileNext;
     static MOS_PUF_KEYLIST      m_ufKeyList;
     static int32_t              m_mosTraceFd;
     static uint64_t             m_filterEnv;


### PR DESCRIPTION
This change is to make media-driver suitable for use in a snap package.
In Ubuntu, AppArmor will intercept access to `/etc/` so we should be able to use alternate locations.

For this, the `GFX_FEATURE_FILE` override can now be enabled via cmake, instead of relying on build type `_RELEASE_INTERNAL`.

In addition, a second environment variable was added: `GFX_FEATURE_FILE_NEXT` because the driver attempts to use two files in `/etc/` and we need to override both of them for usage in snap packages.
