### PR TITLE
Remove RGB support in VP9 profile

### DIFF
--- a/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/capstable_data_vp9_encode_xe_lpm_plus_r0_specific.h
+++ b/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/capstable_data_vp9_encode_xe_lpm_plus_r0_specific.h
@@ -236,8 +236,6 @@ static ProfileSurfaceAttribInfo surfaceAttribInfo_VAProfileVP9Profile2_VAEntrypo
 static ProfileSurfaceAttribInfo surfaceAttribInfo_VAProfileVP9Profile3_VAEntrypointEncSlice_Xe_Lpm_plus_r0 =
 { 
   {VASurfaceAttribPixelFormat, VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE, {VAGenericValueTypeInteger, {VA_FOURCC_Y410}}}, 
-  {VASurfaceAttribPixelFormat, VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE, {VAGenericValueTypeInteger, {VA_FOURCC_ARGB}}}, 
-  {VASurfaceAttribPixelFormat, VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE, {VAGenericValueTypeInteger, {VA_FOURCC_ABGR}}}, 
   {VASurfaceAttribMaxWidth, VA_SURFACE_ATTRIB_GETTABLE, {VAGenericValueTypeInteger, {8192}}}, 
   {VASurfaceAttribMaxHeight, VA_SURFACE_ATTRIB_GETTABLE, {VAGenericValueTypeInteger, {8192}}}, 
   {VASurfaceAttribMinWidth, VA_SURFACE_ATTRIB_GETTABLE, {VAGenericValueTypeInteger, {128}}}, 


### PR DESCRIPTION
Since RGB is not supported yet, media driver should not display this capability to the framework. 

Running gst-inspect-1.0 vavp9enc
### Results before
video/x-raw(memory:VAMemory)
                  width: [ 128, 8192 ]
                 height: [ 96, 8192 ]
                 format: { (string)NV12, (string)VUYA, (string)P010_10LE, (string)Y410, **(string)ARGB, (string)ABGR** }
      video/x-raw(memory:DMABuf)
                  width: [ 128, 8192 ]
                 height: [ 96, 8192 ]
                 format: DMA_DRM
             drm-format: { (string)NV12:0x0100000000000009, (string)AYUV:0x0100000000000009, (string)P010:0x0100000000000009, (string)Y410:0x0100000000000009, **(string)AR24:0x0100000000000009, (string)AB24:0x0100000000000009** }
      video/x-raw
                  width: [ 128, 8192 ]
                 height: [ 96, 8192 ]
                 format: { (string)NV12, (string)VUYA, (string)P010_10LE, (string)Y410, **(string)ARGB, (string)ABGR** }

### Results after
Capabilities:
      video/x-raw(memory:VAMemory)
                  width: [ 128, 8192 ]
                 height: [ 96, 8192 ]
                 format: { (string)NV12, (string)VUYA, (string)P010_10LE, (string)Y410 }
      video/x-raw(memory:DMABuf)
                  width: [ 128, 8192 ]
                 height: [ 96, 8192 ]
                 format: DMA_DRM
             drm-format: { (string)NV12:0x0100000000000009, (string)AYUV:0x0100000000000009, (string)P010:0x0100000000000009, (string)Y410:0x0100000000000009 }
      video/x-raw
                  width: [ 128, 8192 ]
                 height: [ 96, 8192 ]
                 format: { (string)NV12, (string)VUYA, (string)P010_10LE, (string)Y410 }
