### PR TITLE
Replace to emplace C++11 for code refactor and minor optimize inserts

### DIFF
--- a/media_common/agnostic/common/shared/media_factory.h
+++ b/media_common/agnostic/common/shared/media_factory.h
@@ -68,10 +68,9 @@ public:
         Iterator creator = creators.find(key);
         if (creator == creators.end())
         {
-            std::pair<Iterator, bool> result =
-                creators.insert(std::make_pair(key, Create<C>));
-            sizes.insert(std::make_pair(key, (uint32_t)sizeof(C)));
-            placecreators.insert(std::make_pair(key, PlaceCreate<C>));
+            std::pair<Iterator, bool> result = creators.emplace(key, Create<C>);
+            sizes.emplace(key, (uint32_t)sizeof(C));
+            placecreators.emplace(key, PlaceCreate<C>);
             return result.second;
         }
         else
@@ -79,8 +78,7 @@ public:
             if (forceReplace)
             {
                 creators.erase(creator);
-                std::pair<Iterator, bool> result =
-                    creators.insert(std::make_pair(key, Create<C>));
+                std::pair<Iterator, bool> result = creators.emplace(key, Create<C>);
                 return result.second;
             }
             return true; //If it is registered, do nothing then return true.

--- a/media_driver/agnostic/common/codec/hal/codechal_kernel_base.cpp
+++ b/media_driver/agnostic/common/codec/hal/codechal_kernel_base.cpp
@@ -146,7 +146,7 @@ MOS_STATUS CodechalKernelBase::CreateKernelState(
     CODECHAL_ENCODE_CHK_NULL_RETURN(m_kernelBinary);
 
     CODECHAL_ENCODE_CHK_NULL_RETURN((*kernelState) = MOS_New(MHW_KERNEL_STATE));
-    m_kernelStatePool.insert(std::make_pair(kernelIndex, *kernelState));
+    m_kernelStatePool.emplace(kernelIndex, *kernelState);
 
     CODECHAL_KERNEL_HEADER kernelHeader = {};
     uint32_t               kernelSize = 0;
@@ -319,7 +319,7 @@ MOS_STATUS CodechalKernelBase::AllocateSurface(PMOS_ALLOC_GFXRES_PARAMS param, P
 {
     CODECHAL_ENCODE_CHK_NULL_RETURN(param);
     CODECHAL_ENCODE_CHK_NULL_RETURN(surface);
-    m_surfacePool.insert(std::make_pair(surfaceId, surface));
+    m_surfacePool.emplace(surfaceId, surface);
 
     CODECHAL_ENCODE_CHK_STATUS_RETURN(
         m_osInterface->pfnAllocateResource(

--- a/media_driver/agnostic/common/os/mos_util_user_interface.cpp
+++ b/media_driver/agnostic/common/os/mos_util_user_interface.cpp
@@ -36,13 +36,13 @@ MOS_STATUS MosUtilUserInterface::AddEntry(const uint32_t keyId, PMOS_USER_FEATUR
 
     if (result == m_userFeatureKeyMap.end())
     {
-        m_userFeatureKeyMap.insert(std::make_pair(keyId, userFeatureKey));
+        m_userFeatureKeyMap.emplace(keyId, userFeatureKey);
     }
     else
     {
         MOS_OS_NORMALMESSAGE("User feature key already exist, replacing the old one.");
         m_userFeatureKeyMap.erase(keyId);
-        m_userFeatureKeyMap.insert(std::make_pair(keyId, userFeatureKey));
+        m_userFeatureKeyMap.emplace(keyId, userFeatureKey);
         m_mosMutex.Unlock();
         return MOS_STATUS_SUCCESS;
     }

--- a/media_driver/linux/common/ddi/media_ddi_factory.h
+++ b/media_driver/linux/common/ddi/media_ddi_factory.h
@@ -154,8 +154,7 @@ public:
     template <class C>
     static bool RegisterCodec(const KeyType &key)
     {
-        std::pair<iterator, bool> result =
-            GetCreators().insert(std::make_pair(key, create<C>));
+        std::pair<iterator, bool> result = GetCreators().emplace(key, create<C>);
 
         return result.second;
     }

--- a/media_softlet/agnostic/common/codec/hal/dec/shared/packet/decode_sub_packet_manager.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/shared/packet/decode_sub_packet_manager.cpp
@@ -48,7 +48,7 @@ MOS_STATUS DecodeSubPacketManager::Register(uint32_t packetId, DecodeSubPacket& 
     auto iter = m_subPacketList.find(packetId);
     DECODE_CHK_COND(iter != m_subPacketList.end(), "Failed to register sub packet %d", packetId);
 
-    m_subPacketList.insert(std::make_pair(packetId, &subPacket));
+    m_subPacketList.emplace(packetId, &subPacket);
     return MOS_STATUS_SUCCESS;
 }
 

--- a/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/decode_sub_pipeline.cpp
+++ b/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/decode_sub_pipeline.cpp
@@ -72,7 +72,7 @@ MOS_STATUS DecodeSubPipeline::RegisterPacket(uint32_t packetId, MediaPacket& pac
     auto iter = m_packetList.find(packetId);
     if (iter == m_packetList.end())
     {
-        m_packetList.insert(std::make_pair(packetId, &packet));
+        m_packetList.emplace(packetId, &packet);
     }
 
     return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_recycle_resource.cpp
+++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_recycle_resource.cpp
@@ -84,7 +84,7 @@ MOS_STATUS RecycleResource::RegisterResource(
         return MOS_STATUS_CLIENT_AR_NO_SPACE;
     }
 
-    m_resourceQueues.insert(std::make_pair(id, que));
+    m_resourceQueues.emplace(id, que);
 
     return MOS_STATUS_SUCCESS;
 }

--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer.cpp
+++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer.cpp
@@ -66,7 +66,7 @@ MOS_STATUS TrackedBuffer::RegisterParam(BufferType type, MOS_ALLOC_GFXRES_PARAMS
     auto iter = m_allocParams.find(type);
     if (iter == m_allocParams.end())
     {
-        m_allocParams.insert(std::make_pair(type, param));
+        m_allocParams.emplace(type, param);
     }
     else
     {
@@ -279,7 +279,7 @@ std::shared_ptr<BufferQueue> TrackedBuffer::GetBufferQueue(BufferType type)
 
         auto alloc = std::make_shared<BufferQueue>(m_allocator, param->second, m_maxSlotCnt);
         alloc->SetResourceType(resType);
-        m_bufferQueue.insert(std::make_pair(type, alloc));
+        m_bufferQueue.emplace(type, alloc);
         return alloc;
     }
     else

--- a/media_softlet/agnostic/common/media_interfaces/skuwa_factory.h
+++ b/media_softlet/agnostic/common/media_interfaces/skuwa_factory.h
@@ -60,8 +60,7 @@ public:
     //!
     static bool RegisterDevice(KeyType key, Type value)
     {
-        std::pair<iterator, bool> result =
-            GetCreators().insert(std::make_pair(key, value));
+        std::pair<iterator, bool> result = GetCreators().emplace(key, value);
 
         return result.second;
     }

--- a/media_softlet/agnostic/common/os/mos_oca_rtlog_mgr.cpp
+++ b/media_softlet/agnostic/common/os/mos_oca_rtlog_mgr.cpp
@@ -103,7 +103,7 @@ MOS_STATUS MosOcaRTLogMgr::RegisterRes(OsContextNext *osDriverContext, MOS_OCA_R
         MOS_OS_CHK_STATUS_RETURN(status);
     }
     s_ocaMutex.Lock();
-    m_resMap.insert(std::make_pair(osDriverContext, *resInterface));
+    m_resMap.emplace(osDriverContext, *resInterface);
     s_ocaMutex.Unlock();
     osDriverContext->SetRtLogRes(resInterface->ocaRTLogResource);
     return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/renderhal/renderhal.cpp
+++ b/media_softlet/agnostic/common/renderhal/renderhal.cpp
@@ -6804,7 +6804,7 @@ MOS_STATUS RenderHal_SetAndGetSamplerStates(
                     break;
                 }
 
-                samplerMap.insert(std::make_pair(i, stateOffsets));
+                samplerMap.emplace(i, stateOffsets);
 
                 if (MOS_FAILED(eStatus))
                 {

--- a/media_softlet/agnostic/common/shared/pipeline/media_pipeline.cpp
+++ b/media_softlet/agnostic/common/shared/pipeline/media_pipeline.cpp
@@ -138,7 +138,7 @@ MOS_STATUS MediaPipeline::RegisterPacket(uint32_t packetId, MediaPacket *packet)
     {
         m_packetList.erase(iter);
     }
-    m_packetList.insert(std::make_pair(packetId, packet));
+    m_packetList.emplace(packetId, packet);
 
     return MOS_STATUS_SUCCESS;
 }
@@ -257,7 +257,7 @@ MediaTask *MediaPipeline::CreateTask(MediaTask::TaskType type)
     }
     if (nullptr != task)
     {
-        m_taskList.insert(std::make_pair(type, task));
+        m_taskList.emplace(type, task);
     }
     return task;
 }

--- a/media_softlet/agnostic/common/vp/cm_fc_ld/PatchInfoReader.cpp
+++ b/media_softlet/agnostic/common/vp/cm_fc_ld/PatchInfoReader.cpp
@@ -305,9 +305,9 @@ bool PatchInfoReader::readSymbolTableSection(cm::patch::Collection &C,
       S->setExtra(Sym[i].SymExtra);
     }
     // Assume there's just one symbol table section per patch info.
-    SymbolTable.insert(std::make_pair(i, S));
+    SymbolTable.emplace(i, S);
   }
-  SymbolTableSectionMap.insert(std::make_pair(n, true));
+  SymbolTableSectionMap.emplace(n, true);
 
   return false;
 }

--- a/media_softlet/agnostic/common/vp/cm_fc_ld/PatchInfoRecord.h
+++ b/media_softlet/agnostic/common/vp/cm_fc_ld/PatchInfoRecord.h
@@ -510,7 +510,7 @@ public:
       return I->second;
     Symbols.push_back(Symbol(Name, 0, nullptr, 0));
     Symbol *S = &Symbols.back();
-    SymbolMap.insert(std::make_pair(Name, S));
+    SymbolMap.emplace(Name, S);
     return S;
   }
 

--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_hdr_resource_manager.cpp
+++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_hdr_resource_manager.cpp
@@ -88,7 +88,7 @@ MOS_STATUS VphdrResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std
         MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_RENDER));
 
     surfSetting.coeffAllocated = allocated;
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeHdrCoeff, m_hdrCoeff));
+    surfSetting.surfGroup.emplace(SurfaceTypeHdrCoeff, m_hdrCoeff);
 
     // Allocate auto mode CSC CCM Coeff Surface
     VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
