### PR TITLE
[Media Common] home directory using for registry first

### DIFF
--- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
+++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
@@ -46,6 +46,8 @@ class MosMutex;
 #define USER_FEATURE_KEY_EXTERNAL            "UFKEY_EXTERNAL\\"
 
 //user feature
+#define USER_FEATURE_FILE_NAME              "/igfx_user_feature_next.txt"
+
 #if ANDROID_VERSION >= 800
 #define USER_FEATURE_FILE                   "/data/igfx_user_feature.txt"
 #else


### PR DESCRIPTION
/etc is read-only for ChromeOS
so, try to read registry file from user home folder first and write to the user home folder if writing to /etc fails
this allows debugging in user mode or on systems that do not have write access to /etc