### PR TITLE
Fix tonemap vaapi on certain input size issue

### DIFF
--- a/media_driver/agnostic/gen12/vp/hal/vphal_render_vebox_g12_base.cpp
+++ b/media_driver/agnostic/gen12/vp/hal/vphal_render_vebox_g12_base.cpp
@@ -1927,6 +1927,7 @@ void VPHAL_VEBOX_STATE_G12_BASE::SetupSurfaceStates(
     pVeboxSurfaceStateCmdParams->pSurfSTMM     = &pVeboxState->STMMSurfaces[pRenderData->iCurHistIn];
     pVeboxSurfaceStateCmdParams->pSurfDNOutput = pVeboxState->FFDNSurfaces[pRenderData->iCurDNOut];
     pVeboxSurfaceStateCmdParams->bDIEnable     = bDiVarianceEnable;
+    pVeboxSurfaceStateCmdParams->b3DlutEnable  = pRenderData->bHdr3DLut;
 
 }
 

--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -522,6 +522,8 @@ static bool InitAdlsMediaSku(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_SKU(skuTable, FtrAV1VLDLSTDecoding, 1);
 
+    MEDIA_WR_SKU(skuTable, FtrHeight8AlignVE3DLUTDualPipe, 1);
+
     //Disable VP8 for ADLS
     MEDIA_WR_SKU(skuTable, FtrIntelVP8VLDDecoding, 0);
 
@@ -643,7 +645,8 @@ static bool InitAdlnMediaSku(struct GfxDeviceInfo *devInfo,
     {
         MEDIA_WR_SKU(skuTable, FtrGT0_5, 1);
     }
-
+    
+    MEDIA_WR_SKU(skuTable, FtrHeight8AlignVE3DLUTDualPipe, 1);
     MEDIA_WR_SKU(skuTable, FtrAV1VLDLSTDecoding, 1);
     MEDIA_WR_SKU(skuTable, FtrGucSubmission, 1);
     MEDIA_WR_SKU(skuTable, FtrDecodeHEVC422VTScalaDisable, 1);


### PR DESCRIPTION
Fixes: https://github.com/intel/media-driver/issues/1672

Sku table did not init on Linux ADL-S and RPL-S, and it didn't update 3dlutenable params, it need do 8x alignment.