### PR TITLE
[VP] Fix tonemap vaapi extremely slow on certain input size issue on …

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -521,6 +521,8 @@ static bool InitAdlsMediaSku(struct GfxDeviceInfo *devInfo,
     }
 
     MEDIA_WR_SKU(skuTable, FtrAV1VLDLSTDecoding, 1);
+    
+    MEDIA_WR_SKU(skuTable, FtrHeight8AlignVE3DLUTDualPipe, 1);
 
     //Disable VP8 for ADLS
     MEDIA_WR_SKU(skuTable, FtrIntelVP8VLDDecoding, 0);


### PR DESCRIPTION
Fixes: https://github.com/intel/media-driver/issues/1672

Sku table did not init on Linux ADL-S, it need do 8x alignment.