### PR TITLE
media_libva_decoder: don't return early

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -422,11 +422,6 @@ VAStatus DdiDecode_StatusReport(PDDI_MEDIA_CONTEXT mediaCtx, CodechalDecode *dec
                             break;
                         }
                     }
-
-                    if (j == mediaCtx->pSurfaceHeap->uiAllocatedHeapElements)
-                    {
-                        return VA_STATUS_ERROR_OPERATION_FAILED;
-                    }
                 }
                 else
                 {
@@ -506,11 +501,6 @@ VAStatus DdiDecode_StatusReport(PDDI_MEDIA_CONTEXT mediaCtx, DecodePipelineAdapt
                             mediaSurfaceHeapElmt->pSurface->curStatusReportQueryState = DDI_MEDIA_STATUS_REPORT_QUERY_STATE_COMPLETED;
                             break;
                         }
-                    }
-
-                    if (j == mediaCtx->pSurfaceHeap->uiAllocatedHeapElements)
-                    {
-                        return VA_STATUS_ERROR_OPERATION_FAILED;
                     }
                 }
                 else


### PR DESCRIPTION
It is possible a BO in the completed report list has been destroyed from user app.