### PR TITLE
[Decode] Allocate the slice record buffer dynamically for each frame

### DIFF
--- a/media_driver/agnostic/common/codec/hal/codechal_decode_vc1.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_vc1.h
@@ -742,6 +742,7 @@ protected:
     MOS_RESOURCE                   m_resMfdDeblockingFilterRowStoreScratchBuffer;        //!< Handle of MFD Deblocking Filter Row Store Scratch data surface
     MOS_RESOURCE                   m_resBsdMpcRowStoreScratchBuffer;                     //!< Handle of BSD/MPC Row Store Scratch data surface
     MOS_RESOURCE                   m_resVc1BsdMvData[CODECHAL_DECODE_VC1_DMV_MAX];       //!< Handle of VC1 BSD MV Data
+    uint32_t                       m_numVldSliceRecord = 0;
     PCODECHAL_VC1_VLD_SLICE_RECORD m_vldSliceRecord = nullptr;                           //!< [VLD mode] Slice record
     PCODEC_REF_LIST                m_vc1RefList[CODECHAL_NUM_UNCOMPRESSED_SURFACE_VC1];  //!< VC1 Reference List
     MOS_RESOURCE                   m_resSyncObject;                                      //!< Handle of Sync Object

--- a/media_softlet/agnostic/common/os/mos_utilities_next.cpp
+++ b/media_softlet/agnostic/common/os/mos_utilities_next.cpp
@@ -404,6 +404,10 @@ void MosUtilities::MosFreeMemory(void  *ptr)
             MT_MEMORY_PTR, (int64_t)(ptr), 
             functionName, filename, line); 
         free(ptr);
+        /**
+         * Note: this is bug, ptr from outside will never be set to nullptr here;
+         * So, it must set the ptr to nullptr in caller function to avoid foating pointer.
+         */
         ptr = nullptr;
     }
 }


### PR DESCRIPTION
It should align the size of slice record buffer and number of slice to avoid memory access out of bound.