### PR TITLE
[codechal,mhw] Align structures for 64-bit optimize move/copy structures

### DIFF
--- a/media_common/agnostic/common/codec/shared/codec_def_decode_vvc.h
+++ b/media_common/agnostic/common/codec/shared/codec_def_decode_vvc.h
@@ -101,8 +101,8 @@ struct SliceDescriptor
     int32_t          m_numCtusInCurrSlice;                //!< number of CTUs in current slice
 
     //Rect slices params
-    uint16_t         m_tileIdx;                           //!< tile index corresponding to the first CTU in the slice
     uint32_t         m_numSlicesInTile;                   //!< number of slices in current tile for the special case of multiple slices inside a single tile
+    uint16_t         m_tileIdx;                           //!< tile index corresponding to the first CTU in the slice
     int16_t          m_sliceWidthInTiles;                 //!< slice width in units of tiles
     int16_t          m_sliceHeightInTiles;                //!< slice height in units of tiles
     uint16_t         m_sliceHeightInCtu;                  //!< slice height in units of CTUs for the special case of multiple slices inside a single tile

--- a/media_common/agnostic/common/cp/mhw_cp_interface.h
+++ b/media_common/agnostic/common/cp/mhw_cp_interface.h
@@ -71,8 +71,8 @@ typedef struct _MHW_ADD_CP_COPY_PARAMS
 {
     PMOS_RESOURCE presSrc;
     PMOS_RESOURCE presDst;
-    uint32_t      size;
     uint64_t      offset;
+    uint32_t      size;
     bool          bypass;
 } MHW_ADD_CP_COPY_PARAMS, *PMHW_ADD_CP_COPY_PARAMS;
 

--- a/media_common/agnostic/common/hw/mhw_mi.h
+++ b/media_common/agnostic/common/hw/mhw_mi.h
@@ -190,8 +190,8 @@ typedef struct _MHW_PIPE_CONTROL_PARAMS
 typedef struct _MHW_MI_COPY_MEM_MEM_PARAMS
 {
     PMOS_RESOURCE               presSrc;
-    uint32_t                    dwSrcOffset;
     PMOS_RESOURCE               presDst;
+    uint32_t                    dwSrcOffset;
     uint32_t                    dwDstOffset;
 } MHW_MI_COPY_MEM_MEM_PARAMS, *PMHW_MI_COPY_MEM_MEM_PARAMS;
 
@@ -260,9 +260,9 @@ typedef struct _MHW_MI_FLUSH_DW_PARAMS
     uint32_t                    dwResourceOffset;
     uint32_t                    dwDataDW1;                                        // Value to Write
     uint32_t                    dwDataDW2;
-    bool                        bVideoPipelineCacheInvalidate;
     uint32_t                    postSyncOperation;
     uint32_t                    bQWordEnable;
+    bool                        bVideoPipelineCacheInvalidate;
     bool                        bEnablePPCFlush;
 } MHW_MI_FLUSH_DW_PARAMS, *PMHW_MI_FLUSH_DW_PARAMS;
 

--- a/media_common/agnostic/common/hw/mhw_render.h
+++ b/media_common/agnostic/common/hw/mhw_render.h
@@ -132,13 +132,12 @@ typedef struct _MHW_RENDER_ENGINE_CAPS
 typedef struct _MHW_STATE_BASE_ADDR_PARAMS
 {
     PMOS_RESOURCE           presGeneralState;
-    uint32_t                dwGeneralStateSize;
     PMOS_RESOURCE           presDynamicState;
-    uint32_t                dwDynamicStateSize;
-    bool                    bDynamicStateRenderTarget;
     PMOS_RESOURCE           presIndirectObjectBuffer;
-    uint32_t                dwIndirectObjectBufferSize;
     PMOS_RESOURCE           presInstructionBuffer;
+    uint32_t                dwGeneralStateSize;
+    uint32_t                dwDynamicStateSize;
+    uint32_t                dwIndirectObjectBufferSize;
     uint32_t                dwInstructionBufferSize;
     uint32_t                mocs4InstructionCache;
     uint32_t                mocs4GeneralState;
@@ -147,6 +146,7 @@ typedef struct _MHW_STATE_BASE_ADDR_PARAMS
     uint32_t                mocs4IndirectObjectBuffer;
     uint32_t                mocs4StatelessDataport;
     uint32_t                l1CacheConfig;
+    bool                    bDynamicStateRenderTarget;
     bool                    addressDis;
 } MHW_STATE_BASE_ADDR_PARAMS, *PMHW_STATE_BASE_ADDR_PARAMS;
 

--- a/media_common/agnostic/common/hw/mhw_sfc.h
+++ b/media_common/agnostic/common/hw/mhw_sfc.h
@@ -314,8 +314,8 @@ typedef struct _MHW_SFC_OUT_SURFACE_PARAMS
 //!
 typedef struct _MHW_SFC_LOCK_PARAMS
 {
-    uint8_t  sfcPipeMode;                                                        //!< SFC Pipe Mode
     uint32_t dwGaClientId;                                                       // Ga Client Id
+    uint8_t  sfcPipeMode;                                                        //!< SFC Pipe Mode
     bool     bOutputToMemory;                                                    // Write Vebox or Vdbox o/p to memory
 } MHW_SFC_LOCK_PARAMS, *PMHW_SFC_LOCK_PARAMS;
 