@@ -106,7 +106,7 @@ MOS_STATUS VphdrResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std
         deferredDestroyed,
         MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_RENDER));
 
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeHdrAutoModeCoeff, m_hdrAutoModeCoeffSurface));
+    surfSetting.surfGroup.emplace(SurfaceTypeHdrAutoModeCoeff, m_hdrAutoModeCoeffSurface);
 
     // Allocate auto mode iir temp Surface
     dwWidth  = VPHAL_HDR_AUTO_MODE_IIR_TEMP_SIZE;
@@ -127,7 +127,7 @@ MOS_STATUS VphdrResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std
         deferredDestroyed,
         MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_RENDER));
 
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeHdrAutoModeIirTempSurface, m_hdrAutoModeIirTempSurface));
+    surfSetting.surfGroup.emplace(SurfaceTypeHdrAutoModeIirTempSurface, m_hdrAutoModeIirTempSurface);
 
     // Allocate OETF 1D LUT Surface
     dwWidth  = VPHAL_HDR_OETF_1DLUT_WIDTH;
@@ -136,7 +136,7 @@ MOS_STATUS VphdrResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std
     size_t cnt = MOS_MIN(inputSurfaces.size(), VPHAL_MAX_HDR_INPUT_LAYER);
     for (size_t i = 0; i < cnt; ++i)
     {
-        surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeHdrInputLayer0 + i), inputSurfaces[i]));
+        surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeHdrInputLayer0 + i), inputSurfaces[i]);
 
         SwFilterHdr    *hdr    = dynamic_cast<SwFilterHdr *>(executedFilters.GetSwFilter(true, i, FeatureType::FeatureTypeHdrOnRender));
         FeatureParamHdr params = {};
@@ -170,7 +170,7 @@ MOS_STATUS VphdrResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std
                 MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_RENDER));
 
         surfSetting.OETF1DLUTAllocated = allocated;
-        surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeHdrOETF1DLUTSurface0 + i), m_hdrOETF1DLUTSurface[i]));
+        surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeHdrOETF1DLUTSurface0 + i), m_hdrOETF1DLUTSurface[i]);
     }
 
     dwWidth = dwHeight = dwDepth = VPHAL_HDR_CRI_3DLUT_SIZE;
@@ -208,10 +208,10 @@ MOS_STATUS VphdrResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std
              dwDepth));
 
          surfSetting.Cri3DLUTAllocated = allocated;
-         surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeHdrCRI3DLUTSurface0 + i), m_hdrCri3DLUTSurface[i]));
+         surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeHdrCRI3DLUTSurface0 + i), m_hdrCri3DLUTSurface[i]);
     }
 
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeHdrTarget0, outputSurface));
+    surfSetting.surfGroup.emplace(SurfaceTypeHdrTarget0, outputSurface);
     surfSetting.dumpPostSurface = false;
     reporting.GetFeatures().hdrMode = params.hdrMode;
 

--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
+++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
@@ -1035,7 +1035,7 @@ VP_SURFACE * VpResourceManager::GetCopyInstOfExtSurface(VP_SURFACE* surf)
     VP_SURFACE *surface = m_allocator.AllocateVpSurface(*surf);
     if (surface)
     {
-        m_tempSurface.insert(make_pair((uint64_t)surf, surface));
+        m_tempSurface.emplace((uint64_t)surf, surface);
     }
     else
     {
@@ -1067,13 +1067,13 @@ MOS_STATUS VpResourceManager::AssignFcResources(VP_EXECUTE_CAPS &caps, std::vect
             VP_PUBLIC_ASSERTMESSAGE("Temperal input only has 1 layer, do not support multi-layer case!");
             return MOS_STATUS_INVALID_PARAMETER;
         }
-        surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcInputLayer0), m_temperalInput));
+        surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeFcInputLayer0), m_temperalInput);
     }
     else
     {
         for (size_t i = 0; i < inputSurfaces.size(); ++i)
         {
-            surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcInputLayer0 + i), inputSurfaces[i]));
+            surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeFcInputLayer0 + i), inputSurfaces[i]);
 
             if (!resHint.isIScalingTypeNone)
             {
@@ -1091,11 +1091,11 @@ MOS_STATUS VpResourceManager::AssignFcResources(VP_EXECUTE_CAPS &caps, std::vect
                     VP_PUBLIC_NORMALMESSAGE("Interlaced scaling. 2nd field is part of the same frame.");
                 }
                 VP_PUBLIC_CHK_NULL_RETURN(surfField1Dual);
-                surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcInputLayer0Field1Dual + i), surfField1Dual));
+                surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeFcInputLayer0Field1Dual + i), surfField1Dual);
             }
         }
     }
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeFcTarget0, outputSurface));
+    surfSetting.surfGroup.emplace(SurfaceTypeFcTarget0, outputSurface);
 
     // Allocate auto CSC Coeff Surface
     VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
@@ -1116,7 +1116,7 @@ MOS_STATUS VpResourceManager::AssignFcResources(VP_EXECUTE_CAPS &caps, std::vect
         memTypeSurfVideoMem,
         VPP_INTER_RESOURCE_NOTLOCKABLE));
 
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeFcCscCoeff, m_cmfcCoeff));
+    surfSetting.surfGroup.emplace(SurfaceTypeFcCscCoeff, m_cmfcCoeff);
 
     //for decompreesion sync on interlace input of FC
     VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
@@ -1130,7 +1130,7 @@ MOS_STATUS VpResourceManager::AssignFcResources(VP_EXECUTE_CAPS &caps, std::vect
         false,
         MOS_MMC_DISABLED,
         allocated));
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeDecompressionSync, m_decompressionSyncSurface));
+    surfSetting.surfGroup.emplace(SurfaceTypeDecompressionSync, m_decompressionSyncSurface);
 
     if (m_vpUserFeatureControl && m_vpUserFeatureControl->EnableOclFC())
     {
@@ -1266,7 +1266,7 @@ MOS_STATUS VpResourceManager::AssignFcResources(VP_EXECUTE_CAPS &caps, std::vect
                 m_fcIntermediaSurfaceOutput->rcSrc      = outputSurface->rcSrc;
                 m_fcIntermediaSurfaceOutput->rcDst      = outputSurface->rcDst;
                 m_fcIntermediaSurfaceOutput->SampleType = outputSurface->SampleType;
-                surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcIntermediaOutput), m_fcIntermediaSurfaceOutput));
+            surfSetting.surfGroup.emplace((SurfaceType)(SurfaceTypeFcIntermediaOutput), m_fcIntermediaSurfaceOutput);
             }
         }
     }
@@ -1415,7 +1415,7 @@ MOS_STATUS VpResourceManager::AssignRenderResource(VP_EXECUTE_CAPS &caps, std::v
         {
             VP_PUBLIC_CHK_STATUS_RETURN(MOS_STATUS_INVALID_PARAMETER);
         }
-        surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeRenderInput, inputSurfaces[0]));
+        surfSetting.surfGroup.emplace(SurfaceTypeRenderInput, inputSurfaces[0]);
         VP_PUBLIC_CHK_STATUS_RETURN(AssignVeboxResourceForRender(caps, inputSurfaces[0], resHint, surfSetting));
     }
     return MOS_STATUS_SUCCESS;
