### PR TITLE
Remove WaDisableGmmLibOffsetInDeriveImage WA for APL/GLK to fix chromeOS UV shift

### DIFF
--- a/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
+++ b/media_driver/linux/gen9/ddi/media_sku_wa_g9.cpp
@@ -342,7 +342,6 @@ static bool InitBxtMediaWa(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
 
-    MEDIA_WR_WA(waTable, WaDisableGmmLibOffsetInDeriveImage, 1);
     return true;
 }
 
@@ -586,6 +585,7 @@ static bool InitGlkMediaWa(struct GfxDeviceInfo *devInfo,
 
     MEDIA_WR_WA(waTable, Wa16KInputHeightNV12Planar420, 1);
     MEDIA_WR_WA(waTable, WaDisableCodecMmc, 1);
+
     return true;
 }
 


### PR DESCRIPTION
Signed-off-by: Jay Yang <jay.yang@intel.com>