### PR TITLE
[Decode] Add xe drm init entry

### DIFF
--- a/media_softlet/linux/common/os/i915/mos_bufmgr.c
+++ b/media_softlet/linux/common/os/i915/mos_bufmgr.c
@@ -60,6 +60,9 @@
 #include "libdrm_lists.h"
 #include "mos_bufmgr.h"
 #include "mos_bufmgr_priv.h"
+#ifdef ENABLE_NEW_KMD
+#include "mos_bufmgr_xe.h"
+#endif
 #include "string.h"
 
 #include "i915_drm.h"
@@ -5381,6 +5384,12 @@ mos_bufmgr_gem_init(int fd, int batch_size, int *device_type)
     {
         return mos_bufmgr_gem_init_i915(fd, batch_size);
     }
+#ifdef ENABLE_NEW_KMD
+    else if (DEVICE_TYPE_XE == type)
+    {
+        return mos_bufmgr_gem_init_xe(fd, batch_size);
+    }
+#endif
 
     return nullptr;
 }
@@ -5508,6 +5517,11 @@ int mos_get_device_id(int fd, uint32_t *deviceId)
     {
         return mos_get_dev_id_i915(fd, deviceId);
     }
-
+#ifdef ENABLE_NEW_KMD
+    else if (DEVICE_TYPE_XE == device_type)
+    {
+        return mos_get_dev_id_xe(fd, deviceId);
+    }
+#endif
     return -ENODEV;
 }


### PR DESCRIPTION
Query the drm device firstly and init specific drm implement dynamically

Note: this is still need to add build option '-DENABLE_NEW_KMD=ON' to enable xe drm.

Signed-off-by: Xu, Zhengguo <zhengguo.xu@intel.com>