### PR TITLE
Disable Gen10 driver code when -DGEN10=OFF

### DIFF
--- a/media_driver/agnostic/media_srcs.cmake
+++ b/media_driver/agnostic/media_srcs.cmake
@@ -326,7 +326,7 @@ if(ENABLE_REQUIRED_GEN_CODE OR GEN9_KBL)
     media_include_subdirectory(gen9_kbl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN10)
+if(GEN10)
     media_include_subdirectory(gen10)
 endif()
 

--- a/media_driver/cmake/linux/media_gen_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_gen_flags_linux.cmake
@@ -23,7 +23,7 @@
 # Status:
 #   GEN8:  Done
 #   GEN9:  TODO
-#   GEN10: TODO (Remove)
+#   GEN10: Done (TODO: Gen10-specific code)
 #   GEN11: TODO
 #   GEN12: TODO
 option(ENABLE_REQUIRED_GEN_CODE "Make per-Gen options disable only media-kernels (not driver code) if driver code is known to be required for a successful build"

--- a/media_driver/linux/media_srcs.cmake
+++ b/media_driver/linux/media_srcs.cmake
@@ -48,11 +48,11 @@ if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CFL)
     media_include_subdirectory(gen9_cfl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN10)
+if(GEN10)
     media_include_subdirectory(gen10)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN10_CNL)
+if(GEN10_CNL)
     media_include_subdirectory(gen10_cnl)
 endif()
 

--- a/media_driver/media_interface/media_srcs.cmake
+++ b/media_driver/media_interface/media_srcs.cmake
@@ -43,7 +43,7 @@ if(ENABLE_REQUIRED_GEN_CODE OR GEN9_KBL)
     media_include_subdirectory(media_interfaces_m9_kbl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN10_CNL)
+if(GEN10_CNL)
     media_include_subdirectory(media_interfaces_m10_cnl)
 endif()
 


### PR DESCRIPTION
Allowing the driver code to be disabled for Gen10 reduces the binary size by an additional 6.6 MiB over the 4 MiB reduction when removing the media kernels alone.

````
    text     data   bss       dec      hex  filename
45485460  2374412 38736  47898608  2dadff0  iHD_drv_video.so # -DGEN10=ON
41422146  2237132 38768  43698046  29ac77e  iHD_drv_video.so # -DGEN10=OFF before this patch
34483374  2219940 38704  36742018  230a382  iHD_drv_video.so # -DGEN10=OFF after this patch
````

This change was enabled by the compile fix in commit e47460dc0363 ("Encode] Fix build issue when setting -DGEN10=OFF").

Closes: https://github.com/intel/media-driver/issues/1065