### PR TITLE
[Media Common] Add DRM format mappings for JPEG decoder output

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -6989,8 +6989,12 @@ static uint32_t DdiMedia_GetDrmFormatOfSeparatePlane(uint32_t fourcc, int plane)
         {
         case VA_FOURCC_NV12:
         case VA_FOURCC_I420:
+        case VA_FOURCC_IMC3:
         case VA_FOURCC_YV12:
         case VA_FOURCC_YV16:
+        case VA_FOURCC_422H:
+        case VA_FOURCC_422V:
+        case VA_FOURCC_444P:
         case VA_FOURCC_Y800:
         case VA_FOURCC_RGBP:
         case VA_FOURCC_BGRP:
@@ -7063,8 +7067,12 @@ static uint32_t DdiMedia_GetDrmFormatOfSeparatePlane(uint32_t fourcc, int plane)
         case VA_FOURCC_NV12:
             return DRM_FORMAT_GR88;
         case VA_FOURCC_I420:
+        case VA_FOURCC_IMC3:
         case VA_FOURCC_YV12:
         case VA_FOURCC_YV16:
+        case VA_FOURCC_422H:
+        case VA_FOURCC_422V:
+        case VA_FOURCC_444P:
         case VA_FOURCC_RGBP:
         case VA_FOURCC_BGRP:
             return DRM_FORMAT_R8;
@@ -7078,7 +7086,6 @@ static uint32_t DdiMedia_GetDrmFormatOfSeparatePlane(uint32_t fourcc, int plane)
     }
     return 0;
 }
-
 static uint32_t DdiMedia_GetDrmFormatOfCompositeObject(uint32_t fourcc)
 {
     switch (fourcc)
@@ -7087,10 +7094,18 @@ static uint32_t DdiMedia_GetDrmFormatOfCompositeObject(uint32_t fourcc)
         return DRM_FORMAT_NV12;
     case VA_FOURCC_I420:
         return DRM_FORMAT_YUV420;
+    case VA_FOURCC_IMC3:
+        return DRM_FORMAT_YUV420;
     case VA_FOURCC_YV12:
         return DRM_FORMAT_YVU420;
     case VA_FOURCC_YV16:
         return DRM_FORMAT_YVU422;
+    case VA_FOURCC_422H:
+        return DRM_FORMAT_YUV422;
+    case VA_FOURCC_422V:
+        return DRM_FORMAT_YUV422;
+    case VA_FOURCC_444P:
+        return DRM_FORMAT_YUV444;
     case VA_FOURCC_YUY2:
         return DRM_FORMAT_YUYV;
     case VA_FOURCC_YVYU:
@@ -7101,6 +7116,10 @@ static uint32_t DdiMedia_GetDrmFormatOfCompositeObject(uint32_t fourcc)
         return DRM_FORMAT_UYVY;
     case VA_FOURCC_AYUV:
         return DRM_FORMAT_AYUV;
+#if VA_CHECK_VERSION(1, 13, 0)
+    case VA_FOURCC_XYUV:
+        return DRM_FORMAT_XYUV8888;
+#endif
     case VA_FOURCC_Y210:
         return DRM_FORMAT_Y210;
 #if VA_CHECK_VERSION(1, 9, 0)


### PR DESCRIPTION
The output formats from the JPEG decoder are currently not included
in the DRM format mapping functions. This means that any attempt to
call vaExportSurface on JPEG images will fail.

However, there is no functional gap beyond the missing mappings, so if
we add them in, exporting will then work correctly.

The four formats in question are IMC3, 422H, 422V, and 444P.

* 422H and 444P have trivial 1:1 mappings.
* IMC3 can be treated the same as I420, because the only difference is
  the chroma pitch, and that's explicitly set in the descriptor
* 422V (aka 440P) has the same memory layout as 422H - it's just a
  difference in how the consumer handle the chroma

I also added the missing XYUV composite object mapping - it was already
present for separate planes.

Tested with ffmpeg+mpv.
