### PR TITLE
Disable Gen11 driver code when -DGEN11=OFF

### DIFF
--- a/media_driver/agnostic/media_srcs.cmake
+++ b/media_driver/agnostic/media_srcs.cmake
@@ -330,15 +330,15 @@ if(GEN10)
     media_include_subdirectory(gen10)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN11)
+if(GEN11)
     media_include_subdirectory(gen11)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN11_ICLLP)
+if(GEN11_ICLLP)
     media_include_subdirectory(gen11_icllp)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN11_JSL)
+if(GEN11_JSL)
     media_include_subdirectory(gen11_jsl_ehl)
 endif()
 

--- a/media_driver/cmake/linux/media_gen_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_gen_flags_linux.cmake
@@ -24,7 +24,7 @@
 #   GEN8:  Done
 #   GEN9:  TODO
 #   GEN10: Done (TODO: Gen10-specific code)
-#   GEN11: TODO
+#   GEN11: Done
 #   GEN12: TODO
 option(ENABLE_REQUIRED_GEN_CODE "Make per-Gen options disable only media-kernels (not driver code) if driver code is known to be required for a successful build"
     ON)

--- a/media_driver/linux/common/cm/hal/cm_command_buffer_os.cpp
+++ b/media_driver/linux/common/cm/hal/cm_command_buffer_os.cpp
@@ -34,7 +34,6 @@
 #include "cm_group_space.h"
 
 #include "mhw_render_g12_X.h"
-#include "mhw_render_g11_X.h"
 #include "mhw_mi_g12_X.h"
 
 #include "mos_solo_generic.h"

--- a/media_driver/linux/media_srcs.cmake
+++ b/media_driver/linux/media_srcs.cmake
@@ -56,7 +56,7 @@ if(GEN10_CNL)
     media_include_subdirectory(gen10_cnl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN11)
+if(GEN11)
     media_include_subdirectory(gen11)
 endif()
 

--- a/media_driver/media_interface/media_srcs.cmake
+++ b/media_driver/media_interface/media_srcs.cmake
@@ -47,11 +47,11 @@ if(GEN10_CNL)
     media_include_subdirectory(media_interfaces_m10_cnl)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN11_ICLLP)
+if(GEN11_ICLLP)
     media_include_subdirectory(media_interfaces_m11_icllp)
 endif()
 
-if(ENABLE_REQUIRED_GEN_CODE OR GEN11_JSL)
+if(GEN11_JSL)
     media_include_subdirectory(media_interfaces_m11_jsl_ehl)
 endif()
 


### PR DESCRIPTION
Disable Gen11 driver code when -DGEN11=OFF

Allowing the driver code to be disabled for Gen11 reduces the
binary size by an additional 1.0 MiB over the 3.8 MiB reduction when
removing the media kernels alone.

````
    text     data   bss       dec      hex  filename
41573236  2237132 38768  43849136  29d15b0  iHD_drv_video.so # -DGEN11=ON
38439404  1417324 38832  39895560  260c208  iHD_drv_video.so # -DGEN11=OFF before this patch
37402536  1387428 38672  38828636  2507a5c  iHD_drv_video.so # -DGEN11=OFF after this patch
````