--- a/media_common/agnostic/common/hw/mhw_state_heap.h
+++ b/media_common/agnostic/common/hw/mhw_state_heap.h
@@ -189,13 +189,13 @@ typedef enum _MHW_SCALING_MODE
 //!
 typedef struct _MHW_AVS_PARAMS
 {
-    MOS_FORMAT              Format;
-    float                   fScaleX;
-    float                   fScaleY;
     int32_t                 *piYCoefsX;
     int32_t                 *piYCoefsY;
     int32_t                 *piUVCoefsX;
     int32_t                 *piUVCoefsY;
+    MOS_FORMAT              Format;
+    float                   fScaleX;
+    float                   fScaleY;
     bool                    bForcePolyPhaseCoefs;
     bool                    bUse8x8Filter;
 } MHW_AVS_PARAMS, *PMHW_AVS_PARAMS;
@@ -617,6 +617,12 @@ typedef struct _MHW_SAMPLER_AVS_TABLE_PARAM
 //!
 typedef struct _MHW_SAMPLER_STATE_AVS_PARAM
 {
+    PMHW_SAMPLER_AVS_TABLE_PARAM pMhwSamplerAvsTableParam; // pointer to AVS scaling 8x8 table params
+
+    void                         *pTable8x8_Ptr;     // Table data ptr in GSH
+    int32_t                      iTable8x8_Index;   // Table allocation index (not needed on Gen8+)
+    uint32_t                     dwTable8x8_Offset; // Table data offset in GSH
+
     int16_t                      stateID;
 
     // STE params
@@ -656,12 +662,6 @@ typedef struct _MHW_SAMPLER_STATE_AVS_PARAM
     uint16_t YSlope1;
     uint16_t S2U;
     uint16_t S1U;
-
-    PMHW_SAMPLER_AVS_TABLE_PARAM pMhwSamplerAvsTableParam; // pointer to AVS scaling 8x8 table params
-
-    int32_t                      iTable8x8_Index;   // Table allocation index (not needed on Gen8+)
-    void                         *pTable8x8_Ptr;     // Table data ptr in GSH
-    uint32_t                     dwTable8x8_Offset; // Table data offset in GSH
 } MHW_SAMPLER_STATE_AVS_PARAM, *PMHW_SAMPLER_STATE_AVS_PARAM;
 
 //!

--- a/media_common/agnostic/common/hw/mhw_vebox.h
+++ b/media_common/agnostic/common/hw/mhw_vebox.h
@@ -399,18 +399,18 @@ typedef struct _MHW_LACE_PARAMS
 typedef struct _MHW_COLORPIPE_PARAMS
 {
     uint32_t            bActive;                    //!< Active or not
+    uint32_t            dwAceLevel;
+    uint32_t            dwAceStrength;
+    MHW_STE_PARAMS      SteParams;
+    MHW_STD_PARAMS      StdParams;
+    MHW_LACE_PARAMS     LaceParams;
+    MHW_TCC_PARAMS      TccParams;
     bool                bEnableACE;
     bool                bEnableSTE;
     bool                bEnableSTD;                 // vebox STD alone enabled or not
     bool                bEnableTCC;
     bool                bAceLevelChanged;
-    uint32_t            dwAceLevel;
-    uint32_t            dwAceStrength;
     bool                bEnableLACE;
-    MHW_STE_PARAMS      SteParams;
-    MHW_STD_PARAMS      StdParams;
-    MHW_TCC_PARAMS      TccParams;
-    MHW_LACE_PARAMS     LaceParams;
 } MHW_COLORPIPE_PARAMS, *PMHW_COLORPIPE_PARAMS;
 
 //!
@@ -625,10 +625,10 @@ typedef struct _MHW_CAPPIPE_PARAMS
 //!
 typedef struct _MHW_3DLUT_PARAMS
 {
+    uint8_t                 *pLUT;                      //!< Pointer to the LUT value
     uint32_t                bActive;                    //!< Active or not
     uint32_t                LUTSize;                    //!< Size (one dimensions) of the LUT
     uint32_t                LUTLength;                  //!< Length of the LUT, in unit of bit
-    uint8_t                 *pLUT;                      //!< Pointer to the LUT value
     MHW_3DLUT_INTERPOLATION InterpolationMethod;        //!< Vebox 3DLut interpolation method
 } MHW_3DLUT_PARAMS, *PMHW_3DLUT_PARAMS;
 

--- a/media_common/agnostic/common/hw/vdbox/mhw_vdbox.h
+++ b/media_common/agnostic/common/hw/vdbox/mhw_vdbox.h
@@ -276,24 +276,24 @@ using PMHW_VDBOX_PIPE_MODE_SELECT_PARAMS = MHW_VDBOX_PIPE_MODE_SELECT_PARAMS * ;
 
 typedef struct _MHW_VDBOX_SURFACE_PARAMS
 {
-    uint32_t                    Mode;
     PMOS_SURFACE                psSurface;              // 2D surface parameters
+    uint32_t                    Mode;
+    uint32_t                    dwUVPlaneAlignment;
+    uint32_t                    dwActualWidth;
+    uint32_t                    dwActualHeight;
+    uint32_t                    dwReconSurfHeight;
+    uint32_t                    dwCompressionFormat;
+    MOS_MEMCOMP_STATE           mmcState;
+    uint8_t                     mmcSkipMask;
     uint8_t                     ucVDirection;
     uint8_t                     ChromaType;
     uint8_t                     ucSurfaceStateId;
     uint8_t                     ucBitDepthLumaMinus8;
     uint8_t                     ucBitDepthChromaMinus8;
-    uint32_t                    dwUVPlaneAlignment;
     bool                        bDisplayFormatSwizzle;
     bool                        bSrc8Pak10Mode;
     bool                        bColorSpaceSelection;
     bool                        bVdencDynamicScaling;
-    uint32_t                    dwActualWidth;
-    uint32_t                    dwActualHeight;
-    uint32_t                    dwReconSurfHeight;
-    MOS_MEMCOMP_STATE           mmcState;
-    uint8_t                     mmcSkipMask;
-    uint32_t                    dwCompressionFormat;
     uint8_t                     refsMmcEnable;
     uint8_t                     refsMmcType;
 } MHW_VDBOX_SURFACE_PARAMS, *PMHW_VDBOX_SURFACE_PARAMS;