@@ -2335,8 +2335,8 @@ MOS_STATUS VpResourceManager::Assign3DLutKernelResource(VP_EXECUTE_CAPS &caps, R
 
     VP_PUBLIC_CHK_STATUS_RETURN(AllocateResourceFor3DLutKernel(caps));
 
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceType3DLut, m_vebox3DLookUpTables));
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceType3DLutCoef, m_3DLutKernelCoefSurface));
+    surfSetting.surfGroup.emplace(SurfaceType3DLut, m_vebox3DLookUpTables);
+    surfSetting.surfGroup.emplace(SurfaceType3DLutCoef, m_3DLutKernelCoefSurface);
 
     return MOS_STATUS_SUCCESS;
 }
@@ -2372,7 +2372,7 @@ MOS_STATUS VpResourceManager::AssignHVSKernelResource(VP_EXECUTE_CAPS &caps, RES
 
     VP_PUBLIC_CHK_STATUS_RETURN(AllocateResourceForHVSKernel(caps));
 
-    surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeHVSTable, m_veboxDnHVSTables));
+    surfSetting.surfGroup.emplace(SurfaceTypeHVSTable, m_veboxDnHVSTables);
 
     return MOS_STATUS_SUCCESS;
 }
@@ -2389,7 +2389,7 @@ MOS_STATUS VpResourceManager::AssignSurface(VP_EXECUTE_CAPS caps, VEBOX_SURFACE_
             VP_PUBLIC_ASSERTMESSAGE("inputSurface should not be nullptr when surfaceId being VEBOX_SURFACE_INPUT.");
             break;
         }
-        surfGroup.insert(std::make_pair(surfaceType, inputSurface));
+        surfGroup.emplace(surfaceType, inputSurface);
         break;
     case VEBOX_SURFACE_OUTPUT:
         if (nullptr == outputSurface)
@@ -2397,12 +2397,12 @@ MOS_STATUS VpResourceManager::AssignSurface(VP_EXECUTE_CAPS caps, VEBOX_SURFACE_
             VP_PUBLIC_ASSERTMESSAGE("outputSurface should not be nullptr when surfaceId being VEBOX_SURFACE_OUTPUT.");
             break;
         }
