### PR TITLE
Remove stale cmake subdirectory

### DIFF
--- a/media_softlet/linux/common/media_srcs.cmake
+++ b/media_softlet/linux/common/media_srcs.cmake
@@ -20,7 +20,6 @@
 
 media_include_subdirectory(os)
 media_include_subdirectory(cp)
-media_include_subdirectory(dec)
 media_include_subdirectory(vp)
 media_include_subdirectory(media_interfaces)
 media_include_subdirectory(shared)


### PR DESCRIPTION
I believe this was missed in commit df7b0bd796ae ("[Encode] move codechal setting create from hal to ddi")