### PR TITLE
[Decode] Add mutex to protect global resource in status report

### DIFF
--- a/media_softlet/agnostic/common/shared/statusreport/media_status_report.cpp
+++ b/media_softlet/agnostic/common/shared/statusreport/media_status_report.cpp
@@ -54,6 +54,7 @@ MOS_STATUS MediaStatusReport::GetReport(uint16_t requireNum, void *status)
 {
     MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
 
+    Lock();
     uint32_t completedCount = *m_completedCount;
     uint32_t reportedCount = m_reportedCount;
     uint32_t reportedCountOrigin = m_reportedCount;
@@ -85,6 +86,7 @@ MOS_STATUS MediaStatusReport::GetReport(uint16_t requireNum, void *status)
     }
 
     m_reportedCount = reportedCount;
+    UnLock();
 
     return eStatus;
 }
@@ -101,7 +103,9 @@ MOS_STATUS MediaStatusReport::RegistObserver(MediaStatusReportObserver *observer
         return MOS_STATUS_SUCCESS;
     }
 
+    Lock();
     m_completeObservers.push_back(observer);
+    UnLock();
 
     return eStatus;
 }
@@ -118,7 +122,9 @@ MOS_STATUS MediaStatusReport::UnregistObserver(MediaStatusReportObserver *observ
         return MOS_STATUS_INVALID_PARAMETER;
     }
 
+    Lock();
     m_completeObservers.erase(it);
+    UnLock();
 
     return eStatus;
 }

--- a/media_softlet/agnostic/common/shared/statusreport/media_status_report.h
+++ b/media_softlet/agnostic/common/shared/statusreport/media_status_report.h
@@ -183,6 +183,9 @@ protected:
     //!
     MOS_STATUS NotifyObservers(void *mfxStatus, void *rcsStatus, void *statusReport);
 
+    void Lock(){m_lock.lock();};
+    void UnLock(){m_lock.unlock();};
+
     inline uint32_t CounterToIndex(uint32_t counter)
     {
         return counter & (m_statusNum - 1);
@@ -198,6 +201,7 @@ protected:
 
     StatusBufAddr    *m_statusBufAddr        = nullptr;
 
+    std::recursive_mutex                      m_lock;
     std::vector<MediaStatusReportObserver *>  m_completeObservers;
 MEDIA_CLASS_DEFINE_END(MediaStatusReport)
 };


### PR DESCRIPTION
Regarding app may query status report in async mode, global resource protection is needed.