### PR TITLE
[Media Common][VP] fix compressed surface width not align with 32 and seg fault

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -5192,7 +5192,7 @@ VAStatus SwizzleSurface(PDDI_MEDIA_CONTEXT mediaCtx, PGMM_RESOURCE_INFO pGmmResI
 
     memset(&gmmResCopyBlt, 0x0, sizeof(GMM_RES_COPY_BLT));
     uiPicHeight = pGmmResInfo->GetBaseHeight();
-    uiSize = pGmmResInfo->GetSizeSurface();
+    uiSize = pGmmResInfo->GetSizeMainSurface();
     uiPitch = pGmmResInfo->GetRenderPitch();
     gmmResCopyBlt.Gpu.pData = pLockedAddr;
     gmmResCopyBlt.Sys.pData = pResourceBase;

--- a/media_driver/linux/common/ddi/media_libva_util.cpp
+++ b/media_driver/linux/common/ddi/media_libva_util.cpp
@@ -526,11 +526,11 @@ VAStatus DdiMediaUtil_AllocateSurface(
         uint32_t uiPlanesOrAuxPlanes = mediaSurface->pSurfDesc->uiPlanes;
         if(bMemCompEnable)
         {
-            uiPlanesOrAuxPlanes = mediaSurface->pSurfDesc->uiPlanes/2;
             gmmCustomParams.AuxSurf.BaseAlignment = {0};
-            gmmCustomParams.Size = (uiPlanesOrAuxPlanes == 1) ? mediaSurface->pSurfDesc->uiOffsets[1]:mediaSurface->pSurfDesc->uiOffsets[2];
+            gmmCustomParams.NoOfPlanes = mediaSurface->pSurfDesc->uiPlanes/2;
+            gmmCustomParams.Size = (gmmCustomParams.NoOfPlanes == 1) ? mediaSurface->pSurfDesc->uiOffsets[1]:mediaSurface->pSurfDesc->uiOffsets[2];
         }
-        switch(uiPlanesOrAuxPlanes)
+        switch(gmmCustomParams.NoOfPlanes)
         {
             case 1:
                 gmmCustomParams.PlaneOffset.X[GMM_PLANE_Y] = 0;


### PR DESCRIPTION
fix compressed surface width not align with 32 and seg fault caused by wrong plane number passed to gmm


Signed-off-by: caij [jianxing.cai@intel.com](mailto:jianxing.cai@intel.com)