### PR TITLE
[Decode] Optimize error syntax check for hevc

### DIFF
--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/features/decode_hevc_basic_feature.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/features/decode_hevc_basic_feature.cpp
@@ -387,6 +387,11 @@ MOS_STATUS HevcBasicFeature::NumEntryPointOffsetsCheck(uint32_t sliceIdx)
     return MOS_STATUS_SUCCESS;
 }
 
+/**
+ * This is potential issue that may cause output corruption with incorrect referece;
+ * And it has error concealment in hcp ref idx state setting by ignoring invalid reference.
+ * We should avoid stopping playback by giving an error return here.
+*/
 MOS_STATUS HevcBasicFeature::ReferenceParamCheck(uint32_t sliceIdx)
 {
     DECODE_FUNC_CALL();
@@ -397,14 +402,14 @@ MOS_STATUS HevcBasicFeature::ReferenceParamCheck(uint32_t sliceIdx)
         if (m_hevcSliceParams[sliceIdx].num_ref_idx_l0_active_minus1 >= CODEC_MAX_NUM_REF_FRAME_HEVC )
         {
             DECODE_ASSERTMESSAGE("num_ref_idx_l0_active_minus1 %d is out of range [0, 14]\n", m_hevcSliceParams[sliceIdx].num_ref_idx_l0_active_minus1);
-            return MOS_STATUS_INVALID_PARAMETER;
+            m_hevcSliceParams[sliceIdx].num_ref_idx_l0_active_minus1 = 0;
         }
         if (decodeHevcBSlice == m_hevcSliceParams[sliceIdx].LongSliceFlags.fields.slice_type)
         {
             if (m_hevcSliceParams[sliceIdx].num_ref_idx_l1_active_minus1 >= CODEC_MAX_NUM_REF_FRAME_HEVC)
             {
                 DECODE_ASSERTMESSAGE("num_ref_idx_l1_active_minus1 %d is out of range [0, 14]\n", m_hevcSliceParams[sliceIdx].num_ref_idx_l1_active_minus1);
-                return MOS_STATUS_INVALID_PARAMETER;
+                m_hevcSliceParams[sliceIdx].num_ref_idx_l1_active_minus1 = 0;
             }
         }
     }
@@ -447,7 +452,6 @@ MOS_STATUS HevcBasicFeature::ReferenceParamCheck(uint32_t sliceIdx)
         {
             DECODE_ASSERTMESSAGE("num_ref_idx_active_minus1[%d] = %d, RefPicList[%d].FrameIdx is all 127\n",
                                  listIdx, num_ref_idx_active_minus1[listIdx], listIdx);
-            return MOS_STATUS_INVALID_PARAMETER;
         }
     }
     return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/features/decode_hevc_reference_frames.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/features/decode_hevc_reference_frames.cpp
@@ -301,7 +301,13 @@ MOS_STATUS HevcReferenceFrames::UpdateCurRefList(const CODEC_HEVC_PIC_PARAMS & p
 
             if ((refCurrIndex == picParams.CurrPic.FrameIdx) || (refBeforeIndex == picParams.CurrPic.FrameIdx) || (refAfterIndex == picParams.CurrPic.FrameIdx))
             {
-                return MOS_STATUS_INVALID_PARAMETER;
+                DECODE_ASSERTMESSAGE("Invalid refFrame index: refCurrIndex: %d, refBeforeIndex: %d, refAfterIndex: %d, currPic frameInx: %d\n",
+                           refCurrIndex, refBeforeIndex, refAfterIndex, picParams.CurrPic.FrameIdx);
+
+                /**
+                 *This is potential issue that may cause output curruption by refering to destsurface; But should avoid stopping playback by giving an error return here.
+                //return MOS_STATUS_INVALID_PARAMETER;
+                 */
             }
         }
     }


### PR DESCRIPTION
Media driver should avoid stopping playback by giving an ambiguous error since invalid reference will not cause gpu hang.

But application should take care of the assert message indicating to error syntax which may cause output corruption.