--- a/media_driver/agnostic/common/cm/cm_hal.h
+++ b/media_driver/agnostic/common/cm/cm_hal.h
@@ -579,19 +579,19 @@ struct CM_HAL_WAVEFRONT26Z_DISPATCH_INFO
 //*-----------------------------------------------------------------------------
 struct CM_HAL_KERNEL_THREADSPACE_PARAM
 {
+    CM_HAL_DEPENDENCY dependencyInfo;       // [in] Kernel dependency
+    CM_HAL_DEPENDENCY dependencyVectors;    // [in] for engineering build
+    CM_WALKING_PARAMETERS walkingParams;    // [in] for engineering build
+    PCM_HAL_SCOREBOARD threadCoordinates;  // [in]
+    uint32_t colorCountMinusOne;            // [in] for color count minus one
     uint16_t threadSpaceWidth;             // [in] Kernel Threadspace width
     uint16_t threadSpaceHeight;            // [in] Kernel Threadspace height
     CM_DEPENDENCY_PATTERN patternType;      // [in] Kernel dependency as enum
-    CM_HAL_DEPENDENCY dependencyInfo;       // [in] Kernel dependency
-    PCM_HAL_SCOREBOARD threadCoordinates;  // [in]
     uint8_t reuseBBUpdateMask;              // [in]
     CM_HAL_WAVEFRONT26Z_DISPATCH_INFO dispatchInfo;  // [in]
     uint8_t globalDependencyMask;           // [in] dependency mask in gloabal dependency vectors
     uint8_t walkingParamsValid;             // [in] for engineering build
-    CM_WALKING_PARAMETERS walkingParams;    // [in] for engineering build
     uint8_t dependencyVectorsValid;         // [in] for engineering build
-    CM_HAL_DEPENDENCY dependencyVectors;    // [in] for engineering build
-    uint32_t colorCountMinusOne;            // [in] for color count minus one
     CM_MW_GROUP_SELECT groupSelect;         // [in] for group select on BDW+
     CM_HAL_BB_DIRTY_STATUS bbDirtyStatus;   // [in] batch buffer dirty status
     CM_WALKING_PATTERN walkingPattern;      // [in] media walking pattern as enum

--- a/media_driver/agnostic/common/cm/cm_wrapper.h
+++ b/media_driver/agnostic/common/cm/cm_wrapper.h
@@ -188,9 +188,9 @@ typedef struct _CM_CREATEVMESURFACE_PARAM
 
 typedef struct _CM_CREATESAMPLER_PARAM
 {
-    CM_SAMPLER_STATE        sampleState;                // [in]
     void                    *samplerHandle;           // [out]
     void                    *samplerIndexHandle;      // [out]
+    CM_SAMPLER_STATE        sampleState;                // [in]
     int32_t                 returnValue;               // [out]
 }CM_CREATESAMPLER_PARAM, *PCM_CREATESAMPLER_PARAM;
 

--- a/media_driver/agnostic/common/codec/hal/codechal_decode_sfc.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_sfc.h
@@ -187,7 +187,7 @@ protected:
     float              m_cscInOffset[3]  = {0};  //!< Csc In Offset
     float              m_cscOutOffset[3] = {0};  //!< Csc Out Offset
 
-    MHW_AVS_PARAMS           m_avsParams   = {Format_Any};  //!< Avs Params
+    MHW_AVS_PARAMS           m_avsParams   = {.Format = Format_Any};  //!< Avs Params
     MHW_SFC_AVS_LUMA_TABLE   m_lumaTable   = {0};           //!< Avs Luma Table
     MHW_SFC_AVS_CHROMA_TABLE m_chromaTable = {0};           //!< Avs Chroma Table
     MHW_SFC_AVS_STATE        m_avsState    = {0};           //<! Avs State

--- a/media_driver/agnostic/common/codec/hal/codechal_decode_vc1.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_decode_vc1.h
@@ -153,12 +153,12 @@ typedef struct _CODECHAL_DECODE_VC1_BITSTREAM
 {
     uint8_t*    pOriginalBitBuffer;                                   // pointer to the original capsuted bitstream
     uint8_t*    pOriginalBufferEnd;                                   // pointer to the end of the original uncapsuted bitstream
-    uint32_t    u32ZeroNum;                                           // number of continuous zeros before the current bype.
-    uint32_t    u32ProcessedBitNum;                                   // number of bits being processed from initiation
-    uint8_t     CacheBuffer[CODECHAL_DECODE_VC1_BITSTRM_BUF_LEN + 4]; // cache buffer of uncapsuted raw bitstream
     uint32_t*   pu32Cache;                                            // pointer to the cache buffer
     uint32_t*   pu32CacheEnd;                                         // pointer to the updating end of the cache buffer
     uint32_t*   pu32CacheDataEnd;                                     // pointer to the last valid uint32_t of the cache buffer
+    uint32_t    u32ZeroNum;                                           // number of continuous zeros before the current bype.
+    uint32_t    u32ProcessedBitNum;                                   // number of bits being processed from initiation
+    uint8_t     CacheBuffer[CODECHAL_DECODE_VC1_BITSTRM_BUF_LEN + 4]; // cache buffer of uncapsuted raw bitstream
     int32_t     iBitOffset;                                           // offset = 32 is the MSB, offset = 1 is the LSB.
     int32_t     iBitOffsetEnd;                                        // bit offset of the last valid uint32_t
     bool        bIsEBDU;                                              // 1 if it is EBDU and emulation prevention bytes are present.

--- a/media_driver/agnostic/common/codec/hal/codechal_encode_sfc_base.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_encode_sfc_base.h
@@ -449,7 +449,7 @@ protected:
     float                           m_cscInOffset[3] = { 0.0f, };
     float                           m_cscOutOffset[3] = { 0.0f, };
 
-    MHW_AVS_PARAMS                  m_avsParams = { Format_Any, };
+    MHW_AVS_PARAMS                  m_avsParams = { .Format = Format_Any, };
     MHW_SFC_AVS_LUMA_TABLE          m_lumaTable = { 0, };
     MHW_SFC_AVS_CHROMA_TABLE        m_chromaTable = { 0, };
     MHW_SFC_AVS_STATE               m_avsState = { 0, };

--- a/media_driver/agnostic/common/codec/hal/codechal_huc_cmd_initializer.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_huc_cmd_initializer.h
@@ -166,18 +166,11 @@ struct HucInputCmd2
 //!
 struct Vp9CmdInitializerParams
 {
-    uint8_t                             vdencMvCosts[12] = { 0 };
-    uint8_t                             vdencRdMvCosts[12] = { 0 };
-    uint8_t                             vdencHmeMvCosts[8] = { 0 };
-    uint8_t                             vdencModeCosts[CODEC_VDENC_NUM_MODE_COST] = { 0 };
-
-    uint16_t                            pictureCodingType   = 0;
-
     PCODEC_VP9_ENCODE_SEQUENCE_PARAMS   seqParams           = nullptr;
     PCODEC_VP9_ENCODE_PIC_PARAMS        picParams           = nullptr;
+    PCODEC_VP9_ENCODE_SEGMENT_PARAMS    segmentParams       = nullptr;
     bool                                segmentationEnabled = false;
     bool                                segmentMapProvided  = false;
-    PCODEC_VP9_ENCODE_SEGMENT_PARAMS    segmentParams       = nullptr;
     bool                                prevFrameSegEnabled = false;
     uint8_t                             numRefFrames        = 0;
     bool                                me16Enabled         = false;
@@ -197,6 +190,12 @@ struct Vp9CmdInitializerParams
     uint16_t                            rdQpLambda                      = 0;
     bool                                vdencPakOnlyMultipassEnabled    = false;
 
+    uint8_t                             vdencMvCosts[12] = { 0 };
+    uint8_t                             vdencRdMvCosts[12] = { 0 };
+    uint8_t                             vdencHmeMvCosts[8] = { 0 };
+    uint8_t                             vdencModeCosts[CODEC_VDENC_NUM_MODE_COST] = { 0 };
+
+    uint16_t                            pictureCodingType   = 0;
 };
 #endif
 

--- a/media_driver/agnostic/common/codec/hal/codechal_utilities.h
+++ b/media_driver/agnostic/common/codec/hal/codechal_utilities.h
@@ -55,28 +55,39 @@ typedef enum _CODECHAL_WALKER_DEGREE
 
 typedef struct _CODECHAL_WALKER_CODEC_PARAMS
 {
+    CODECHAL_WALKER_DEGREE  WalkerDegree;
     uint32_t                WalkerMode;
-    bool                    bUseScoreboard;
     uint32_t                dwResolutionX;
     uint32_t                dwResolutionY;
-    bool                    bNoDependency;
-    CODECHAL_WALKER_DEGREE  WalkerDegree;
-    bool                    bUseVerticalRasterScan;
     uint32_t                wPictureCodingType;
+    uint32_t                bDirectSpatialMVPredFlag;
+    uint32_t                dwNumSlices;
+    uint32_t                ScoreboardMask;
+    bool                    bUseScoreboard;
+    bool                    bNoDependency;
+    bool                    bUseVerticalRasterScan;
     bool                    bMbEncIFrameDistInUse;
     bool                    bMbaff;
-    uint32_t                bDirectSpatialMVPredFlag;
     bool                    bColorbitSupported;
-    uint32_t                dwNumSlices;
     uint16_t                usSliceHeight;
     bool                    bGroupIdSelectSupported;
     uint8_t                 ucGroupId;
-    uint32_t                ScoreboardMask;
     uint16_t                usTotalThreadNumPerLcu; //Used by Gen10 HEVC
 } CODECHAL_WALKER_CODEC_PARAMS, *PCODECHAL_WALKER_CODEC_PARAMS;
 
 typedef struct _CODECHAL_SURFACE_CODEC_PARAMS
 {
+    PMOS_SURFACE                psSurface;              // 2D surface parameters
+    PMOS_RESOURCE               presBuffer;             // Buffer parameters
+    uint32_t                    dwSize;                 // Buffer size
+    uint32_t                    dwOffset;               // Buffer offset
+    uint32_t                    dwBindingTableOffset;   // Binding table offset for given surface
+    uint32_t                    dwUVBindingTableOffset; // Binding table offset for the UV plane
+    uint32_t                    dwVerticalLineStride;
+    uint32_t                    dwVerticalLineStrideOffset;
+    uint8_t                     ucVDirection;
+    uint32_t                    dwCacheabilityControl;
+    uint32_t                    ChromaType;
     uint32_t                    Mode;
     bool                        bIs2DSurface;
     bool                        bUseUVPlane;
@@ -90,18 +101,7 @@ typedef struct _CODECHAL_SURFACE_CODEC_PARAMS
     bool                        bRenderTarget;
     bool                        bIsWritable;
     bool                        bUseHalfHeight;
-    PMOS_SURFACE                psSurface;              // 2D surface parameters
-    PMOS_RESOURCE               presBuffer;             // Buffer parameters
-    uint32_t                    dwSize;                 // Buffer size
-    uint32_t                    dwOffset;               // Buffer offset
-    uint32_t                    dwBindingTableOffset;   // Binding table offset for given surface
-    uint32_t                    dwUVBindingTableOffset; // Binding table offset for the UV plane
-    uint32_t                    dwVerticalLineStride;
-    uint32_t                    dwVerticalLineStrideOffset;
-    uint8_t                     ucVDirection;
-    uint32_t                    dwCacheabilityControl;
     bool                        bForceChromaFormat;
-    uint32_t                    ChromaType;
     bool                        bRawSurface;
     uint8_t                     ucSurfaceStateId;
 

--- a/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_avp_interface.h
+++ b/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_avp_interface.h
@@ -99,6 +99,8 @@ struct MhwVdboxAvpPakInsertObjParams
 {
     PBSBuffer pBsBuffer;
     // also reuse dwBitSize for passing SrcDataEndingBitInclusion when (pEncoder->bLastPicInStream || pEncoder->bLastPicInSeq)
+    uint32_t *        pdwMpeg2PicHeaderTotalBufferSize;
+    uint32_t *        pdwMpeg2PicHeaderDataStartOffset;
     uint32_t          dwBitSize;
     uint32_t          dwOffset;
     uint32_t          uiSkipEmulationCheckCount;
@@ -109,8 +111,6 @@ struct MhwVdboxAvpPakInsertObjParams
     bool              bSetLastPicInStreamData;
     bool              bSliceHeaderIndicator;
     bool              bHeaderLengthExcludeFrmSize;
-    uint32_t *        pdwMpeg2PicHeaderTotalBufferSize;
-    uint32_t *        pdwMpeg2PicHeaderDataStartOffset;
     bool              bResetBitstreamStartingPos;
     uint32_t          m_endOfHeaderInsertion;
     uint32_t          dwLastPicInSeqData;
@@ -195,15 +195,15 @@ public:
 
 struct MhwVdboxAvpBufferSizeParams
 {
-    uint8_t                         m_bitDepthIdc;
     uint32_t                        m_picWidth;                // picWidth in SB
     uint32_t                        m_picHeight;               // picHeight in SB
     uint32_t                        m_tileWidth;               // tileWidth in SB
     uint32_t                        m_bufferSize;
-    bool                            m_isSb128x128;
     uint32_t                        m_curFrameTileNum;
     uint32_t                        m_numTileCol;
     uint8_t                         m_numOfActivePipes;
+    uint8_t                         m_bitDepthIdc;
+    bool                            m_isSb128x128;
 };
 
 struct MhwVdboxAvpBufferReallocParams

--- a/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_hcp_interface.h
+++ b/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_hcp_interface.h
@@ -85,8 +85,6 @@ typedef struct _MHW_VDBOX_HCP_BUFFER_SIZE_PARAMS
 
 typedef struct _MHW_VDBOX_HCP_BUFFER_REALLOC_PARAMS
 {
-    uint8_t    ucMaxBitDepth;
-    uint8_t    ucChromaFormat;
     uint32_t   dwPicWidth;
     uint32_t   dwPicHeight;
     uint32_t   dwPicWidthAlloced;
@@ -95,6 +93,8 @@ typedef struct _MHW_VDBOX_HCP_BUFFER_REALLOC_PARAMS
     uint32_t   dwCtbLog2SizeYMax;
     uint32_t   dwFrameSize;
     uint32_t   dwFrameSizeAlloced;
+    uint8_t    ucMaxBitDepth;
+    uint8_t    ucChromaFormat;
     bool       bNeedBiggerSize;
 }MHW_VDBOX_HCP_BUFFER_REALLOC_PARAMS, *PMHW_VDBOX_HCP_BUFFER_REALLOC_PARAMS;
 

--- a/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_mfx_interface.h
+++ b/media_driver/agnostic/common/hw/vdbox/mhw_vdbox_mfx_interface.h
@@ -316,16 +316,16 @@ typedef struct _MHW_VDBOX_AVC_DPB_PARAMS
 
 typedef struct _MHW_VDBOX_AVC_DIRECTMODE_PARAMS
 {
-    CODEC_PICTURE                   CurrPic;
-    bool                            isEncode;
-    uint32_t                        uiUsedForReferenceFlags;
     PMOS_RESOURCE                   presAvcDmvBuffers;
-    uint8_t                         ucAvcDmvIdx;
     PCODEC_AVC_DMV_LIST             pAvcDmvList;
     PCODEC_PIC_ID                   pAvcPicIdx;
     void                            **avcRefList;
+    CODEC_PICTURE                   CurrPic;
+    uint32_t                        uiUsedForReferenceFlags;
+    bool                            isEncode;
     bool                            bPicIdRemappingInUse;
     int32_t                         CurrFieldOrderCnt[2];
+    uint8_t                         ucAvcDmvIdx;
     bool                            bDisableDmvBuffers;
     PMOS_RESOURCE                   presMvcDummyDmvBuffer;
 } MHW_VDBOX_AVC_DIRECTMODE_PARAMS, *PMHW_VDBOX_AVC_DIRECTMODE_PARAMS;

--- a/media_driver/agnostic/gen9/codec/hal/codechal_fei_avc_g9.cpp
+++ b/media_driver/agnostic/gen9/codec/hal/codechal_fei_avc_g9.cpp
@@ -1983,8 +1983,8 @@ typedef struct _CODECHAL_ENCODE_AVC_MBENC_DISPATCH_PARAMS
     CodechalEncodeMdfKernelResource*        pKernelRes;
     struct CodechalEncodeAvcSurfaceIdx      *avcMBEncSurface;
     uint32_t                                frameWidthInMBs;
-    uint16_t                                wSliceHeight;
     uint32_t                                numSlices;
+    uint16_t                                wSliceHeight;
     uint16_t                                wSliceType;
     uint32_t                                dwNumMBs;
     bool                                    EnableArbitrarySliceSize;

--- a/media_softlet/agnostic/common/codec/hal/dec/vvc/packet/decode_vvc_s2l_packet.h
+++ b/media_softlet/agnostic/common/codec/hal/dec/vvc/packet/decode_vvc_s2l_packet.h
@@ -474,8 +474,8 @@ struct VvcS2lExtraBss
             int32_t m_numCtusInCurrSlice;  //!< number of CTUs in current slice
 
             //Rect slices params
-            uint16_t m_tileIdx;             //!< tile index corresponding to the first CTU in the slice
             uint32_t m_numSlicesInTile;     //!< number of slices in current tile for the special case of multiple slices inside a single tile
+            uint16_t m_tileIdx;             //!< tile index corresponding to the first CTU in the slice
             uint16_t m_sliceWidthInTiles;   //!< slice width in units of tiles
             uint16_t m_sliceHeightInTiles;  //!< slice height in units of tiles
             uint16_t m_sliceHeightInCtu;    //!< slice height in units of CTUs for the special case of multiple slices inside a single tile

--- a/media_softlet/agnostic/common/codec/hal/enc/shared/features/encode_preenc_defs.h
+++ b/media_softlet/agnostic/common/codec/hal/enc/shared/features/encode_preenc_defs.h
@@ -70,8 +70,8 @@ struct EncodePreencDef1
 
 struct PreEncInfo
 {
-    uint8_t  EncodePreEncInfo0 = 0;
     uint32_t EncodePreEncInfo1 = 0;
+    uint8_t  EncodePreEncInfo0 = 0;
     uint8_t  EncodePreEncInfo2 = 0;
     uint8_t  EncodePreEncInfo3 = 0;
     uint32_t preEncSrcWidth    = 0;

--- a/media_softlet/agnostic/common/hw/mhw_memory_pool.cpp
+++ b/media_softlet/agnostic/common/hw/mhw_memory_pool.cpp
@@ -32,8 +32,8 @@ typedef struct _MHW_MEMORY_POOL_ENTRY
     PMHW_MEMORY_POOL_ENTRY  pPrev;              //!< Prev pool entry (doubled linked list)
     PMHW_MEMORY_POOL        pPool;              //!< Pool object
     void                    *pAllocation;        //!< Memory allocation from malloc (to be freed)
-    uint32_t                dwSize;             //!< Memory size allocated from malloc
     void                    *pObjects;           //!< Pointer to first object in this pool entry
+    uint32_t                dwSize;             //!< Memory size allocated from malloc
     uint32_t                dwCount;            //!< Number of objects in this pool allocation
 } MHW_MEMORY_POOL_ENTRY, *PMHW_MEMORY_POOL_ENTRY;
 

--- a/media_softlet/agnostic/common/hw/mhw_mi_cmdpar.h
+++ b/media_softlet/agnostic/common/hw/mhw_mi_cmdpar.h
@@ -276,9 +276,9 @@ namespace mi
         uint32_t                    dwResourceOffset              = 0;
         uint32_t                    dwDataDW1                     = 0;                // Value to Write
         uint32_t                    dwDataDW2                     = 0;
-        bool                        bVideoPipelineCacheInvalidate = false;
         uint32_t                    postSyncOperation             = 0;
         uint32_t                    bQWordEnable                  = 0;
+        bool                        bVideoPipelineCacheInvalidate = false;
         bool                        bEnablePPCFlush               = false;
     };
 

--- a/media_softlet/agnostic/common/hw/mhw_render_cmdpar.h
+++ b/media_softlet/agnostic/common/hw/mhw_render_cmdpar.h
@@ -178,25 +178,25 @@ struct MHW_VFE_PARAMS
 
 struct _MHW_PAR_T(MEDIA_OBJECT)
 {
+    void*                               pInlineData                  = nullptr;
     uint32_t                            dwInterfaceDescriptorOffset  = 0;
     uint32_t                            dwHalfSliceDestinationSelect = 0;
     uint32_t                            dwSliceDestinationSelect     = 0;
     uint32_t                            dwIndirectLoadLength         = 0;
     uint32_t                            dwIndirectDataStartAddress   = 0;
-    void*                               pInlineData                  = nullptr;
     uint32_t                            dwInlineDataSize             = 0;
-    bool                                bForceDestination            = false;
     MHW_VFE_SCOREBOARD                  VfeScoreboard                = {};
+    bool                                bForceDestination            = false;
 };
 
 struct _MHW_PAR_T(PIPE_MODE_SELECT)
 {
+    void*              pInlineData                  = nullptr;
     uint32_t           dwInterfaceDescriptorOffset  = 0;
     uint32_t           dwHalfSliceDestinationSelect = 0;
     uint32_t           dwSliceDestinationSelect     = 0;
     uint32_t           dwIndirectLoadLength         = 0;
     uint32_t           dwIndirectDataStartAddress   = 0;
-    void*              pInlineData                  = nullptr;
     uint32_t           dwInlineDataSize             = 0;
     bool               bForceDestination            = false;
     MHW_VFE_SCOREBOARD VfeScoreboard                = {};

--- a/media_softlet/agnostic/common/hw/vdbox/mhw_vdbox_hcp_cmdpar.h
+++ b/media_softlet/agnostic/common/hw/vdbox/mhw_vdbox_hcp_cmdpar.h
@@ -551,6 +551,9 @@ struct _MHW_PAR_T(HCP_PIPE_BUF_ADDR_STATE)
 struct _MHW_PAR_T(HCP_PAK_INSERT_OBJECT)
 {
     PBSBuffer         pBsBuffer                        = nullptr;
+    PMHW_BATCH_BUFFER pBatchBufferForPakSlices         = nullptr;
+    uint32_t *        pdwMpeg2PicHeaderTotalBufferSize = nullptr;
+    uint32_t *        pdwMpeg2PicHeaderDataStartOffset = nullptr;
     uint32_t          dwBitSize                        = 0;
     uint32_t          dwOffset                         = 0;
     uint32_t          uiSkipEmulationCheckCount        = 0;
@@ -561,13 +564,10 @@ struct _MHW_PAR_T(HCP_PAK_INSERT_OBJECT)
     bool              bSetLastPicInStreamData          = false;
     bool              bSliceHeaderIndicator            = false;
     bool              bHeaderLengthExcludeFrmSize      = false;
-    uint32_t *        pdwMpeg2PicHeaderTotalBufferSize = nullptr;
-    uint32_t *        pdwMpeg2PicHeaderDataStartOffset = nullptr;
     bool              bResetBitstreamStartingPos       = false;
     bool              bEndOfSlice                      = false;
     uint32_t          dwLastPicInSeqData               = 0;
     uint32_t          dwLastPicInStreamData            = 0;
-    PMHW_BATCH_BUFFER pBatchBufferForPakSlices         = nullptr;
     bool              bVdencInUse                      = false;
     uint32_t          dataBitsInLastDw                 = 0;
     uint8_t           databyteoffset                   = 0;
@@ -675,14 +675,8 @@ struct _MHW_PAR_T(HCP_TILE_CODING)
     uint32_t numOfTileColumnsInFrame              = 0;
     uint32_t tileStartLCUX                        = 0;
     uint32_t tileStartLCUY                        = 0;
-    uint16_t tileHeightInMinCbMinus1              = 0;
-    uint16_t tileWidthInMinCbMinus1               = 0;
-    bool     isLastTileofColumn                   = false;
-    bool     isLastTileofRow                      = false;
     uint32_t tileRowStoreSelect                   = 0;
     uint32_t tileColumnStoreSelect                = 0;
-    bool     nonFirstPassTile                     = false;
-    bool     bitstreamByteOffsetEnable            = false;
     uint32_t numberOfActiveBePipes                = 0;
     uint32_t bitstreamByteOffset                  = 0;
     uint32_t pakTileStatisticsOffset              = 0;
@@ -693,6 +687,12 @@ struct _MHW_PAR_T(HCP_TILE_CODING)
     uint32_t saoRowstoreOffset                    = 0;
     uint32_t tileSizeStreamoutOffset              = 0;
     uint32_t vp9ProbabilityCounterStreamoutOffset = 0;
+    uint16_t tileHeightInMinCbMinus1              = 0;
+    uint16_t tileWidthInMinCbMinus1               = 0;
+    bool     nonFirstPassTile                     = false;
+    bool     bitstreamByteOffsetEnable            = false;
+    bool     isLastTileofColumn                   = false;
+    bool     isLastTileofRow                      = false;
 };
 
 struct _MHW_PAR_T(HCP_PALETTE_INITIALIZER_STATE)

--- a/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.h
+++ b/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.h
@@ -91,6 +91,14 @@ typedef struct _PIPECONTRL_PARAMS
 
 typedef struct _KERNEL_WALKER_PARAMS
 {
+    uint8_t*                            inlineData;
+    PMHW_INLINE_DATA_PARAMS             inlineDataParamBase;
+    uint32_t                            inlineDataLength;
+    uint32_t                            inlineDataParamSize;
+    uint32_t                            slmSize;
+    bool                                isEmitInlineParameter;
+    bool                                hasBarrier;
+
     int32_t                             iBindingTable;
     int32_t                             iMediaID;
     int32_t                             iCurbeOffset;
@@ -107,21 +115,12 @@ typedef struct _KERNEL_WALKER_PARAMS
     bool                                calculateBlockXYByAlignedRect;      // true if iBlocksX/iBlocksY is calculated by alignedRect in RenderCmdPacket instead of kernel object.
     bool                                forcePreferredSLMZero;              // true if preferredSLM need force to 0.
 
-    bool                                isEmitInlineParameter;
-    uint32_t                            inlineDataLength;
-    uint8_t*                            inlineData;
-
     uint32_t                            threadWidth;
     uint32_t                            threadHeight;
     uint32_t                            threadDepth;
 
     bool                                isGenerateLocalID;
     MHW_EMIT_LOCAL_MODE                 emitLocal;
-
-    bool                                hasBarrier;
-    uint32_t                            slmSize;
-    PMHW_INLINE_DATA_PARAMS             inlineDataParamBase;
-    uint32_t                            inlineDataParamSize;
 }KERNEL_WALKER_PARAMS, * PKERNEL_WALKER_PARAMS;
 
 typedef struct _KERNEL_PACKET_RENDER_DATA

--- a/media_softlet/agnostic/common/vp/hal/features/vp_filter.h
+++ b/media_softlet/agnostic/common/vp/hal/features/vp_filter.h
@@ -167,19 +167,19 @@ struct _SFC_SCALING_PARAMS
 
 struct _SFC_CSC_PARAMS
 {
+    PVPHAL_IEF_PARAMS               iefParams;                                   // Vphal Params
+    VPHAL_CSPACE                    inputColorSpace;                             // Input Color Space
+    MOS_FORMAT                      inputFormat;                                 // SFC Input Format
+    MOS_FORMAT                      outputFormat;                                // SFC Output Format
+    uint32_t                        sfcSrcChromaSiting;                          // SFC Source Chroma Siting location
+    uint32_t                        chromaDownSamplingVerticalCoef;              // Chroma DownSampling Vertical Coeff
+    uint32_t                        chromaDownSamplingHorizontalCoef;            // Chroma DownSampling Horizontal Coeff
     bool                            bCSCEnabled;                                 // CSC Enabled
     bool                            isInputColorSpaceRGB;                        // 0: YUV color space, 1:RGB color space
     bool                            bIEFEnable;                                  // IEF Enabled
     bool                            bChromaUpSamplingEnable;                     // ChromaUpSampling
     bool                            b8tapChromafiltering;                        // Enables 8 tap filtering for Chroma Channels
     bool                            isDitheringNeeded;                           // 0: dithering is not needed; 1: dithering is needed
-    VPHAL_CSPACE                    inputColorSpace;                             // Input Color Space
-    MOS_FORMAT                      inputFormat;                                 // SFC Input Format
-    MOS_FORMAT                      outputFormat;                                // SFC Output Format
-    PVPHAL_IEF_PARAMS               iefParams;                                   // Vphal Params
-    uint32_t                        sfcSrcChromaSiting;                          // SFC Source Chroma Siting location
-    uint32_t                        chromaDownSamplingVerticalCoef;              // Chroma DownSampling Vertical Coeff
-    uint32_t                        chromaDownSamplingHorizontalCoef;            // Chroma DownSampling Horizontal Coeff
     bool                            isFullRgbG10P709;                            // Whether output colorspace is DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709
     bool                            isDemosaicNeeded;                            // 0: demosaic is not needed; 1: demosaic is needed       
 };
@@ -193,13 +193,13 @@ struct _SFC_ROT_MIR_PARAMS
 
 struct _VEBOX_DN_PARAMS
 {
+    VPHAL_HVSDENOISE_PARAMS         HVSDenoise;
     bool                            bDnEnabled;
     bool                            bChromaDenoise;                             // bEnableChroma && bEnableLuma
     bool                            bAutoDetect;
     float                           fDenoiseFactor;
     VPHAL_NOISELEVEL                NoiseLevel;
     bool                            bEnableHVSDenoise;
-    VPHAL_HVSDENOISE_PARAMS         HVSDenoise;
     bool                            bProgressive;
 };
 
@@ -247,12 +247,12 @@ struct _VEBOX_TCC_PARAMS
 
 struct _VEBOX_CGC_PARAMS
 {
-    bool                                bEnableCGC;                                 // CGC Enabled
-    bool                                bBt2020ToRGB;                               // Bt2020 convert to sRGB
     VPHAL_CSPACE                        inputColorSpace;
     VPHAL_CSPACE                        outputColorSpace;
     MOS_FORMAT                          inputFormat;
     MOS_FORMAT                          outputFormat;
+    bool                                bEnableCGC;                                 // CGC Enabled
+    bool                                bBt2020ToRGB;                               // Bt2020 convert to sRGB
     bool                                bExtendedSrcGamut;
     bool                                bExtendedDstGamut;
     VPHAL_GAMUT_MODE                    GCompMode;


### PR DESCRIPTION
not all structures are affected, such optimization can optimize even more frequently called structures.

If you are really chasing performance media-driver, then I can also offer PR with other structures later.