### PR TITLE
[VP9] [Encode] Fill padding to tiled format buffer directly

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
@@ -3481,39 +3481,128 @@ void CodechalVdencVp9StateG12::fill_pad_with_value(PMOS_SURFACE psSurface, uint3
         uint32_t pitch         = psSurface->dwPitch;
         uint32_t UVPlaneOffset = psSurface->UPlaneOffset.iSurfaceOffset;
         uint32_t YPlaneOffset  = psSurface->dwOffset;
+        uint32_t pad_rows = aligned_height - real_height;
+        uint32_t y_plane_size   = pitch * real_height;
+        uint32_t uv_plane_size   = pitch * real_height / 2;
 
         MOS_LOCK_PARAMS lockFlags;
         MOS_ZeroMemory(&lockFlags, sizeof(MOS_LOCK_PARAMS));
         lockFlags.WriteOnly = 1;
 
-        uint8_t *src_data   = (uint8_t *)m_osInterface->pfnLockResource(m_osInterface, &(psSurface->OsResource), &lockFlags);
-
-        if (!src_data)
+        // padding for the linear format buffer.
+        if (psSurface->OsResource.TileType == MOS_TILE_LINEAR)
         {
-            return;
+            uint8_t *src_data   = (uint8_t *)m_osInterface->pfnLockResource(m_osInterface, &(psSurface->OsResource), &lockFlags);
+
+            if (!src_data)
+                return;
+
+            uint8_t *src_data_y     = src_data + YPlaneOffset;
+            uint8_t *src_data_y_end = src_data_y + y_plane_size;
+            for (uint32_t i = 0; i < pad_rows; i++)
+            {
+                MOS_SecureMemcpy(src_data_y_end + i * pitch, pitch, src_data_y_end - pitch, pitch);
+            }
+
+            uint8_t *src_data_uv     = src_data + UVPlaneOffset;
+            uint8_t *src_data_uv_end = src_data_uv + uv_plane_size;
+            for (uint32_t i = 0; i < pad_rows / 2; i++)
+            {
+                MOS_SecureMemcpy(src_data_uv_end + i * pitch, pitch, src_data_uv_end - pitch, pitch);
+            }
+
+            m_osInterface->pfnUnlockResource(m_osInterface, &(psSurface->OsResource));
         }
-
-        uint32_t pad_rows = aligned_height - real_height;
-
-        uint8_t *src_data_y     = src_data + YPlaneOffset;
-        uint32_t y_plane_size   = pitch * real_height;
-        uint8_t *src_data_y_end = src_data_y + y_plane_size;
-        uint32_t y_pitch = pitch;
-        for (uint32_t i = 0; i < pad_rows; i++)
+        else if (psSurface->OsResource.TileType == MOS_TILE_Y)
         {
-            MOS_SecureMemcpy(src_data_y_end + i * y_pitch, y_pitch, src_data_y_end - y_pitch, y_pitch);
-        }
+            // we don't copy out the tiled buffer to linear and padding on the tiled buffer directly.
+            lockFlags.TiledAsTiled = 1;
 
-        uint8_t *src_data_uv     = src_data + UVPlaneOffset;
-        uint32_t uv_plane_size   = pitch * real_height / 2;
-        uint8_t *src_data_uv_end = src_data_uv + uv_plane_size;
-        uint32_t uv_pitch = pitch / 2;
-        for (uint32_t i = 0; i < pad_rows; i++)
-        {
-            MOS_SecureMemcpy(src_data_uv_end + i * uv_pitch, uv_pitch, src_data_uv_end - uv_pitch, uv_pitch);
-        }
+            uint8_t *src_data   = (uint8_t *)m_osInterface->pfnLockResource(m_osInterface, &(psSurface->OsResource), &lockFlags);
+            if (!src_data)
+                return;
 
-        m_osInterface->pfnUnlockResource(m_osInterface, &(psSurface->OsResource));
+            uint8_t* padding_data = (uint8_t *)MOS_AllocMemory(pitch);
+
+            int32_t LinearOffset;
+            int32_t TileOffset;
+            int32_t x;
+            int32_t y;
+
+            int32_t swizzleflags = 0; // 0 for MOS_TILE_Y
+
+            // copy out the last Y row data.
+            y = (YPlaneOffset + y_plane_size - pitch) / pitch;
+            for (x = 0, LinearOffset = 0; x < static_cast<int32_t>(pitch); x++, LinearOffset++)
+            {
+                TileOffset = Mos_SwizzleOffsetWrapper(
+                    x,
+                    y,
+                    pitch,
+                    MOS_TILE_Y,
+                    false,
+                    swizzleflags);
+                if (TileOffset < psSurface->OsResource.iSize)
+                    *(padding_data + LinearOffset) = *(src_data + TileOffset);
+            }
+
+            // padding the unaligned region for Y.
+            y = (YPlaneOffset + y_plane_size) / pitch;
+            for (uint32_t i = 0; i < pad_rows; y++, i++)
+            {
+                LinearOffset = 0;
+                for (x = 0; x < static_cast<int32_t>(pitch); x++, LinearOffset++)
+                {
+                    TileOffset = Mos_SwizzleOffsetWrapper(
+                        x,
+                        y,
+                        pitch,
+                        MOS_TILE_Y,
+                        false,
+                        swizzleflags);
+                    if (TileOffset < psSurface->OsResource.iSize)
+                        *(src_data + TileOffset) = *(padding_data + LinearOffset);
+                }
+            }
+
+            // copy out the last UV row data.
+            y = (UVPlaneOffset + uv_plane_size - pitch) / pitch;
+            for (x = 0, LinearOffset = 0; x < static_cast<int32_t>(pitch); x++, LinearOffset++)
+            {
+                TileOffset = Mos_SwizzleOffsetWrapper(
+                    x,
+                    y,
+                    pitch,
+                    MOS_TILE_Y,
+                    false,
+                    swizzleflags);
+                if (TileOffset < psSurface->OsResource.iSize)
+                    *(padding_data + LinearOffset) = *(src_data + TileOffset);
+            }
+
+            // padding the unaligned region for UV.
+            y = (UVPlaneOffset + uv_plane_size) / pitch;
+            for (uint32_t i = 0; i < pad_rows / 2; y++, i++)
+            {
+                LinearOffset = 0;
+                for (x = 0; x < static_cast<int32_t>(pitch); x++, LinearOffset++)
+                {
+                    TileOffset = Mos_SwizzleOffsetWrapper(
+                        x,
+                        y,
+                        pitch,
+                        MOS_TILE_Y,
+                        false,
+                        swizzleflags);
+                    if (TileOffset < psSurface->OsResource.iSize)
+                        *(src_data + TileOffset) = *(padding_data + LinearOffset);
+                }
+            }
+
+            MOS_FreeMemory(padding_data);
+            padding_data = nullptr;
+            m_osInterface->pfnUnlockResource(m_osInterface, &(psSurface->OsResource));
+        }
     }
 }
 

