### PR TITLE
Set WaDisableSetObjectCapture on DG1

### DIFF
--- a/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
+++ b/media_driver/linux/gen12/ddi/media_sku_wa_g12.cpp
@@ -442,6 +442,9 @@ static bool InitDG1MediaWa(struct GfxDeviceInfo *devInfo,
 
     /* Enable VPP copy */
     MEDIA_WR_WA(waTable, WaEnableVPPCopy, 1);
+
+    MEDIA_WR_WA(waTable, WaDisableSetObjectCapture, 1);
+
     return true;
 }
 


### PR DESCRIPTION
Starting with commit 71b1669ea9bd ("drm/i915/uapi: tweak error capture on recoverable contexts") i915 started to reject EXEC_CAPTURE + recoverable contexts, which means DG1 is currently broken. Set WaDisableSetObjectCapture to disable EXEC_CAPTURE on DG1.