### PR TITLE
[VP] Port segfault fix from media_libva to media_libva_next

### DIFF
--- a/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
@@ -1824,7 +1824,16 @@ VAStatus MediaLibvaInterfaceNext::PutImage(
         }
 
         //Copy data from image to temp surferce
-        MOS_STATUS eStatus = MOS_SecureMemcpy(tempSurfData, vaimg->data_size, imageData, vaimg->data_size);
+        MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
+        if (tempMediaSurface->data_size >= vaimg->data_size)
+        {
+            eStatus = MOS_SecureMemcpy(tempSurfData, tempMediaSurface->data_size, imageData, vaimg->data_size);
+        }
+        else
+        {
+            eStatus = MOS_SecureMemcpy(tempSurfData, tempMediaSurface->data_size, imageData, tempMediaSurface->data_size);
+        }
+
         if (eStatus != MOS_STATUS_SUCCESS)
         {
             DDI_ASSERTMESSAGE("Failed to copy image to surface buffer.");


### PR DESCRIPTION
This applies the same fix in commit 722793d2eb507755affcacb151189e1bd052ce4c to media_libva_interface_next.cpp.

Should close #1859.

Tested locally under mpv and seems to work.