-        surfGroup.insert(std::make_pair(surfaceType, outputSurface));
+        surfGroup.emplace(surfaceType, outputSurface);
         break;
     case VEBOX_SURFACE_PAST_REF:
         if (caps.bDN && m_pastDnOutputValid)
         {
-            surfGroup.insert(std::make_pair(surfaceType, m_veboxDenoiseOutput[(m_currentDnOutput + 1) & 1]));
+            surfGroup.emplace(surfaceType, m_veboxDenoiseOutput[(m_currentDnOutput + 1) & 1]);
         }
         else
         {
@@ -2423,7 +2423,7 @@ MOS_STATUS VpResourceManager::AssignSurface(VP_EXECUTE_CAPS caps, VEBOX_SURFACE_
                 // state is for both of them. Check pitch to handle it.
                 pastSurface->osSurface->dwPitch == curDnOutputSurface->osSurface->dwPitch)
             {
-                surfGroup.insert(std::make_pair(surfaceType, pastSurface));
+                surfGroup.emplace(surfaceType, pastSurface);
             }
             else
             {
@@ -2443,19 +2443,19 @@ MOS_STATUS VpResourceManager::AssignSurface(VP_EXECUTE_CAPS caps, VEBOX_SURFACE_
             VP_PUBLIC_ASSERTMESSAGE("futureSurface should not be nullptr when surfaceId being VEBOX_SURFACE_FUTURE_REF.");
             break;
         }
-        surfGroup.insert(std::make_pair(surfaceType, futureSurface));
+        surfGroup.emplace(surfaceType, futureSurface);
         break;
     case VEBOX_SURFACE_FRAME0:
-        surfGroup.insert(std::make_pair(surfaceType, m_veboxOutput[(m_currentDnOutput + 0) % m_veboxOutputCount]));
+        surfGroup.emplace(surfaceType, m_veboxOutput[(m_currentDnOutput + 0) % m_veboxOutputCount]);
         break;
     case VEBOX_SURFACE_FRAME1:
-        surfGroup.insert(std::make_pair(surfaceType, m_veboxOutput[(m_currentDnOutput + 1) % m_veboxOutputCount]));
+        surfGroup.emplace(surfaceType, m_veboxOutput[(m_currentDnOutput + 1) % m_veboxOutputCount]);
         break;
     case VEBOX_SURFACE_FRAME2:
-        surfGroup.insert(std::make_pair(surfaceType, m_veboxOutput[(m_currentDnOutput + 2) % m_veboxOutputCount]));
+        surfGroup.emplace(surfaceType, m_veboxOutput[(m_currentDnOutput + 2) % m_veboxOutputCount]);
         break;
     case VEBOX_SURFACE_FRAME3:
-        surfGroup.insert(std::make_pair(surfaceType, m_veboxOutput[(m_currentDnOutput + 3) % m_veboxOutputCount]));
+        surfGroup.emplace(surfaceType, m_veboxOutput[(m_currentDnOutput + 3) % m_veboxOutputCount]);
         break;
     default:
         break;
@@ -2515,24 +2515,24 @@ MOS_STATUS VpResourceManager::AssignVeboxResource(VP_EXECUTE_CAPS& caps, VP_SURF
         if (caps.bDN)
         {
             // Insert DN output surface
-            surfGroup.insert(std::make_pair(SurfaceTypeDNOutput, m_veboxDenoiseOutput[m_currentDnOutput]));
+            surfGroup.emplace(SurfaceTypeDNOutput, m_veboxDenoiseOutput[m_currentDnOutput]);
         }
 
         caps.bRefValid = surfGroup.find(SurfaceTypeVeboxPreviousInput) != surfGroup.end();
     }
     else
     {
-        surfGroup.insert(std::make_pair(SurfaceTypeVeboxInput, inputSurface));
-        surfGroup.insert(std::make_pair(SurfaceTypeVeboxCurrentOutput, GetVeboxOutputSurface(caps, outputSurface)));
+        surfGroup.emplace(SurfaceTypeVeboxInput, inputSurface);
+        surfGroup.emplace(SurfaceTypeVeboxCurrentOutput, GetVeboxOutputSurface(caps, outputSurface));
 
         if (caps.bDN)
         {
             // Insert DN output surface
-            surfGroup.insert(std::make_pair(SurfaceTypeDNOutput, m_veboxDenoiseOutput[m_currentDnOutput]));
+            surfGroup.emplace(SurfaceTypeDNOutput, m_veboxDenoiseOutput[m_currentDnOutput]);
             // Insert DN Reference surface
             if (caps.bRefValid)
             {
-                surfGroup.insert(std::make_pair(SurfaceTypeVeboxPreviousInput, m_veboxDenoiseOutput[(m_currentDnOutput + 1) & 1]));
+                surfGroup.emplace(SurfaceTypeVeboxPreviousInput, m_veboxDenoiseOutput[(m_currentDnOutput + 1) & 1]);
             }
         }
     }
@@ -2540,32 +2540,32 @@ MOS_STATUS VpResourceManager::AssignVeboxResource(VP_EXECUTE_CAPS& caps, VP_SURF
     if (VeboxSTMMNeeded(caps, true))
     {
         // Insert STMM input surface
-        surfGroup.insert(std::make_pair(SurfaceTypeSTMMIn, m_veboxSTMMSurface[m_currentStmmIndex]));
+        surfGroup.emplace(SurfaceTypeSTMMIn, m_veboxSTMMSurface[m_currentStmmIndex]);
         // Insert STMM output surface
-        surfGroup.insert(std::make_pair(SurfaceTypeSTMMOut, m_veboxSTMMSurface[(m_currentStmmIndex + 1) & 1]));
+        surfGroup.emplace(SurfaceTypeSTMMOut, m_veboxSTMMSurface[(m_currentStmmIndex + 1) & 1]);
     }
 
 #if VEBOX_AUTO_DENOISE_SUPPORTED
     if (caps.bDnKernelUpdate)
     {
         // Insert Vebox auto DN noise level surface
-        surfGroup.insert(std::make_pair(SurfaceTypeAutoDNNoiseLevel, m_veboxDNTempSurface));
+        surfGroup.emplace(SurfaceTypeAutoDNNoiseLevel, m_veboxDNTempSurface);
         // Insert Vebox auto DN spatial config surface/buffer
-        surfGroup.insert(std::make_pair(SurfaceTypeAutoDNSpatialConfig, m_veboxDNSpatialConfigSurface));
+        surfGroup.emplace(SurfaceTypeAutoDNSpatialConfig, m_veboxDNSpatialConfigSurface);
     }
 #endif
 
     // Insert Vebox histogram surface
-    surfGroup.insert(std::make_pair(SurfaceTypeLaceAceRGBHistogram, m_veboxRgbHistogram));
+    surfGroup.emplace(SurfaceTypeLaceAceRGBHistogram, m_veboxRgbHistogram);
 
     // Insert Vebox statistics surface
     if (caps.b1stPassOfSfc2PassScaling)
     {
-        surfGroup.insert(std::make_pair(SurfaceTypeStatistics, m_veboxStatisticsSurfacefor1stPassofSfc2Pass));
+        surfGroup.emplace(SurfaceTypeStatistics, m_veboxStatisticsSurfacefor1stPassofSfc2Pass);
     }
     else
     {
-        surfGroup.insert(std::make_pair(SurfaceTypeStatistics, m_veboxStatisticsSurface));
+        surfGroup.emplace(SurfaceTypeStatistics, m_veboxStatisticsSurface);
     }
     surfSetting.dwVeboxPerBlockStatisticsHeight = m_dwVeboxPerBlockStatisticsHeight;
     surfSetting.dwVeboxPerBlockStatisticsWidth  = m_dwVeboxPerBlockStatisticsWidth;
@@ -2573,25 +2573,25 @@ MOS_STATUS VpResourceManager::AssignVeboxResource(VP_EXECUTE_CAPS& caps, VP_SURF
     if (VeboxHdr3DlutNeeded(caps))
     {
         // Insert Vebox 3Dlut surface
-        surfGroup.insert(std::make_pair(SurfaceType3DLut, m_vebox3DLookUpTables));
+        surfGroup.emplace(SurfaceType3DLut, m_vebox3DLookUpTables);
     }
 
     if (resHint.isHVSTableNeeded)
     {
         VP_PUBLIC_CHK_NULL_RETURN(m_veboxDnHVSTables);
         // Insert Vebox HVS DN surface
-        surfGroup.insert(std::make_pair(SurfaceTypeHVSTable, m_veboxDnHVSTables));
+        surfGroup.emplace(SurfaceTypeHVSTable, m_veboxDnHVSTables);
     }
 
     if (caps.b1K1DLutInUse)
     {
         // Insert DV 1Dlut surface
-        surfGroup.insert(std::make_pair(SurfaceType1k1dLut, m_vebox1DLookUpTables));
+        surfGroup.emplace(SurfaceType1k1dLut, m_vebox1DLookUpTables);
     }
 
     if (caps.enableSFCLinearOutputByTileConvert)
     {
-        surfGroup.insert(std::make_pair(SurfaceTypeInnerTileConvertInput, m_innerTileConvertInput));
+        surfGroup.emplace(SurfaceTypeInnerTileConvertInput, m_innerTileConvertInput);
     }
 
     // Update previous Dn output flag for next frame to use.

--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.h
+++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.h
@@ -468,7 +468,7 @@ protected:
     void AddSurfaceConfig(bool _b64DI, bool _sfcEnable, bool _sameSample, bool _outOfBound, bool _pastRefAvailable, bool _futureRefAvailable, bool _firstDiField,
         VEBOX_SURFACE_ID _currentInputSurface, VEBOX_SURFACE_ID _pastInputSurface, VEBOX_SURFACE_ID _currentOutputSurface, VEBOX_SURFACE_ID _pastOutputSurface)
     {
-        m_veboxSurfaceConfigMap.insert(std::make_pair(VEBOX_SURFACES_CONFIG(_b64DI, _sfcEnable, _sameSample, _outOfBound, _pastRefAvailable, _futureRefAvailable, _firstDiField).value, VEBOX_SURFACES(_currentInputSurface, _pastInputSurface, _currentOutputSurface, _pastOutputSurface)));
+        m_veboxSurfaceConfigMap.emplace(VEBOX_SURFACES_CONFIG(_b64DI, _sfcEnable, _sameSample, _outOfBound, _pastRefAvailable, _futureRefAvailable, _firstDiField).value, VEBOX_SURFACES(_currentInputSurface, _pastInputSurface, _currentOutputSurface, _pastOutputSurface));
     }
 
     virtual MOS_STATUS GetIntermediaColorAndFormat3DLutOutput(VPHAL_CSPACE &colorSpace, MOS_FORMAT &format, SwFilterPipe &executedFilters);

--- a/media_softlet/agnostic/common/vp/hal/feature_manager/policy.cpp
+++ b/media_softlet/agnostic/common/vp/hal/feature_manager/policy.cpp
@@ -157,69 +157,69 @@ MOS_STATUS Policy::RegisterFeatures()
     // Vebox/Sfc features.
     PolicyFeatureHandler *p = MOS_New(PolicySfcCscHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeCscOnSfc, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeCscOnSfc, p);
 
     p = MOS_New(PolicySfcRotMirHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeRotMirOnSfc, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeRotMirOnSfc, p);
 
     p = MOS_New(PolicySfcScalingHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeScalingOnSfc, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeScalingOnSfc, p);
 
     p = MOS_New(PolicyVeboxDnHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeDnOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeDnOnVebox, p);
 
     p = MOS_New(PolicyRenderDnHVSCalHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeDnHVSCalOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeDnHVSCalOnRender, p);
 
     p = MOS_New(PolicyVeboxCscHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeCscOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeCscOnVebox, p);
 
     p = MOS_New(PolicyVeboxSteHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeSteOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeSteOnVebox, p);
 
     p = MOS_New(PolicyVeboxTccHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeTccOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeTccOnVebox, p);
 
     p = MOS_New(PolicyVeboxProcampHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeProcampOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeProcampOnVebox, p);
 
     p = MOS_New(PolicyVeboxHdrHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeHdrOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeHdrOnVebox, p);
 
     p = MOS_New(PolicyRenderHdr3DLutCalHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeHdr3DLutCalOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeHdr3DLutCalOnRender, p);
 
     p = MOS_New(PolicyRenderHdrHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeHdrOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeHdrOnRender, p);
 
     p = MOS_New(PolicyDiHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeDiOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeDiOnVebox, p);
 
     p = MOS_New(PolicySfcColorFillHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeColorFillOnSfc, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeColorFillOnSfc, p);
 
     p = MOS_New(PolicySfcAlphaHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeAlphaOnSfc, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeAlphaOnSfc, p);
 
     VP_PUBLIC_CHK_STATUS_RETURN(RegisterFcFeatures());
 
     p = MOS_New(PolicyVeboxCgcHandler, m_hwCaps);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_VeboxSfcFeatureHandlers.insert(std::make_pair(FeatureTypeCgcOnVebox, p));
+    m_VeboxSfcFeatureHandlers.emplace(FeatureTypeCgcOnVebox, p);
 
     p = MOS_New(PolicyAiHandler, m_hwCaps, m_vpInterface.GetGraphManager());
     VP_PUBLIC_CHK_NULL_RETURN(p);
@@ -289,43 +289,43 @@ MOS_STATUS Policy::RegisterFcFeatures()
     //In the future, after all caps formats added for OCL FC, the wrapper will be removed and only register specific OCL/Legacy FC handler
     PolicyFeatureHandler *p = MOS_New(PolicyFcWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeFcOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeFcOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeLumakeyOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeLumakeyOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeBlendingOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeBlendingOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeColorFillOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeColorFillOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeAlphaOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeAlphaOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeCscOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeCscOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeScalingOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeScalingOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeRotMirOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeRotMirOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeDiOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeDiOnRender, p);
 
     p = MOS_New(PolicyFcFeatureWrapHandler, m_hwCaps, enableOclFC);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_RenderFeatureHandlers.insert(std::make_pair(FeatureTypeProcampOnRender, p));
+    m_RenderFeatureHandlers.emplace(FeatureTypeProcampOnRender, p);
 
 #if (_DEBUG || _RELEASE_INTERNAL)
     VpFeatureReport *vpFeatureReport = m_vpInterface.GetHwInterface()->m_reporting;

--- a/media_softlet/agnostic/common/vp/hal/feature_manager/sw_filter.cpp
+++ b/media_softlet/agnostic/common/vp/hal/feature_manager/sw_filter.cpp
@@ -2369,7 +2369,7 @@ MOS_STATUS SwFilterSet::AddSwFilter(SwFilter *swFilter)
         VP_PUBLIC_ASSERTMESSAGE("Invalid parameter! SwFilter for feature %d has already been exists in swFilterSet!", swFilter->GetFeatureType());
         return MOS_STATUS_INVALID_PARAMETER;
     }
-    m_swFilters.insert(std::make_pair(swFilter->GetFeatureType(), swFilter));
+    m_swFilters.emplace(swFilter->GetFeatureType(), swFilter);
     swFilter->SetLocation(this);
     return MOS_STATUS_SUCCESS;
 }

--- a/media_softlet/agnostic/common/vp/hal/feature_manager/sw_filter_pipe.cpp
+++ b/media_softlet/agnostic/common/vp/hal/feature_manager/sw_filter_pipe.cpp
@@ -1062,7 +1062,7 @@ MOS_STATUS RemoveUnusedLayers(std::vector<uint32_t> &indexForRemove, std::vector
             {
                 VP_PUBLIC_CHK_STATUS_RETURN(MOS_STATUS_INVALID_PARAMETER);
             }
-            objForRemove.insert(std::make_pair(layers[index], layers[index]));
+            objForRemove.emplace(layers[index], layers[index]);
             layers[index] = nullptr;
         }
         for (auto it : objForRemove)

--- a/media_softlet/agnostic/common/vp/hal/feature_manager/vp_feature_manager.cpp
+++ b/media_softlet/agnostic/common/vp/hal/feature_manager/vp_feature_manager.cpp
@@ -138,59 +138,59 @@ MOS_STATUS VpFeatureManagerNext::RegisterFeatures()
     // Vebox/Sfc features.
     SwFilterFeatureHandler *p = MOS_New(SwFilterCscHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeCsc, p));
+    m_featureHandler.emplace(FeatureTypeCsc, p);
 
     p = MOS_New(SwFilterRotMirHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeRotMir, p));
