### PR TITLE
[DDI] Fixed incorrect convert FOURCC to GMM format (P012)

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -3578,7 +3578,7 @@ GMM_RESOURCE_FORMAT MediaLibvaCaps::ConvertFourccToGmmFmt(uint32_t fourcc)
         case VA_FOURCC_IMC3   : return GMM_FORMAT_IMC3_TYPE;
         case VA_FOURCC_P208   : return GMM_FORMAT_P208_TYPE;
         case VA_FOURCC_P010   : return GMM_FORMAT_P010_TYPE;
-        case VA_FOURCC_P012   : return GMM_FORMAT_P016_TYPE;
+        case VA_FOURCC_P012   : return GMM_FORMAT_P012_TYPE;
         case VA_FOURCC_P016   : return GMM_FORMAT_P016_TYPE;
         case VA_FOURCC_Y210   : return GMM_FORMAT_Y210_TYPE;
         case VA_FOURCC_Y410   : return GMM_FORMAT_Y410_TYPE;


### PR DESCRIPTION
Affected  function parameter `uint32_t fourcc` with enum value `VA_FOURCC_P012 (0x32313050)`

More info about P012 format.
```
P012: two-plane 12-bit YUV 4:2:0.
Each sample is a two-byte little-endian value with the bottom four bits ignored.
The first plane contains Y, the second plane contains U and V in pairs of samples.
```