### PR TITLE
[Encode] Add Y210 caps for BMG HEVC encode

### DIFF
--- a/media_softlet/linux/xe2_hpm_r0/encode/hevc/ddi/capstable_data_hevc_encode_xe2_hpm_r0_specific.h
+++ b/media_softlet/linux/xe2_hpm_r0/encode/hevc/ddi/capstable_data_hevc_encode_xe2_hpm_r0_specific.h
@@ -486,6 +486,7 @@ static const ProfileSurfaceAttribInfo surfaceAttribInfo_VAProfileHEVCMain10_VAEn
 static const ProfileSurfaceAttribInfo surfaceAttribInfo_VAProfileHEVCMain422_10_VAEntrypointEncSlice_Xe2_Hpm_r0 =
 {
   {VASurfaceAttribPixelFormat, VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE, {VAGenericValueTypeInteger, {VA_FOURCC_YUY2}}},
+  {VASurfaceAttribPixelFormat, VA_SURFACE_ATTRIB_GETTABLE | VA_SURFACE_ATTRIB_SETTABLE, {VAGenericValueTypeInteger, {VA_FOURCC_Y210}}},
   {VASurfaceAttribMaxWidth, VA_SURFACE_ATTRIB_GETTABLE, {VAGenericValueTypeInteger, {CODEC_16K_MAX_PIC_WIDTH}}},
   {VASurfaceAttribMaxHeight, VA_SURFACE_ATTRIB_GETTABLE, {VAGenericValueTypeInteger, {CODEC_12K_MAX_PIC_HEIGHT}}},
   {VASurfaceAttribMinWidth, VA_SURFACE_ATTRIB_GETTABLE, {VAGenericValueTypeInteger, {CODEC_128_MIN_PIC_WIDTH}}},


### PR DESCRIPTION
The patch is to add Y210 HEVC encode support  on BMG with gstreamer-va.

Tested with below:
`gst-launch-1.0 -v filesrc location=Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw, format=Y210" ! vah265enc bitrate=3000 rate-control=cbr ! filesink location = output_Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422_cbr_system_memory.h265`
`gst-launch-1.0 -v filesrc location=Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw(memory:VAMemory), format=Y210" ! vah265enc bitrate=3000 rate-control=cbr ! filesink location = output_Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422_cbr_va_memory.h265`
`gst-launch-1.0 -v filesrc location=Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw(memory:DMABuf), drm-format=Y210:0x0100000000000009" ! vah265enc bitrate=3000 rate-control=cbr ! filesink location = output_Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422_cbr_dmabuf.h265`