### PR TITLE
[Encode] Fix the HEVC ICQ capability on DG2

### DIFF
--- a/media_driver/linux/Xe_M/ddi/media_libva_caps_dg2.cpp
+++ b/media_driver/linux/Xe_M/ddi/media_libva_caps_dg2.cpp
@@ -693,26 +693,17 @@ VAStatus MediaLibvaCapsDG2::CreateEncAttributes(
 
     attrib.type = VAConfigAttribRateControl;
     attrib.value = VA_RC_CQP;
-    if (entrypoint != VAEntrypointEncSliceLP ||
-            (entrypoint == VAEntrypointEncSliceLP &&
-             MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrEnableMediaKernels) &&
-             !IsHevcSccProfile(profile))) // Currently, SCC doesn't support BRC
+    if (entrypoint == VAEntrypointEncSliceLP &&
+        MEDIA_IS_SKU(&(m_mediaCtx->SkuTable), FtrEnableMediaKernels) &&
+        !IsHevcSccProfile(profile)) // Currently, SCC doesn't support BRC
     {
         attrib.value |= VA_RC_CBR | VA_RC_VBR | VA_RC_MB;
         if (IsHevcProfile(profile))
         {
-            if (entrypoint != VAEntrypointEncSliceLP)
-            {
-                attrib.value |= VA_RC_ICQ;
-            }
+            attrib.value |= VA_RC_ICQ | VA_RC_VCM | VA_RC_QVBR;
 #if VA_CHECK_VERSION(1, 10, 0)
-            else
-            {
-                attrib.value |= VA_RC_TCBRC;
-            }
+            attrib.value |= VA_RC_TCBRC;
 #endif
-
-            attrib.value |= VA_RC_VCM | VA_RC_QVBR;
         }
         if (IsVp9Profile(profile))
         {


### PR DESCRIPTION
Tested with FFmpeg `hevc_{qsv,vaapi} -global_quality 25` on DG2/A380.

Also the AV1 ICQ need extra handling since it is not implemented yet.