### PR TITLE
[Decode] Do not report AV1d support in free kernel build on TGLx and DG2

### DIFF
--- a/media_driver/linux/Xe_M/ddi/media_sku_wa_xe.cpp
+++ b/media_driver/linux/Xe_M/ddi/media_sku_wa_xe.cpp
@@ -71,8 +71,8 @@ static struct LinuxCodecInfo XehpSdvCodecInfo =
     .vp8Encoding    = 0,
     .hevcVdenc      = 0,
     .vp9Vdenc       = 0,
-    .adv0Decoding   = 1,
-    .adv1Decoding   = 1,
+    .adv0Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
+    .adv1Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
 };
 
 static struct LinuxCodecInfo Dg2CodecInfo =
@@ -96,8 +96,8 @@ static struct LinuxCodecInfo Dg2CodecInfo =
     .vp8Encoding    = 0,
     .hevcVdenc      = 1,
     .vp9Vdenc       = 1,
-    .adv0Decoding   = 1,
-    .adv1Decoding   = 1,
+    .adv0Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
+    .adv1Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
 };
 
 static struct LinuxCodecInfo PvcCodecInfo =
@@ -131,8 +131,8 @@ static struct LinuxCodecInfo PvcCodecInfo =
     .hevcVdenc      = 0,
     .vp9Vdenc       = 0,
 #endif
-    .adv0Decoding   = 1,
-    .adv1Decoding   = 1,
+    .adv0Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
+    .adv1Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
 };
 
 static bool InitTglMediaSkuExt(struct GfxDeviceInfo *devInfo,

--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -59,8 +59,8 @@ static struct LinuxCodecInfo tglCodecInfo =
     .vp8Encoding    = 0,
     .hevcVdenc      = 1,
     .vp9Vdenc       = 1,
-    .adv0Decoding   = 1,
-    .adv1Decoding   = 1,
+    .adv0Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
+    .adv1Decoding   = SET_STATUS_BY_FULL_OPEN_SOURCE(1, 0),
 };
 
 static bool InitTglMediaSku(struct GfxDeviceInfo *devInfo,


### PR DESCRIPTION
> Av1 decode needs filmgrain kernel support, and free kernel build will not support av1 decode.

This [has been fixed in the docs](https://github.com/intel/media-driver/pull/1853) and needs to be fixed in libva's capabilities as well.

Fixes:

https://github.com/intel/media-driver/pull/1853#issuecomment-2385982039
Downstream https://github.com/mpv-player/mpv/issues/14941
Downstream https://trac.ffmpeg.org/ticket/11213