### PR TITLE
Expose va-attrib to configure scanout flag

### DIFF
--- a/media_softlet/linux/common/ddi/media_libva_util_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
@@ -849,6 +849,9 @@ VAStatus MediaLibvaUtilNext::CreateInternalSurface(
         alloc.ext.mem_type = params.memType;
         alloc.ext.pat_index = patIndex;
         alloc.ext.cpu_cacheable = isCpuCacheable;
+        if (VA_SURFACE_ATTRIB_USAGE_HINT_SCANOUT & mediaSurface->surfaceUsageHint)
+            alloc.ext.use_scanout = true;
+
         bo = mos_bo_alloc(mediaDrvCtx->pDrmBufMgr, &alloc);
         params.pitch = gmmPitch;
     }
@@ -863,6 +866,8 @@ VAStatus MediaLibvaUtilNext::CreateInternalSurface(
         alloc_tiled.ext.mem_type = params.memType;;
         alloc_tiled.ext.pat_index = patIndex;
         alloc_tiled.ext.cpu_cacheable = isCpuCacheable;
+        if (VA_SURFACE_ATTRIB_USAGE_HINT_SCANOUT & mediaSurface->surfaceUsageHint)
+            alloc_tiled.ext.use_scanout = true;
 
         bo = mos_bo_alloc_tiled(mediaDrvCtx->pDrmBufMgr, &alloc_tiled);
         params.pitch = alloc_tiled.pitch;

--- a/media_softlet/linux/common/os/i915/include/mos_bufmgr_api.h
+++ b/media_softlet/linux/common/os/i915/include/mos_bufmgr_api.h
@@ -211,6 +211,7 @@ struct mos_drm_bo_alloc_ext{
     int mem_type = 0;
     uint16_t pat_index = PAT_INDEX_INVALID;
     bool     cpu_cacheable = true;
+    bool     use_scanout = false;
 };
 
 struct mos_drm_bo_alloc {

--- a/media_softlet/linux/common/os/xe/mos_bufmgr_xe.c
+++ b/media_softlet/linux/common/os/xe/mos_bufmgr_xe.c
@@ -1295,6 +1295,9 @@ mos_bo_alloc_xe(struct mos_bufmgr *bufmgr,
      */
     create.cpu_caching = alloc->ext.cpu_cacheable ? DRM_XE_GEM_CPU_CACHING_WB : DRM_XE_GEM_CPU_CACHING_WC;
 
+    if (alloc->ext.use_scanout)
+        create.flags |= DRM_XE_GEM_CREATE_FLAG_SCANOUT;
+
     ret = drmIoctl(bufmgr_gem->fd,
         DRM_IOCTL_XE_GEM_CREATE,
         &create);


### PR DESCRIPTION
This can be used to tell the driver set scanout surface. XE DMA DRM render case required this.
The MR has dependencies to libVA header: https://github.com/intel/libva/pull/820 
