### PR TITLE
Add CI builds that disable MTL and ARL support

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -666,6 +666,71 @@ jobs:
         make VERBOSE=1 -j$(nproc)
         sudo make install
 
+  gcc-10-mtl-off:
+    runs-on: ubuntu-20.04
+    env:
+      CC: /usr/bin/gcc-10
+      CXX: /usr/bin/g++-10
+      ASM: /usr/bin/gcc-10
+    steps:
+    - name: checkout media-driver
+      uses: actions/checkout@v2
+      with:
+        path: media
+    - name: checkout libva
+      uses: actions/checkout@v2
+      with:
+        repository: intel/libva
+        path: libva
+    - name: checkout gmmlib
+      uses: actions/checkout@v2
+      with:
+        repository: intel/gmmlib
+        path: gmmlib
+    - name: install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake \
+          libdrm-dev \
+          libx11-dev \
+          libx11-xcb-dev \
+          libxcb-dri3-dev \
+          libxext-dev \
+          libxfixes-dev \
+          libwayland-dev \
+          make
+    - name: print tools versions
+      run: |
+        cmake --version
+        $CC --version
+        $CXX --version
+    - name: build libva
+      run: |
+        cd libva
+        ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+        make -j$(nproc)
+        sudo make install
+    - name: build gmmlib
+      run: |
+        cd gmmlib
+        mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib/x86_64-linux-gnu ..
+        make VERBOSE=1 -j$(nproc)
+        sudo make install
+    - name: build media-driver
+      run: |
+        cd media
+        mkdir build && cd build
+        cmake -DMTL=OFF \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_LIBDIR=/usr/lib/x86_64-linux-gnu \
+          -DCMAKE_C_FLAGS_RELEASE="$_CFLAGS" \
+          -DCMAKE_CXX_FLAGS_RELEASE="$_CFLAGS" \
+          ..
+        make VERBOSE=1 -j$(nproc)
+        sudo make install
+
   gcc-10-AVC-HEVC-exclude:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -731,6 +731,71 @@ jobs:
         make VERBOSE=1 -j$(nproc)
         sudo make install
 
+  gcc-10-arl-off:
+    runs-on: ubuntu-20.04
+    env:
+      CC: /usr/bin/gcc-10
+      CXX: /usr/bin/g++-10
+      ASM: /usr/bin/gcc-10
+    steps:
+    - name: checkout media-driver
+      uses: actions/checkout@v2
+      with:
+        path: media
+    - name: checkout libva
+      uses: actions/checkout@v2
+      with:
+        repository: intel/libva
+        path: libva
+    - name: checkout gmmlib
+      uses: actions/checkout@v2
+      with:
+        repository: intel/gmmlib
+        path: gmmlib
+    - name: install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake \
+          libdrm-dev \
+          libx11-dev \
+          libx11-xcb-dev \
+          libxcb-dri3-dev \
+          libxext-dev \
+          libxfixes-dev \
+          libwayland-dev \
+          make
+    - name: print tools versions
+      run: |
+        cmake --version
+        $CC --version
+        $CXX --version
+    - name: build libva
+      run: |
+        cd libva
+        ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+        make -j$(nproc)
+        sudo make install
+    - name: build gmmlib
+      run: |
+        cd gmmlib
+        mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib/x86_64-linux-gnu ..
+        make VERBOSE=1 -j$(nproc)
+        sudo make install
+    - name: build media-driver
+      run: |
+        cd media
+        mkdir build && cd build
+        cmake -DARL=OFF \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_LIBDIR=/usr/lib/x86_64-linux-gnu \
+          -DCMAKE_C_FLAGS_RELEASE="$_CFLAGS" \
+          -DCMAKE_CXX_FLAGS_RELEASE="$_CFLAGS" \
+          ..
+        make VERBOSE=1 -j$(nproc)
+        sudo make install
+
   gcc-10-AVC-HEVC-exclude:
     runs-on: ubuntu-20.04
     env:

--- a/media_driver/cmake/linux/media_gen_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_gen_flags_linux.cmake
@@ -113,14 +113,16 @@ cmake_dependent_option(PVC
 
 option(MTL "Enable MTL support" ON)
 
-option(ARL "Enable ARL support" ON)
+cmake_dependent_option(ARL
+    "Enable ARL support" ON
+    "MTL" OFF)
 
-if(MTL OR ARL)
+if(MTL)
     option(XE_LPM_PLUS_SUPPORT "Enable XE_LPM_PLUS support" ON)
     option(XE_LPG "Enable XE_LPG support" ON)
 endif()
 
-if(MTL OR ARL)
+if(MTL)
     option(Xe_M_plus "Enable Xe_M_plus support" ON)
 endif()
 


### PR DESCRIPTION
Cc: @XinfengZhang, @Sherry-Lin

I expect the MTL-disabled build to fail with:

```
  In file included from /root/projects/intel/media-driver/media_softlet/media_interface/media_interfaces_arl/media_interfaces_arl.cpp:30:    
  /root/projects/intel/media-driver/media_softlet/media_interface/media_interfaces_arl/media_interfaces_arl.h:32:10: fatal error: 'media_interfaces_mtl.h' file not found    
  #include "media_interfaces_mtl.h"    
          ¦^~~~~~~~~~~~~~~~~~~~~~~~    
  1 error generated.    
```

