### PR TITLE
[Encode] XRGB force to do swizzle for AVC/HEVC

### DIFF
--- a/media_softlet/linux/common/codec/ddi/enc/ddi_encode_avc_specific.h
+++ b/media_softlet/linux/common/codec/ddi/enc/ddi_encode_avc_specific.h
@@ -557,6 +557,7 @@ private:
     inline bool NeedDisplayFormatSwizzle(DDI_MEDIA_SURFACE *rawSurface)
     {
         if (Media_Format_A8R8G8B8 == rawSurface->format ||
+            Media_Format_X8R8G8B8 == rawSurface->format ||
             Media_Format_B10G10R10A2 == rawSurface->format)
         {
             return true;

--- a/media_softlet/linux/common/codec/ddi/enc/ddi_encode_hevc_specific.h
+++ b/media_softlet/linux/common/codec/ddi/enc/ddi_encode_hevc_specific.h
@@ -293,14 +293,16 @@ private:
         bool ret = false;
 
         if (Media_Format_A8R8G8B8 == rawSurface->format ||
-           Media_Format_B10G10R10A2 == rawSurface->format)
+            Media_Format_X8R8G8B8 == rawSurface->format ||
+            Media_Format_B10G10R10A2 == rawSurface->format)
         {
             ret = true;
         }
 
         if (ret &&
             (Media_Format_A8R8G8B8 == reconSurface->format ||
-            Media_Format_B10G10R10A2 == reconSurface->format))
+             Media_Format_X8R8G8B8 == reconSurface->format ||
+             Media_Format_B10G10R10A2 == reconSurface->format))
         {
             ret = false;
         }


### PR DESCRIPTION
This is to fix msdkh264enc/msdkh265enc incorrect encoded output when having BGRx input.  