### PR TITLE
Add FORCE_DISABLE_MTL_MEDIA_CCS env variable

### DIFF
--- a/media_softlet/linux/Xe_M_plus/ddi/media_sku_wa_mtl.cpp
+++ b/media_softlet/linux/Xe_M_plus/ddi/media_sku_wa_mtl.cpp
@@ -178,6 +178,16 @@ static bool InitMtlMediaSkuExt(struct GfxDeviceInfo *devInfo,
     MEDIA_WR_SKU(skuTable, Ftr10bitDecMemoryCompression, 0);
 
     MEDIA_WR_SKU(skuTable, FtrCCSNode, 1);
+    // get user CCS value from environment variable
+    char *CCS_Env = getenv("FORCE_DISABLE_INTEL_MEDIA_MTL_CCS");
+    if (CCS_Env != nullptr)
+    {
+       uint8_t user_ccs_env_value = (uint8_t)atoi(CCS_Env);
+       if (user_ccs_env_value == 1)
+        {
+           MEDIA_WR_SKU(skuTable, FtrCCSNode, 0);
+       }
+    }
 
     MEDIA_WR_SKU(skuTable, FtrVpP010Output, 1);
     MEDIA_WR_SKU(skuTable, FtrVp10BitSupport, 1);


### PR DESCRIPTION
Default media driver is enable Media CCS, would
like to add new FORCE_DISABLE_MTL_MEDIA_CCS in environment variable to disable Media CCS.
This is allow user choose to disable MTL Media CCS if needed.