### PR TITLE
[Media Common] Add non-free build info inside the vendor string

### DIFF
--- a/media_driver/cmake/linux/media_feature_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_feature_flags_linux.cmake
@@ -180,6 +180,9 @@ endif()
 
 if(NOT ENABLE_NONFREE_KERNELS)
     add_definitions(-D_FULL_OPEN_SOURCE)
+    add_definitions(-DBUILD_DETAILS="")
+else()
+    add_definitions(-DBUILD_DETAILS="non-free")
 endif()
 
 if(ENABLE_NEW_KMD AND NOT ENABLE_PRODUCTION_KMD)

--- a/media_driver/linux/common/ddi/media_libva.h
+++ b/media_driver/linux/common/ddi/media_libva.h
@@ -70,7 +70,7 @@
 #endif
 #define DDI_CODEC_GEN_MAX_ATTRIBS_TYPE             4    //VAConfigAttribRTFormat,    VAConfigAttribRateControl,    VAConfigAttribDecSliceMode,    VAConfigAttribEncPackedHeaders
 
-#define DDI_CODEC_GEN_STR_VENDOR                   "Intel iHD driver for Intel(R) Gen Graphics - " MEDIA_VERSION " (" MEDIA_VERSION_DETAILS ")"
+#define DDI_CODEC_GEN_STR_VENDOR                   "Intel iHD driver for Intel(R) Gen Graphics - " MEDIA_VERSION " (" MEDIA_VERSION_DETAILS BUILD_DETAILS ")"
 
 #define DDI_CODEC_GET_VTABLE(ctx)                  (ctx->vtable)
 #define DDI_CODEC_GET_VTABLE_VPP(ctx)              (ctx->vtable_vpp)


### PR DESCRIPTION
The behavior of the driver is very different if is built with the closed source pre-built binary shaders. Adding this info in the vendor string is very useful for debugging. Also, it take advantage of the empty parentheses that release build contains.