### PR TITLE
[Encode] Fix BGRx AVC/HEVC Enc for g12

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_g12.cpp
@@ -96,6 +96,7 @@ MOS_STATUS CodechalEncodeCscDsG12::CheckRawColorFormat(MOS_FORMAT format, MOS_TI
         m_cscRequireConvTo8bPlanar = (uint8_t)HCP_CHROMA_FORMAT_YUV422 == m_outputChromaFormat;
         break;
     case Format_A8R8G8B8:
+    case Format_X8R8G8B8:
         m_colorRawSurface = cscColorARGB;
         m_cscUsingSfc = IsSfcEnabled() ? 1 : 0;
         m_cscRequireColor = 1;

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_avc.h
@@ -527,6 +527,7 @@ private:
     inline bool NeedDisplayFormatSwizzle(DDI_MEDIA_SURFACE *rawSurface)
     {
         if (Media_Format_A8R8G8B8 == rawSurface->format ||
+            Media_Format_X8R8G8B8 == rawSurface->format ||
             Media_Format_B10G10R10A2 == rawSurface->format)
         {
             return true;

--- a/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.h
+++ b/media_driver/linux/common/codec/ddi/media_ddi_encode_hevc.h
@@ -293,6 +293,7 @@ private:
         bool ret = false;
 
         if (Media_Format_A8R8G8B8 == rawSurface->format ||
+           Media_Format_X8R8G8B8 == rawSurface->format  ||
            Media_Format_B10G10R10A2 == rawSurface->format)
         {
             ret = true;
@@ -300,6 +301,7 @@ private:
 
         if (ret && 
             (Media_Format_A8R8G8B8 == reconSurface->format ||
+            Media_Format_X8R8G8B8 == reconSurface->format ||
             Media_Format_B10G10R10A2 == reconSurface->format))
         {
             ret = false;


### PR DESCRIPTION
The patch is to fix BGRx AVC/HEVC enc on ADL with gstVPL. 

reproducer cmd: 
1. gst-launch-1.0 ximagesrc -v use-damage=0 num-buffers=120 startx=0 starty=0 endx=800 endy=600 ! video/x-raw,framerate=30/1 ! msdkh265enc rate-control=cqp ! video/x-h265,profile=screen-extended-main ! filesink location=yocto-ximagesrc-adl.h265
2. gst-launch-1.0 ximagesrc -v use-damage=0 num-buffers=120 startx=0 starty=0 endx=800 endy=600 ! video/x-raw,framerate=30/1 ! msdkh264enc rate-control=cqp ! video/x-h264,profile=baseline ! filesink location=yocto-ximagesrc-adl.h264
3.	gst-launch-1.0 filesrc location=BGRX_1080.yuv ! videoparse width=1920 height=1080 format=bgrx ! msdkh264enc ! filesink location=test.h264
4.	gst-launch-1.0 filesrc location=BGRX_1080.yuv ! videoparse width=1920 height=1080 format=bgrx ! msdkh265enc ! filesink location=test.h265