### PR TITLE
Add WaDisableGmmLibOffsetInDeriveImage WA on gen8/9/10 to fix chromeOS UV shift

### DIFF
--- a/media_driver/linux/gen10/ddi/media_sku_wa_g10.cpp
+++ b/media_driver/linux/gen10/ddi/media_sku_wa_g10.cpp
@@ -186,6 +186,8 @@ static bool InitCnlMediaWa(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
     MEDIA_WR_WA(waTable, WaDisableSetObjectCapture, 0);
+
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 

--- a/media_driver/linux/gen8/ddi/media_sku_wa_g8.cpp
+++ b/media_driver/linux/gen8/ddi/media_sku_wa_g8.cpp
@@ -130,6 +130,7 @@ static bool InitBdwMediaWa(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
     MEDIA_WR_WA(waTable, WaDisableSetObjectCapture, 0);
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 

--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -237,6 +237,8 @@ static bool InitSklMediaWa(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
     MEDIA_WR_WA(waTable, WaDisableSetObjectCapture, 0);
+
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 
@@ -339,6 +341,8 @@ static bool InitBxtMediaWa(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
+
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 
@@ -473,6 +477,8 @@ static bool InitKblMediaWa(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
+
+    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 


### PR DESCRIPTION
Signed-off-by: Jay Yang <jay.yang@intel.com>