### PR TITLE
Fix address of ‘VPHAL_RENDER_PARAMS::pSrc’ will never be NULL

### DIFF
--- a/media_softlet/agnostic/common/vp/hal/pipeline/vp_pipeline.cpp
+++ b/media_softlet/agnostic/common/vp/hal/pipeline/vp_pipeline.cpp
@@ -1104,7 +1104,7 @@ MOS_STATUS VpPipeline::PrepareVpPipelineScalabilityParams(PVP_PIPELINE_PARAMS pa
 {
     VP_FUNC_CALL();
     VP_PUBLIC_CHK_NULL_RETURN(params);
-    if (params->pSrc == nullptr || params->pSrc[0] == nullptr)
+    if (params->pSrc[0] == nullptr)
     {
         VP_PUBLIC_NORMALMESSAGE("No input will not need scalability! ");
         return MOS_STATUS_SUCCESS;


### PR DESCRIPTION
Compile with gcc 13.1.0 produces error due to line 1107 check whether params->pSrc == nullptr. Removing the check enables compilation to complete.

Although gcc 13.1.0 could be blamed, if the error message is correct (it will never be NULL) then the check can safely be removed for all compilers.