### PR TITLE
[Media Common] Enable Wa to disable object capture for DG1

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -442,6 +442,9 @@ static bool InitDG1MediaWa(struct GfxDeviceInfo *devInfo,
 
     /* Enable VPP copy */
     MEDIA_WR_WA(waTable, WaEnableVPPCopy, 1);
+
+    MEDIA_WR_WA(waTable, WaDisableSetObjectCapture, 1);
+
     return true;
 }
 


### PR DESCRIPTION
This Wa is needed for using DG1 with the upstream i915 kernel.

Partially fixes:
https://github.com/intel/media-driver/issues/1415#issuecomment-2042018933

The other part needs to be fixed on KMD side by disabling `HCP_POWERGATE` and `MFXVDENC_POWERGATE` for DG1. Unlike TGLx, DG1 doesn't support sub-pipe PG and setting these bits will cause HEVC and VP9 decoding failure.

See also https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/13381