### PR TITLE
[Media Common] [VP] Fix vaGetImage 422 format V plane shift issue

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -5282,7 +5282,12 @@ static VAStatus DdiMedia_CopySurfaceToImage(
         if(image->num_planes > 2)
         {
             uint8_t *vSrc = uSrc + chromaPitch * chromaHeight;
-            uint8_t *vDst = yDst + image->offsets[2];
+
+            // there may be padding between U/V plane
+            // should use pitch * height as offset, not image->offsets[2]
+            // otherwise V plane may down shift.
+            uint8_t *vDst = uDst + imageChromaPitch * imageChromaHeight;
+
             DdiMedia_CopyPlane(vDst, image->pitches[2], vSrc, chromaPitch, imageChromaHeight);
         }
     }

--- a/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
@@ -1571,7 +1571,12 @@ VAStatus MediaLibvaInterfaceNext::CopySurfaceToImage(
         if(image->num_planes > 2)
         {
             uint8_t *vSrc = uSrc + chromaPitch * chromaHeight;
-            uint8_t *vDst = yDst + image->offsets[2];
+
+            // there may be padding between U/V plane
+            // should use pitch * height as offset, not image->offsets[2]
+            // otherwise V plane may down shift.
+            uint8_t *vDst = uDst + imageChromaPitch * imageChromaHeight;
+  
             CopyPlane(vDst, image->pitches[2], vSrc, chromaPitch, imageChromaHeight);
         }
     }


### PR DESCRIPTION
There may be padding between U/V plane. When CPU copies V plane from surface to image, should use pitch * height as offset, not image->offsets[2]. Otherwise V plane may down shift.

[Internal]
Commit_Type: Refactor
Platforms: N/A
OS: N/A
Feature impact: N/A
Resolves: VSMGWL-67480
Related-to: VSMGWL-67480
Klocwork: PASS
TP_Passed: N/A
IP Scan: PASS