### PR TITLE
Fix failed 4k videowalll test case in Gen12 platform

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_render_composite.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_composite.cpp
@@ -6784,6 +6784,13 @@ bool CompositeState::BuildFilter(
 
     for (i = 0; (i < (int)pCompParams->uSourceCount) && (iMaxFilterSize > 0); i++)
     {
+        if (i > 0)
+        {
+            if (!RECT1_CONTAINS_RECT2(pCompParams->pSource[0]->rcDst, pCompParams->pSource[i]->rcDst))
+            {
+                pFilter->forceToTargetColorSpace = true;
+            }
+        }
         pSrc = pCompParams->pSource[i];
 
         //--------------------------------

--- a/media_driver/linux/common/vp/ddi/media_libva_vp.c
+++ b/media_driver/linux/common/vp/ddi/media_libva_vp.c
@@ -1148,7 +1148,7 @@ DdiVp_SetProcPipelineParams(
 
     // Background Colorfill
     // According to libva  definition, if alpha in output background color is zero, then colorfill is not needed
-    if ((pPipelineParam->output_background_color >> 24) != 0 || pVpHalTgtSurf->ColorSpace == CSpace_sRGB)
+    if ((pPipelineParam->output_background_color >> 24) != 0)
     {
         if (pVpHalRenderParams->pColorFillParams == nullptr)
         {
@@ -1157,18 +1157,10 @@ DdiVp_SetProcPipelineParams(
 
         DDI_CHK_NULL(pVpHalRenderParams->pColorFillParams, "Null pColorFillParams.", VA_STATUS_ERROR_UNKNOWN);
 
-        if (pVpHalTgtSurf->ColorSpace == CSpace_sRGB && (pPipelineParam->output_background_color >> 24) == 0)
-        {
-            // set color space for sRGB output
-            pVpHalRenderParams->pColorFillParams->CSpace    = CSpace_sRGB;
-        }
-        else
-        {
-            // set background colorfill option
-            pVpHalRenderParams->pColorFillParams->Color     = pPipelineParam->output_background_color;
-            pVpHalRenderParams->pColorFillParams->bYCbCr    = false;
-            pVpHalRenderParams->pColorFillParams->CSpace    = CSpace_sRGB;
-        }
+        // set background colorfill option
+        pVpHalRenderParams->pColorFillParams->Color     = pPipelineParam->output_background_color;
+        pVpHalRenderParams->pColorFillParams->bYCbCr    = false;
+        pVpHalRenderParams->pColorFillParams->CSpace    = CSpace_sRGB;
     }else
     {
         MOS_FreeMemAndSetNull(pVpHalRenderParams->pColorFillParams);


### PR DESCRIPTION
Fix failed 4k video wall test case from 16CH video only show 1CH output in RPL-P platform. This issue has been fixed in MTL platform before.

platform: TGL/ADL/RPL

Code Fixed: https://github.com/intel/media-driver/issues/1838