### PR TITLE
[Encode] Fix array out of bound and cause memory corruption or except…

### DIFF
--- a/media_softlet/agnostic/common/hw/vdbox/mhw_vdbox_vdenc_impl.h
+++ b/media_softlet/agnostic/common/hw/vdbox/mhw_vdbox_vdenc_impl.h
@@ -652,7 +652,7 @@ protected:
         typename cmd_t::VDENC_Reference_Picture_CMD *fwdRefs[] =
             {&cmd.FwdRef0, &cmd.FwdRef1, &cmd.FwdRef2, &cmd.BwdRef0};
         uint32_t fwdRefsDwLoaction[] =
-            {_MHW_CMD_DW_LOCATION(FwdRef0), _MHW_CMD_DW_LOCATION(FwdRef1), _MHW_CMD_DW_LOCATION(FwdRef2)};
+            {_MHW_CMD_DW_LOCATION(FwdRef0), _MHW_CMD_DW_LOCATION(FwdRef1), _MHW_CMD_DW_LOCATION(FwdRef2), _MHW_CMD_DW_LOCATION(BwdRef0)};
 
         typename cmd_t::VDENC_Down_Scaled_Reference_Picture_CMD *fwdRefsDsStage1[] =
             {&cmd.DsFwdRef0, &cmd.DsFwdRef1};


### PR DESCRIPTION
…ion issue

    [Internal]
    OSPR: Auto
    Commit_Type: Bugfix
    Platforms: MTL
    OS: Linux
    Feature impact: h265 encode
    Resolves: Jira NEXGRAPHIC-60
    Related-to: Jira NEXGRAPHIC-60
    Klocwork: N/A
    TP_Passed: N/A
    IP Scan: N/A
    Open/Embargo Dependency: N/A

Without this fix, will encounter exception when compile media code with -flto compilation option with CMAKE_CXX_FLAGS
As memory allocation will be different.