+    m_featureHandler.emplace(FeatureTypeRotMir, p);
 
     p = MOS_New(SwFilterScalingHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeScaling, p));
+    m_featureHandler.emplace(FeatureTypeScaling, p);
 
     p = MOS_New(SwFilterDnHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeDn, p));
+    m_featureHandler.emplace(FeatureTypeDn, p);
 
     p = MOS_New(SwFilterSteHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeSte, p));
+    m_featureHandler.emplace(FeatureTypeSte, p);
 
     p = MOS_New(SwFilterTccHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeTcc, p));
+    m_featureHandler.emplace(FeatureTypeTcc, p);
 
     p = MOS_New(SwFilterProcampHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeProcamp, p));
+    m_featureHandler.emplace(FeatureTypeProcamp, p);
 
     p = MOS_New(SwFilterHdrHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeHdr, p));
+    m_featureHandler.emplace(FeatureTypeHdr, p);
 
     p = MOS_New(SwFilterDiHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeDi, p));
+    m_featureHandler.emplace(FeatureTypeDi, p);
 
     p = MOS_New(SwFilterLumakeyHandler, m_vpInterface, FeatureTypeLumakey);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeLumakey, p));
+    m_featureHandler.emplace(FeatureTypeLumakey, p);
 
     p = MOS_New(SwFilterBlendingHandler, m_vpInterface, FeatureTypeBlending);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeBlending, p));
+    m_featureHandler.emplace(FeatureTypeBlending, p);
 
     p = MOS_New(SwFilterColorFillHandler, m_vpInterface, FeatureTypeColorFill);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeColorFill, p));
+    m_featureHandler.emplace(FeatureTypeColorFill, p);
 
     p = MOS_New(SwFilterAlphaHandler, m_vpInterface, FeatureTypeAlpha);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeAlpha, p));
+    m_featureHandler.emplace(FeatureTypeAlpha, p);
 
     p = MOS_New(SwFilterCgcHandler, m_vpInterface);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_featureHandler.insert(std::make_pair(FeatureTypeCgc, p));
+    m_featureHandler.emplace(FeatureTypeCgc, p);
 
     m_isFeatureRegistered = true;
     return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/vp/hal/feature_manager/vp_kernelset.cpp
+++ b/media_softlet/agnostic/common/vp/hal/feature_manager/vp_kernelset.cpp
@@ -242,7 +242,7 @@ MOS_STATUS VpKernelSet::CreateKernelObjects(
 
             VP_RENDER_CHK_STATUS_RETURN(VpStatusHandler(kernel->InitKernel(binary, kernelSize, kernelConfigs, surfacesGroup, surfMemCacheCtl)));
 
-            kernelObjs.insert(std::make_pair(kernelIndex, kernel));
+            kernelObjs.emplace(kernelIndex, kernel);
         }
         else
         {
@@ -250,7 +250,7 @@ MOS_STATUS VpKernelSet::CreateKernelObjects(
 
             VP_RENDER_CHK_STATUS_RETURN(VpStatusHandler(kernel->SetKernelConfigs(kernelParams[kernelIndex], surfacesGroup, samplerStateGroup, kernelConfigs, sharedContext)));
 
-            kernelObjs.insert(std::make_pair(kernelIndex, kernel));
+            kernelObjs.emplace(kernelIndex, kernel);
         }
     }
 

--- a/media_softlet/agnostic/common/vp/hal/features/vp_ocl_fc_filter.cpp
+++ b/media_softlet/agnostic/common/vp/hal/features/vp_ocl_fc_filter.cpp
@@ -354,7 +354,7 @@ MOS_STATUS VpOclFcFilter::GenerateFc420PL3InputParam(OCL_FC_LAYER_PARAM &inputLa
         VP_PUBLIC_CHK_STATUS_RETURN(SetupSingleFc420PL3InputBti(uIndex, index, surfaceParam, bInit));
         if (bInit)
         {
-            krnStatefulSurfaces.insert(std::make_pair(uIndex, surfaceParam));
+            krnStatefulSurfaces.emplace(uIndex, surfaceParam);
         }
     }
     param.kernelArgs             = krnArgs;
@@ -656,7 +656,7 @@ MOS_STATUS VpOclFcFilter::GenerateFc444PL3OutputParam(OCL_FC_LAYER_PARAM &output
         if (argHandle == m_fc444PL3OutputKrnArgs.end())
         {
             KRN_ARG krnArg = {};
-            argHandle      = m_fc444PL3OutputKrnArgs.insert(std::make_pair(uIndex, krnArg)).first;
+            argHandle      = m_fc444PL3OutputKrnArgs.emplace(uIndex, krnArg).first;
             VP_PUBLIC_CHK_NOT_FOUND_RETURN(argHandle, &m_fc444PL3OutputKrnArgs);
         }
         KRN_ARG &krnArg = argHandle->second;
@@ -691,7 +691,7 @@ MOS_STATUS VpOclFcFilter::GenerateFc444PL3OutputParam(OCL_FC_LAYER_PARAM &output
         VP_PUBLIC_CHK_STATUS_RETURN(SetupSingleFc444PL3OutputBti(uIndex, surfaceParam, bInit));
         if (bInit)
         {
-            krnStatefulSurfaces.insert(std::make_pair(uIndex, surfaceParam));
+            krnStatefulSurfaces.emplace(uIndex, surfaceParam);
         }
     }
     param.kernelArgs             = krnArgs;
@@ -786,7 +786,7 @@ MOS_STATUS VpOclFcFilter::GenerateFc444PL3InputParam(OCL_FC_LAYER_PARAM &layer, 
     if (argLayerHandle == m_fc444PL3InputMultiLayersKrnArgs.end())
     {
         KERNEL_INDEX_ARG_MAP fc444PL3InputSingleLayerKrnArgs = {};
-        argLayerHandle                                       = m_fc444PL3InputMultiLayersKrnArgs.insert(std::make_pair(layerIndex, fc444PL3InputSingleLayerKrnArgs)).first;
+        argLayerHandle                                       = m_fc444PL3InputMultiLayersKrnArgs.emplace(layerIndex, fc444PL3InputSingleLayerKrnArgs).first;
         VP_PUBLIC_CHK_NOT_FOUND_RETURN(argLayerHandle, &m_fc444PL3InputMultiLayersKrnArgs);
     }
     KERNEL_INDEX_ARG_MAP &fc444PL3InputKrnArgs = argLayerHandle->second;
@@ -798,7 +798,7 @@ MOS_STATUS VpOclFcFilter::GenerateFc444PL3InputParam(OCL_FC_LAYER_PARAM &layer, 
         if (argHandle == fc444PL3InputKrnArgs.end())
         {
             KRN_ARG krnArg = {};
-            argHandle      = fc444PL3InputKrnArgs.insert(std::make_pair(uIndex, krnArg)).first;
+            argHandle      = fc444PL3InputKrnArgs.emplace(uIndex, krnArg).first;
             VP_PUBLIC_CHK_NOT_FOUND_RETURN(argHandle, &fc444PL3InputKrnArgs);
         }
         KRN_ARG &krnArg = argHandle->second;
@@ -837,7 +837,7 @@ MOS_STATUS VpOclFcFilter::GenerateFc444PL3InputParam(OCL_FC_LAYER_PARAM &layer, 
 
         if (bInit)
         {
-            krnStatefulSurfaces.insert(std::make_pair(uIndex, surfaceParam));
+            krnStatefulSurfaces.emplace(uIndex, surfaceParam);
         }
     }
 
@@ -986,7 +986,7 @@ MOS_STATUS VpOclFcFilter::GenerateFcCommonKrnParam(OCL_FC_COMP_PARAM &compParam,
 
         if (bInit)
         {
-            krnStatefulSurfaces.insert(std::make_pair(uIndex, surfaceParam));
+            krnStatefulSurfaces.emplace(uIndex, surfaceParam);
         }
     }
 
@@ -2922,7 +2922,7 @@ MOS_STATUS VpOclFcFilter::GenerateFcFastExpressKrnParam(OCL_FC_COMP_PARAM &compP
 
         if (bInit)
         {
-            krnStatefulSurfaces.insert(std::make_pair(uIndex, surfaceParam));
+            krnStatefulSurfaces.emplace(uIndex, surfaceParam);
         }
     }
 

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_cmd_packet.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_cmd_packet.cpp
@@ -266,7 +266,7 @@ MOS_STATUS VpRenderCmdPacket::Prepare()
                 m_renderData.iInlineLength,
                 m_renderData.scoreboardParams));
 
-            m_kernelRenderData.insert(std::make_pair(it->first, m_renderData));
+            m_kernelRenderData.emplace(it->first, m_renderData);
         }
     }
     else if (m_submissionMode == MULTI_KERNELS_SINGLE_MEDIA_STATE)
