### PR TITLE
 Disable Gen9 driver code when -DGEN9=OFF

### DIFF
--- a/media_driver/agnostic/media_srcs.cmake
+++ b/media_driver/agnostic/media_srcs.cmake
@@ -298,31 +298,31 @@ if(GEN8_BDW)
     media_include_subdirectory(gen8_bdw)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9)
+if(GEN9)
     media_include_subdirectory(gen9)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CML)
+if(GEN9_CML)
     media_include_subdirectory(gen9_cml)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CMPV)
+if(GEN9_CMPV)
     media_include_subdirectory(gen9_cmpv)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_BXT)
+if(GEN9_BXT)
     media_include_subdirectory(gen9_bxt)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_SKL)
+if(GEN9_SKL)
     media_include_subdirectory(gen9_skl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_GLK)
+if(GEN9_GLK)
     media_include_subdirectory(gen9_glk)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_KBL)
+if(GEN9_KBL)
     media_include_subdirectory(gen9_kbl)
 endif()
 

--- a/media_driver/cmake/linux/media_gen_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_gen_flags_linux.cmake
@@ -22,7 +22,7 @@
 #       driver code.
 # Status:
 #   GEN8:  Done
-#   GEN9:  TODO
+#   GEN9:  Done
 #   GEN10: Done (TODO: Gen10-specific code)
 #   GEN11: TODO
 #   GEN12: TODO

--- a/media_driver/linux/media_srcs.cmake
+++ b/media_driver/linux/media_srcs.cmake
@@ -24,27 +24,27 @@ if(GEN8)
     media_include_subdirectory(gen8)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9)
+if(GEN9)
     media_include_subdirectory(gen9)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_BXT)
+if(GEN9_BXT)
     media_include_subdirectory(gen9_bxt)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_SKL)
+if(GEN9_SKL)
     media_include_subdirectory(gen9_skl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_SKL)
+if(GEN9_SKL)
     media_include_subdirectory(gen9_kbl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_GLK)
+if(GEN9_GLK)
     media_include_subdirectory(gen9_glk)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CFL)
+if(GEN9_CFL)
     media_include_subdirectory(gen9_cfl)
 endif()
 

--- a/media_driver/media_interface/media_interfaces_m8_bdw/media_interfaces_g8_bdw.h
+++ b/media_driver/media_interface/media_interfaces_m8_bdw/media_interfaces_g8_bdw.h
@@ -37,7 +37,6 @@
 #include "mhw_cp_interface.h"
 #include "mhw_mi_g8_X.h"
 #include "mhw_render_g8_X.h"
-#include "mhw_sfc_g9_X.h"
 #include "mhw_state_heap_g8.h"
 #include "mhw_vebox_g8_X.h"
 #include "mhw_vdbox_mfx_g8_bdw.h"
@@ -47,8 +46,6 @@
 #ifdef _AVC_DECODE_SUPPORTED
 #include "codechal_decode_avc.h"
 #endif
-
-#include "codechal_decode_downsampling_g9.h"
 
 #ifdef _HEVC_DECODE_SUPPORTED
 #include "codechal_decode_hevc.h"

--- a/media_driver/media_interface/media_srcs.cmake
+++ b/media_driver/media_interface/media_srcs.cmake
@@ -23,23 +23,23 @@ if(GEN8_BDW)
     media_include_subdirectory(media_interfaces_m8_bdw)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_BXT)
+if(GEN9_BXT)
     media_include_subdirectory(media_interfaces_m9_bxt)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_SKL)
+if(GEN9_SKL)
     media_include_subdirectory(media_interfaces_m9_skl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CFL)
+if(GEN9_CFL)
     media_include_subdirectory(media_interfaces_m9_cfl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_GLK)
+if(GEN9_GLK)
     media_include_subdirectory(media_interfaces_m9_glk)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN9_KBL)
+if(GEN9_KBL)
     media_include_subdirectory(media_interfaces_m9_kbl)
 endif()
 


### PR DESCRIPTION
Disable Gen9 driver code when -DGEN9=OFF

Allowing the driver code to be disabled for Gen9 reduces the
binary size by an additional 2.1 MiB over the 5.0 MiB reduction when
removing the media kernels alone.

````
    text     data   bss       dec      hex  filename
41573236  2237132 38768  43849136  29d15b0  iHD_drv_video.so # -DGEN9=ON
36324898  2237132 38768  38600798  24d005e  iHD_drv_video.so # -DGEN9=OFF before this patch
34124420  2196548 38384  36359352  22accb8  iHD_drv_video.so # -DGEN9=OFF after this patch
````