### PR TITLE
[Media Common] SW swizzling regression fix for Gen8/9/10

### DIFF
--- a/media_driver/linux/gen10/ddi/media_sku_wa_g10.cpp
+++ b/media_driver/linux/gen10/ddi/media_sku_wa_g10.cpp
@@ -152,6 +152,8 @@ static bool InitCnlMediaSku(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_SKU(skuTable, FtrTileY, 1);
 
+    MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
+
     return true;
 }
 

--- a/media_driver/linux/gen8/ddi/media_sku_wa_g8.cpp
+++ b/media_driver/linux/gen8/ddi/media_sku_wa_g8.cpp
@@ -105,6 +105,8 @@ static bool InitBdwMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrSliceShutdownOverride, 1);
     MEDIA_WR_SKU(skuTable, FtrTileY, 1);
 
+    MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
+
     return true;
 }
 

--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -206,6 +206,8 @@ static bool InitSklMediaSku(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_SKU(skuTable, FtrTileY, 1);
 
+    MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
+
     return true;
 }
 
@@ -300,6 +302,8 @@ static bool InitBxtMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrPerCtxtPreemptionGranularityControl, 1);
 
     MEDIA_WR_SKU(skuTable, FtrVpP010Output, 1);
+
+    MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
 
     return true;
 }
@@ -432,6 +436,8 @@ static bool InitKblMediaSku(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, FtrVpP010Output, 1);
 
     MEDIA_WR_SKU(skuTable, FtrPerCtxtPreemptionGranularityControl, 1);
+
+    MEDIA_WR_SKU(skuTable, FtrUseSwSwizzling, 1);
 
     return true;
 }


### PR DESCRIPTION
Signed-off-by: Jay Yang <jay.yang@intel.com>
Fix: https://github.com/intel/media-driver/issues/1590

Add sw swizzling sku for Gen8/9/10, without which there will be perf
drop because mos_gem_bo_map_unsynchronized is called.