@@ -335,7 +335,7 @@ MOS_STATUS VpRenderCmdPacket::Prepare()
 
             VP_RENDER_CHK_STATUS_RETURN(SetupWalkerParams());
 
-            m_kernelRenderData.insert(std::make_pair(it->first, m_renderData));
+            m_kernelRenderData.emplace(it->first, m_renderData);
         }
 
         VP_RENDER_CHK_STATUS_RETURN(m_renderHal->pfnSetVfeStateParams(
@@ -2069,7 +2069,7 @@ MOS_STATUS VpRenderCmdPacket::SetFcParams(PRENDER_FC_PARAMS params)
     VP_FUNC_CALL();
     VP_RENDER_CHK_NULL_RETURN(params);
 
-    m_kernelConfigs.insert(std::make_pair(params->kernelId, (void *)params));
+    m_kernelConfigs.emplace(params->kernelId, (void *)params);
 
     KERNEL_PARAMS kernelParams = {};
     kernelParams.kernelId      = params->kernelId;
@@ -2101,7 +2101,7 @@ MOS_STATUS VpRenderCmdPacket::SetOclFcParams(PRENDER_OCL_FC_PARAMS params)
 
         m_renderKernelParams.push_back(kernelParam);
 
-        m_kernelConfigs.insert(std::make_pair(krnParams.kernelId, (void *)(&krnParams.kernelConfig)));
+        m_kernelConfigs.emplace(krnParams.kernelId, (void *)(&krnParams.kernelConfig));
     }
 
     m_submissionMode            = MULTI_KERNELS_SINGLE_MEDIA_STATE;
@@ -2144,7 +2144,7 @@ MOS_STATUS VpRenderCmdPacket::SetHdr3DLutParams(
     VP_FUNC_CALL();
     VP_RENDER_CHK_NULL_RETURN(params);
 
-    m_kernelConfigs.insert(std::make_pair(params->kernelId, (void *)params));
+    m_kernelConfigs.emplace(params->kernelId, (void *)params);
 
     KERNEL_PARAMS kernelParams = {};
     kernelParams.kernelId = params->kernelId;
@@ -2187,7 +2187,7 @@ MOS_STATUS VpRenderCmdPacket::SetDnHVSParams(
     VP_FUNC_CALL();
     VP_RENDER_CHK_NULL_RETURN(params);
 
-    m_kernelConfigs.insert(std::make_pair(params->kernelId, (void *)params));
+    m_kernelConfigs.emplace(params->kernelId, (void *)params);
 
     KERNEL_PARAMS kernelParams = {};
     kernelParams.kernelId      = params->kernelId;
@@ -2249,10 +2249,10 @@ MOS_STATUS VpRenderCmdPacket::SetHdrParams(PRENDER_HDR_PARAMS params)
         default:
             break;
         }
-        m_kernelSamplerStateGroup.insert(std::make_pair(i, samplerStateParam));
+        m_kernelSamplerStateGroup.emplace(i, samplerStateParam);
     }
 
-    m_kernelConfigs.insert(std::make_pair(params->kernelId, (void *)params));
+    m_kernelConfigs.emplace(params->kernelId, (void *)params);
 
     kernelParams.kernelId                  = params->kernelId;
     kernelParams.kernelThreadSpace.uWidth  = params->threadWidth;

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_fc_kernel.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_fc_kernel.cpp
@@ -316,7 +316,7 @@ MOS_STATUS VpRenderFcKernel::SetupSurfaceState()
                                     m_surfMemCacheCtl.PrimaryInputSurfMemObjCtl :
                                     m_surfMemCacheCtl.InputSurfMemObjCtl;
 
-        m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeFcInputLayer0 + layer->layerID), surfParam));
+        m_surfaceState.emplace(SurfaceType(SurfaceTypeFcInputLayer0 + layer->layerID), surfParam);
 
         //update render GMM resource usage type
         m_allocator->UpdateResourceUsageType(&layer->surf->osSurface->OsResource, MOS_HW_RESOURCE_USAGE_VP_INPUT_PICTURE_RENDER);
@@ -332,7 +332,7 @@ MOS_STATUS VpRenderFcKernel::SetupSurfaceState()
             }
 
             UpdateCurbeBindingIndex(SurfaceType(SurfaceTypeFcInputLayer0Field1Dual + layer->layerID), s_bindingTableIndexField[layer->layerID]);
-            m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeFcInputLayer0Field1Dual + layer->layerID), surfParamField));
+            m_surfaceState.emplace(SurfaceType(SurfaceTypeFcInputLayer0Field1Dual + layer->layerID), surfParamField);
 
             //update render GMM resource usage type
             m_allocator->UpdateResourceUsageType(&layer->surfField->osSurface->OsResource, MOS_HW_RESOURCE_USAGE_VP_INPUT_PICTURE_RENDER);
@@ -380,7 +380,7 @@ MOS_STATUS VpRenderFcKernel::SetupSurfaceState()
 
         surfParam.surfaceOverwriteParams.renderSurfaceParams.MemObjCtl = m_surfMemCacheCtl.TargetSurfMemObjCtl;
 
-        m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeFcTarget0 + i), surfParam));
+        m_surfaceState.emplace(SurfaceType(SurfaceTypeFcTarget0 + i), surfParam);
 
         //update render GMM resource usage type
         m_allocator->UpdateResourceUsageType(&compParams.target[i].surf->osSurface->OsResource, MOS_HW_RESOURCE_USAGE_VP_OUTPUT_PICTURE_RENDER);
@@ -411,7 +411,7 @@ MOS_STATUS VpRenderFcKernel::SetupSurfaceState()
         surfParam.surfaceOverwriteParams.renderSurfaceParams.Boundary      = RENDERHAL_SS_BOUNDARY_ORIGINAL;
         surfParam.surfaceOverwriteParams.renderSurfaceParams.bWidth16Align = false;
         surfParam.surfaceOverwriteParams.renderSurfaceParams.MemObjCtl     = m_surfMemCacheCtl.InputSurfMemObjCtl;
-        m_surfaceState.insert(std::make_pair(SurfaceTypeFcCscCoeff, surfParam));
+        m_surfaceState.emplace(SurfaceTypeFcCscCoeff, surfParam);
     }
 
     return MOS_STATUS_SUCCESS;
@@ -2828,7 +2828,7 @@ MOS_STATUS VpRenderFcKernel::SetSamplerStates(KERNEL_SAMPLER_STATE_GROUP& sample
             samplerStateParam.Unorm.AddressV            = MHW_GFX3DSTATE_TEXCOORDMODE_CLAMP;
             samplerStateParam.Unorm.AddressW            = MHW_GFX3DSTATE_TEXCOORDMODE_CLAMP;
 
-            samplerStateGroup.insert(std::make_pair(samplerIndex, samplerStateParam));
+            samplerStateGroup.emplace(samplerIndex, samplerStateParam);
 
             VP_RENDER_NORMALMESSAGE("Scaling Info: layer %d, layerOrigin %d, entry %d, format %d, scalingMode %d, samplerType %d, samplerFilterMode %d, samplerIndex %d, yuvPlane %d",
                 layer.layerID, layer.layerIDOrigin, entryIndex, layer.surf->osSurface->Format, layer.scalingMode, samplerType, samplerStateParam.Unorm.SamplerFilterMode, samplerIndex, entry->YUVPlane);

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_fc_types.h
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_fc_types.h
@@ -1431,7 +1431,7 @@ public:
             p = m_idle.begin()->second;
             m_idle.erase(p);
         }
-        m_inuse.insert(std::make_pair(p, p));
+        m_inuse.emplace(p, p);
         return p;
     }
 
@@ -1442,7 +1442,7 @@ public:
             return;
         }
         m_inuse.erase(p);
-        m_idle.insert(std::make_pair(p, p));
+        m_idle.emplace(p, p);
     }
 
 private:

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_hdr_kernel.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_hdr_kernel.cpp
@@ -3433,7 +3433,7 @@ MOS_STATUS VpRenderHdrKernel::SetupSurfaceState()
 
         surfParam.surfaceOverwriteParams.renderSurfaceParams.MemObjCtl = m_surfMemCacheCtl.SourceSurfMemObjCtl;
 
-        m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeHdrInputLayer0 + i), surfParam));
+        m_surfaceState.emplace(SurfaceType(SurfaceTypeHdrInputLayer0 + i), surfParam);
 
         auto OETF1DLUT = m_surfaceGroup->find(SurfaceType(SurfaceTypeHdrOETF1DLUTSurface0 + i));
         VP_SURFACE *OETF1DLUTSrc = (m_surfaceGroup->end() != OETF1DLUT) ? OETF1DLUT->second : nullptr;