--- a/media_softlet/agnostic/common/os/mos_utilities.h
+++ b/media_softlet/agnostic/common/os/mos_utilities.h
@@ -2032,6 +2032,14 @@ public:
         int32_t       extFlags);
 #endif
 
+    static int32_t MosSwizzleOffsetWrapper(
+        int32_t         OffsetX,
+        int32_t         OffsetY,
+        int32_t         Pitch,
+        MOS_TILE_TYPE   TileFormat,
+        int32_t         CsxSwizzle,
+        int32_t         flags);
+
     //!
     //! \brief    Wrapper function for SwizzleOffset
     //! \details  Wrapper function for SwizzleOffset in Mos
@@ -3191,6 +3199,8 @@ do{                                                     \
 #define  Mos_SwizzleData(pSrc, pDst, SrcTiling, DstTiling, iHeight, iPitch, extFlags)   \
     MosUtilities::MosSwizzleData(pSrc, pDst, SrcTiling, DstTiling, iHeight, iPitch, extFlags)
 
+#define Mos_SwizzleOffsetWrapper(OffsetX, OffsetY, Pitch, TileFormat, CsxSwizzle, Flags)   \
+    MosUtilities::MosSwizzleOffsetWrapper(OffsetX, OffsetY, Pitch, TileFormat, CsxSwizzle, Flags)
 //------------------------------------------------------------------------------
 //  trace
 //------------------------------------------------------------------------------

--- a/media_softlet/agnostic/common/os/mos_utilities_next.cpp
+++ b/media_softlet/agnostic/common/os/mos_utilities_next.cpp
@@ -696,6 +696,17 @@ __inline int32_t MosUtilities::MosSwizzleOffset(
     return(SwizzledOffset);
 }
 
+int32_t MosUtilities::MosSwizzleOffsetWrapper(
+    int32_t         OffsetX,
+    int32_t         OffsetY,
+    int32_t         Pitch,
+    MOS_TILE_TYPE   TileFormat,
+    int32_t         CsxSwizzle,
+    int32_t         Flags)
+{
+    return Mos_SwizzleOffset(OffsetX, OffsetY, Pitch, TileFormat, CsxSwizzle, Flags);
+}
+
 void MosUtilities::MosSwizzleData(
     uint8_t         *pSrc,
     uint8_t         *pDst,

--- a/media_softlet/linux/common/os/mos_interface.cpp
+++ b/media_softlet/linux/common/os/mos_interface.cpp
@@ -1601,6 +1601,8 @@ MOS_STATUS MosInterface::ConvertResourceFromDdi(
         resource->iWidth   = mediaSurface->iWidth;
         resource->iHeight  = mediaSurface->iHeight;
         resource->iPitch   = mediaSurface->iPitch;
+        // Use surface bo size as resource size since we need real bounds checking when fill padding for the surface.
+        resource->iSize    = mediaSurface->bo->size;
         resource->iCount   = mediaSurface->iRefCount;
         resource->isTiled  = mediaSurface->isTiled;
         resource->TileType = LinuxToMosTileType(mediaSurface->TileType);
@@ -1655,6 +1657,7 @@ MOS_STATUS MosInterface::ConvertResourceFromDdi(
             MOS_OS_ASSERTMESSAGE("MOS: unsupported media format for surface.");
             break;
         }
+        resource->iSize    = mediaBuffer->bo->size;
         resource->iCount   = mediaBuffer->iRefCount;
         resource->isTiled  = 0;
         resource->TileType = LinuxToMosTileType(mediaBuffer->TileType);


### PR DESCRIPTION
Direct fill padding to tiled format buffer to avoid unnecessary memory copies between tiled buffer and linear buffer.