### PR TITLE
[Media Common] Set Scanout by default

### DIFF
--- a/media_softlet/linux/common/os/xe/mos_bufmgr_xe.c
+++ b/media_softlet/linux/common/os/xe/mos_bufmgr_xe.c
@@ -1295,6 +1295,10 @@ mos_bo_alloc_xe(struct mos_bufmgr *bufmgr,
      */
     create.cpu_caching = alloc->ext.cpu_cacheable ? DRM_XE_GEM_CPU_CACHING_WB : DRM_XE_GEM_CPU_CACHING_WC;
 
+    if ((strcmp(alloc->name, "MEDIA") == 0 || strcmp(alloc->name, "Media") == 0)
+        && create.cpu_caching == DRM_XE_GEM_CPU_CACHING_WC)
+            create.flags |= DRM_XE_GEM_CREATE_FLAG_SCANOUT;
+
     ret = drmIoctl(bufmgr_gem->fd,
         DRM_IOCTL_XE_GEM_CREATE,
         &create);


### PR DESCRIPTION
recommend flagging all potential scanout surfaces as SCANOUT 