@@ -3468,7 +3468,7 @@ MOS_STATUS VpRenderHdrKernel::SetupSurfaceState()
         {
             surfaceResource.surfaceOverwriteParams.renderSurfaceParams.MemObjCtl                = m_surfMemCacheCtl.Lut2DSurfMemObjCtl;
             UpdateCurbeBindingIndex(SurfaceType(SurfaceTypeHdrOETF1DLUTSurface0 + i), iBTentry + VPHAL_HDR_BTINDEX_OETF1DLUT_OFFSET);
-            m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeHdrOETF1DLUTSurface0 + i), surfaceResource));
+            m_surfaceState.emplace(SurfaceType(SurfaceTypeHdrOETF1DLUTSurface0 + i), surfaceResource);
         }
         else if (m_hdrParams->LUTMode[i] == VPHAL_HDR_LUT_MODE_3D)
         {
@@ -3476,7 +3476,7 @@ MOS_STATUS VpRenderHdrKernel::SetupSurfaceState()
             UpdateCurbeBindingIndex(SurfaceType(SurfaceTypeHdrCRI3DLUTSurface0 + i), iBTentry + VPHAL_HDR_BTINDEX_CRI3DLUT_OFFSET);
             surfaceResource.surfaceOverwriteParams.renderSurfaceParams.bWidthInDword_Y          = false;
             surfaceResource.surfaceOverwriteParams.renderSurfaceParams.bWidthInDword_UV         = false;
-            m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeHdrCRI3DLUTSurface0 + i), surfaceResource));
+            m_surfaceState.emplace(SurfaceType(SurfaceTypeHdrCRI3DLUTSurface0 + i), surfaceResource);
         }
     }
 
@@ -3509,7 +3509,7 @@ MOS_STATUS VpRenderHdrKernel::SetupSurfaceState()
 
         surfParam.surfaceOverwriteParams.renderSurfaceParams.MemObjCtl = m_surfMemCacheCtl.TargetSurfMemObjCtl;
 
-        m_surfaceState.insert(std::make_pair(SurfaceType(SurfaceTypeHdrTarget0 + i), surfParam));
+        m_surfaceState.emplace(SurfaceType(SurfaceTypeHdrTarget0 + i), surfParam);
 
         //update render GMM resource usage type
         m_allocator->UpdateResourceUsageType(&layer->osSurface->OsResource, MOS_HW_RESOURCE_USAGE_VP_OUTPUT_PICTURE_RENDER);
@@ -3545,12 +3545,12 @@ MOS_STATUS VpRenderHdrKernel::SetupSurfaceState()
     if (m_hdrParams->bUsingAutoModePipe && bHasAutoModeLayer)
     {
         UpdateCurbeBindingIndex(SurfaceTypeHdrAutoModeCoeff, VPHAL_HDR_BTINDEX_COEFF);
-        m_surfaceState.insert(std::make_pair(SurfaceTypeHdrAutoModeCoeff, surfCoeffParam));
+        m_surfaceState.emplace(SurfaceTypeHdrAutoModeCoeff, surfCoeffParam);
     }
     else
     {
         UpdateCurbeBindingIndex(SurfaceTypeHdrCoeff, VPHAL_HDR_BTINDEX_COEFF);
-        m_surfaceState.insert(std::make_pair(SurfaceTypeHdrCoeff, surfCoeffParam));
+        m_surfaceState.emplace(SurfaceTypeHdrCoeff, surfCoeffParam);
     }
 
     return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.cpp
@@ -256,7 +256,7 @@ MOS_STATUS VpRenderKernelObj::SetupStatelessBufferResource(SurfaceType surf, boo
             &curSurf->osSurface->OsResource,
             isWrite,
             true));
-        m_statelessArray.insert(std::make_pair(surf, ui64GfxAddress));
+        m_statelessArray.emplace(surf, ui64GfxAddress);
     }
 
     return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.h
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.h
@@ -460,7 +460,7 @@ public:
         {
             std::set<uint32_t> bindingMap;
             bindingMap.insert(index);
-            m_surfaceBindingIndex.insert(std::make_pair(surface, bindingMap));
+            m_surfaceBindingIndex.emplace(surface, bindingMap);
         }
 
         return MOS_STATUS_SUCCESS;
@@ -474,7 +474,7 @@ public:
         {
             VP_RENDER_ASSERTMESSAGE("No surface index created for current surface");
             std::set<uint32_t> bindingMap;
-            it = m_surfaceBindingIndex.insert(std::make_pair(surface, bindingMap)).first;
+            it = m_surfaceBindingIndex.emplace(surface, bindingMap).first;
         }
         return it->second;
     }
@@ -533,7 +533,7 @@ public:
     {
         if (surf != SurfaceTypeInvalid)
         {
-            m_bindlessSurfaceArray.insert(std::make_pair(surf, surfStateOffset));
+            m_bindlessSurfaceArray.emplace(surf, surfStateOffset);
         }
 
         return MOS_STATUS_SUCCESS;

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_ocl_fc_kernel.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_ocl_fc_kernel.cpp
@@ -90,7 +90,7 @@ MOS_STATUS VpRenderOclFcKernel::Init(VpRenderKernel &kernel)
     for (auto &arg : kernel.GetKernelArgs())
     {
         arg.pData = nullptr;
-        m_kernelArgs.insert(std::make_pair(arg.uIndex,arg));
+        m_kernelArgs.emplace(arg.uIndex,arg);
     }
 
     m_kernelBtis = kernel.GetKernelBtis();
@@ -124,7 +124,7 @@ MOS_STATUS VpRenderOclFcKernel::SetSamplerStates(KERNEL_SAMPLER_STATE_GROUP &sam
         if (m_linearSamplerIndex >= 0)
         {
             VP_RENDER_NORMALMESSAGE("Bilinear Sampler Set on Sampler Index %d", m_linearSamplerIndex);
-            samplerStateGroup.insert(std::make_pair(m_linearSamplerIndex, samplerStateParam));
+            samplerStateGroup.emplace(m_linearSamplerIndex, samplerStateParam);
         }
         else
         {
@@ -143,7 +143,7 @@ MOS_STATUS VpRenderOclFcKernel::SetSamplerStates(KERNEL_SAMPLER_STATE_GROUP &sam
         if (m_nearestSamplerIndex >= 0)
         {
             VP_RENDER_NORMALMESSAGE("Nearest Sampler Set on Sampler Index %d", m_nearestSamplerIndex);
-            samplerStateGroup.insert(std::make_pair(m_nearestSamplerIndex, samplerStateParam));
+            samplerStateGroup.emplace(m_nearestSamplerIndex, samplerStateParam);
         }
         else
         {
@@ -361,7 +361,7 @@ MOS_STATUS VpRenderOclFcKernel::SetupSurfaceState()
             kernelSurfaceParam.surfaceOverwriteParams.bufferResource       = true;
         }
 
-        m_surfaceState.insert(std::make_pair(surfType, kernelSurfaceParam));
+        m_surfaceState.emplace(surfType, kernelSurfaceParam);
 
         UpdateCurbeBindingIndex(surfType, bti);
     }

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_vebox_hdr_3dlut_kernel.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_vebox_hdr_3dlut_kernel.cpp
@@ -249,10 +249,10 @@ MOS_STATUS VpRenderHdr3DLutKernel::SetupSurfaceState()
 
     UpdateCurbeBindingIndex(SurfaceType3DLut, BI_VEBOX_HDR_3DLUT_3DLUT);
     kernelSurfaceParam.isOutput                         = true;
-    m_surfaceState.insert(std::make_pair(SurfaceType3DLut, kernelSurfaceParam));
+    m_surfaceState.emplace(SurfaceType3DLut, kernelSurfaceParam);
     UpdateCurbeBindingIndex(SurfaceType3DLutCoef, BI_VEBOX_HDR_3DLUT_COEF);
     kernelSurfaceParam.isOutput                         = false;
-    m_surfaceState.insert(std::make_pair(SurfaceType3DLutCoef, kernelSurfaceParam));
+    m_surfaceState.emplace(SurfaceType3DLutCoef, kernelSurfaceParam);
 
     VP_RENDER_CHK_STATUS_RETURN(InitCoefSurface(m_maxDisplayLum, m_maxContentLevelLum, m_hdrMode));
 
@@ -593,10 +593,10 @@ MOS_STATUS VpRenderHdr3DLutKernelCM::SetupSurfaceState()
 
     UpdateCurbeBindingIndex(SurfaceType3DLut, BI_VEBOX_HDR_3DLUT_3DLUT_CM);
     kernelSurfaceParam.isOutput                         = true;
-    m_surfaceState.insert(std::make_pair(SurfaceType3DLut, kernelSurfaceParam));
+    m_surfaceState.emplace(SurfaceType3DLut, kernelSurfaceParam);
     UpdateCurbeBindingIndex(SurfaceType3DLutCoef, BI_VEBOX_HDR_3DLUT_COEF_CM);
     kernelSurfaceParam.isOutput                         = false;
-    m_surfaceState.insert(std::make_pair(SurfaceType3DLutCoef, kernelSurfaceParam));
+    m_surfaceState.emplace(SurfaceType3DLutCoef, kernelSurfaceParam);
     
     VP_RENDER_CHK_STATUS_RETURN(InitCoefSurface(m_maxDisplayLum, m_maxContentLevelLum, m_hdrMode));
 

--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_vebox_hvs_kernel.cpp
+++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_vebox_hvs_kernel.cpp
@@ -349,7 +349,7 @@ MOS_STATUS VpRenderHVSKernel::SetupSurfaceState()
             //            MOS_MP_RESOURCE_USAGE_DEFAULT,
             //            osInterface->pfnGetGmmClientContext(osInterface))).DwordValue;
 
-            m_surfaceState.insert(std::make_pair(*(SurfaceType *)arg.pData, kernelSurfaceParam));
+            m_surfaceState.emplace(*(SurfaceType *)arg.pData, kernelSurfaceParam);
         }
     }
 

--- a/media_softlet/agnostic/common/vp/hal/pipeline/vp_packet_reuse_manager.cpp
+++ b/media_softlet/agnostic/common/vp/hal/pipeline/vp_packet_reuse_manager.cpp
@@ -153,7 +153,7 @@ MOS_STATUS VpScalingReuse::StoreTeamsParams(SwFilter *filter, uint32_t index)
         m_params_Teams.erase(index);
     }
 
-    m_params_Teams.insert(std::make_pair(index, params));
+    m_params_Teams.emplace(index, params);
     return MOS_STATUS_SUCCESS;
 }
 
@@ -290,7 +290,7 @@ MOS_STATUS VpCscReuse::StoreTeamsParams(SwFilter *filter, uint32_t index)
         m_params_Teams.erase(index);
     }
 
-    m_params_Teams.insert(std::make_pair(index, params));
+    m_params_Teams.emplace(index, params);
     return MOS_STATUS_SUCCESS;
 }
 
@@ -378,7 +378,7 @@ MOS_STATUS VpRotMirReuse::StoreTeamsParams(SwFilter *filter, uint32_t index)
         m_params_Teams.erase(index);
     }
 
-    m_params_Teams.insert(std::make_pair(index, params));
+    m_params_Teams.emplace(index, params);
     return MOS_STATUS_SUCCESS;
 }
 
@@ -747,39 +747,39 @@ MOS_STATUS VpPacketReuseManager::RegisterFeatures()
     }
     VpFeatureReuseBase *p = MOS_New(VpScalingReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeScaling, p));
+    m_features.emplace(FeatureTypeScaling, p);
 
     p = MOS_New(VpCscReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeCsc, p));
+    m_features.emplace(FeatureTypeCsc, p);
 
     p = MOS_New(VpRotMirReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeRotMir, p));
+    m_features.emplace(FeatureTypeRotMir, p);
 
     p = MOS_New(VpColorFillReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeColorFill, p));
+    m_features.emplace(FeatureTypeColorFill, p);
 
     p = MOS_New(VpDenoiseReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeDn, p));
+    m_features.emplace(FeatureTypeDn, p);
 
     p = MOS_New(VpAlphaReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeAlpha, p));
+    m_features.emplace(FeatureTypeAlpha, p);
 
     p = MOS_New(VpTccReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeTcc, p));
+    m_features.emplace(FeatureTypeTcc, p);
 
     p = MOS_New(VpSteReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeSte, p));
+    m_features.emplace(FeatureTypeSte, p);
 
     p = MOS_New(VpProcampReuse);
     VP_PUBLIC_CHK_NULL_RETURN(p);
-    m_features.insert(std::make_pair(FeatureTypeProcamp, p));
+    m_features.emplace(FeatureTypeProcamp, p);
 
 
     return MOS_STATUS_SUCCESS;
@@ -1083,7 +1083,7 @@ MOS_STATUS VpPacketReuseManager::UpdatePacketPipeConfig(PacketPipe *&pipe)
             m_pipeReused_TeamsPacket.erase(curIndex);
         }
 
-        m_pipeReused_TeamsPacket.insert(std::make_pair(curIndex, pipe));
+        m_pipeReused_TeamsPacket.emplace(curIndex, pipe);
 
         curIndex++;
         if (curIndex >= MaxTeamsPacketSize)

--- a/media_softlet/agnostic/common/vp/hal/platform_interface/vp_platform_interface.cpp
+++ b/media_softlet/agnostic/common/vp/hal/platform_interface/vp_platform_interface.cpp
@@ -138,7 +138,7 @@ MOS_STATUS VpPlatformInterface::InitVPFCKernels(
             patchKernelSize,
             ModifyFunctionPointers);
 
-        m_kernelPool.insert(std::make_pair(vpKernel.GetKernelName(), vpKernel));
+        m_kernelPool.emplace(vpKernel.GetKernelName(), vpKernel);
     }
 
     return MOS_STATUS_SUCCESS;
@@ -260,7 +260,7 @@ void VpPlatformInterface::AddVpIsaKernelEntryToList(
     else
     {
         m_vpDelayLoadedBinaryList.push_back(tmpEntry);
-        m_vpDelayLoadedFeatureSet.insert(std::make_pair(delayKernelType, false));
+        m_vpDelayLoadedFeatureSet.emplace(delayKernelType, false);
     }
 }
 
@@ -275,7 +275,7 @@ void VpPlatformInterface::AddVpNativeAdvKernelEntryToList(
     tmpEntry.kernelBin     = kernelBin;
     tmpEntry.kernelBinSize = kernelBinSize;
 
-    m_vpNativeAdvKernelBinaryList.insert(std::make_pair(kernelName, tmpEntry));
+    m_vpNativeAdvKernelBinaryList.emplace(kernelName, tmpEntry);
 }
 
 void VpPlatformInterface::InitVpDelayedNativeAdvKernel(
@@ -296,7 +296,7 @@ void VpPlatformInterface::AddNativeAdvKernelToDelayedList(
     DelayLoadedFunc       func)
 {
     VP_FUNC_CALL();
-    m_vpDelayLoadedNativeFunctionSet.insert(std::make_pair(kernelType, func));
+    m_vpDelayLoadedNativeFunctionSet.emplace(kernelType, func);
 }
 
 void       KernelDll_ModifyFunctionPointers_Next(Kdll_State *pState);
@@ -357,7 +357,7 @@ void VpPlatformInterface::InitVpNativeAdvKernels(
     vpKernel.SetKernelName(kernelName);
     vpKernel.SetKernelBinOffset(0x0);
     vpKernel.SetKernelBinSize(kernelBinaryEntry.kernelBinSize);
-    m_kernelPool.insert(std::make_pair(vpKernel.GetKernelName(), vpKernel));
+    m_kernelPool.emplace(vpKernel.GetKernelName(), vpKernel);
 
     return;
 }
@@ -522,7 +522,7 @@ MOS_STATUS VpPlatformInterface::InitVpCmKernels(
             vpKernel.AddKernelArg(kernelArg);
         }
 
-        m_kernelPool.insert(std::make_pair(vpKernel.GetKernelName(), vpKernel));
+        m_kernelPool.emplace(vpKernel.GetKernelName(), vpKernel);
     }
 
     MOS_Delete(isaFile);
@@ -748,5 +748,5 @@ void VpPlatformInterface::InitVpDelayedNativeAdvKernel(
         vpKernel.AddKernelBti(kernelBtis[i]);
     }
 
-    m_kernelPool.insert(std::make_pair(vpKernel.GetKernelName(), vpKernel));
+    m_kernelPool.emplace(vpKernel.GetKernelName(), vpKernel);
 }

--- a/media_softlet/linux/common/os/mos_oca_specific.cpp
+++ b/media_softlet/linux/common/os/mos_oca_specific.cpp
@@ -885,7 +885,7 @@ MOS_STATUS MosOcaInterfaceSpecific::InsertOcaBufHandleMap(uint32_t *key, MOS_OCA
     MOS_OS_CHK_NULL_RETURN(key);
 
     MosOcaAutoLock autoLock(m_ocaMutex);
-    auto success = m_hOcaMap.insert(std::make_pair(key, handle));
+    auto success = m_hOcaMap.emplace(key, handle);
     if (!success.second)
     {
         // Should never come to here.


### PR DESCRIPTION
Rather, it refers more to refactoring and code reduction, I checked assembly listing -O0 and -O2 on clang. And it also affects optimization insert on Release configuration.

Clang 19 emplace -O0
![изображение](https://github.com/user-attachments/assets/bacca8d1-2f24-4571-8eb1-10ab0792e752)

Clang 19 emplace -O2
![изображение](https://github.com/user-attachments/assets/c4e22c50-b393-407b-ab59-e2ac5c587eaf)

VS

Clang 19 insert make_pair -O0
![изображение](https://github.com/user-attachments/assets/8f9a144b-6e0c-4a44-88da-f453bed6bbc7)

Clang 19 insert make_pair -O2
![изображение](https://github.com/user-attachments/assets/a3653d83-3eaf-4e39-8bb6-346a7b71bfbc)

