### PR TITLE
add loongarch64 build support

### DIFF
--- a/cmrtlib/build_linux.sh
+++ b/cmrtlib/build_linux.sh
@@ -138,7 +138,11 @@ case $BUILD_SIZE in
         if [[ $BUILD_64 -eq 1 ]]; then
             CROSS_BUILD=1
             BUILD_SIZE=64
-            EXTRA_OPTIONS="export CFLAGS=-m64 CXXFLAGS=-m64"
+            if [ ${MACHINE_TYPE} == 'loongarch64' ]; then
+                EXTRA_OPTIONS=""
+            else
+                EXTRA_OPTIONS="export CFLAGS=-m64 CXXFLAGS=-m64"
+            fi
         fi
         ;;
     64)

--- a/media_driver/agnostic/common/cm/cm_mem.cpp
+++ b/media_driver/agnostic/common/cm/cm_mem.cpp
@@ -26,27 +26,40 @@
 
 #include "cm_mem.h"
 #include "cm_mem_c_impl.h"
+
+#if !defined(__loongarch64)
 #include "cm_mem_sse2_impl.h"
+#endif
 
 typedef void(*t_CmFastMemCopy)( void* dst, const   void* src, const size_t bytes );
 typedef void(*t_CmFastMemCopyWC)( void* dst,   const void* src, const size_t bytes );
 
+#if !defined(__loongarch64)
 #define CM_FAST_MEM_COPY_CPU_INIT_C(func)       (func ## _C)
 #define CM_FAST_MEM_COPY_CPU_INIT_SSE2(func)    (func ## _SSE2)
 #define CM_FAST_MEM_COPY_CPU_INIT(func)         (is_SSE2_available ? CM_FAST_MEM_COPY_CPU_INIT_SSE2(func) : CM_FAST_MEM_COPY_CPU_INIT_C(func))
+#endif
 
 void CmFastMemCopy( void* dst, const void* src, const size_t bytes )
 {
+#if defined(__loongarch64)
+    CmFastMemCopy_C(dst, src, bytes);
+#else
     static const bool is_SSE2_available = (GetCpuInstructionLevel() >= CPU_INSTRUCTION_LEVEL_SSE2);
     static const t_CmFastMemCopy CmFastMemCopy_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopy);
 
     CmFastMemCopy_impl(dst, src, bytes);
+#endif
 }
 
 void CmFastMemCopyWC( void* dst, const void* src, const size_t bytes )
 {
+#if defined(__loongarch64)
+    CmFastMemCopyWC_C(dst, src, bytes);
+#else
     static const bool is_SSE2_available = (GetCpuInstructionLevel() >= CPU_INSTRUCTION_LEVEL_SSE2);
     static const t_CmFastMemCopyWC CmFastMemCopyWC_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopyWC);
 
     CmFastMemCopyWC_impl(dst, src, bytes);
+#endif
 }

--- a/media_driver/agnostic/common/cm/cm_mem.h
+++ b/media_driver/agnostic/common/cm/cm_mem.h
@@ -25,9 +25,15 @@
 //!
 #pragma once
 
+#if defined(__loongarch64)
+#define SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse2.h>
+#else
 #include <mmintrin.h>
 #include <xmmintrin.h>
 #include <emmintrin.h>
+#endif
+
 #include "cm_debug.h"
 #include "mos_utilities.h"
 
@@ -43,7 +49,11 @@ enum CPU_INSTRUCTION_LEVEL
     NUM_CPU_INSTRUCTION_LEVELS
 };
 
+#if defined(__loongarch64)
+typedef __m128i             DQWORD;         // 128-bits,   16-bytes
+#else
 typedef __m128              DQWORD;         // 128-bits,   16-bytes
+#endif
 typedef uint32_t            PREFETCH[8];    //             32-bytes
 typedef uint32_t            CACHELINE[8];   //             32-bytes
 typedef uint16_t            DHWORD[32];     // 512-bits,   64-bytes
@@ -230,9 +240,12 @@ inline CPU_INSTRUCTION_LEVEL GetCpuInstructionLevel( void )
     int cpuInfo[4];
     memset( cpuInfo, 0, 4*sizeof(int) );
 
+#if !defined(__loongarch64)
     GetCPUID(cpuInfo, 1);
+#endif
 
     CPU_INSTRUCTION_LEVEL cpuInstructionLevel = CPU_INSTRUCTION_LEVEL_UNKNOWN;
+#if !defined(__loongarch64)
     if( (cpuInfo[2] & BIT(19)) && TestSSE4_1() )
     {
         cpuInstructionLevel = CPU_INSTRUCTION_LEVEL_SSE4_1;
@@ -253,6 +266,7 @@ inline CPU_INSTRUCTION_LEVEL GetCpuInstructionLevel( void )
     {
         cpuInstructionLevel = CPU_INSTRUCTION_LEVEL_MMX;
     }
+#endif
 
     return cpuInstructionLevel;
 }

--- a/media_driver/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_driver/cmake/linux/media_compile_flags_linux.cmake
@@ -54,8 +54,6 @@ set(MEDIA_COMPILER_FLAGS_COMMON
 
     # Enable c++14 features
     -std=c++14
-    # -m32 or -m64
-    -m${ARCH}
 
     # Global defines
     -DLINUX=1
@@ -65,6 +63,13 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -DINTEL_NOT_PUBLIC
     -g
 )
+
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^loongarch")
+    list(APPEND MEDIA_COMPILER_FLAGS_COMMON "-Wno-overloaded-virtual")
+else()
+    # -m32 or -m64
+    list(APPEND MEDIA_COMPILER_FLAGS_COMMON "-m${ARCH}")
+endif()
 
 if(MEDIA_BUILD_HARDENING)
     set(MEDIA_COMPILER_FLAGS_COMMON

--- a/media_driver/linux/common/cm/hal/osservice/cm_mem_os.cpp
+++ b/media_driver/linux/common/cm/hal/osservice/cm_mem_os.cpp
@@ -27,18 +27,27 @@
 #include "cm_mem.h"
 #include "cm_mem_os.h"
 #include "cm_mem_os_c_impl.h"
+
+#if !defined(__loongarch64)
 #include "cm_mem_os_sse4_impl.h"
+#endif
 
 typedef void(*t_CmFastMemCopyFromWC)( void* dst, const void* src, const size_t bytes );
 
+#if !defined(__loongarch64)
 #define CM_FAST_MEM_COPY_CPU_INIT_C(func)       (func ## _C)
 #define CM_FAST_MEM_COPY_CPU_INIT_SSE4(func)    (func ## _SSE4)
 #define CM_FAST_MEM_COPY_CPU_INIT(func)         (is_SSE4_available ? CM_FAST_MEM_COPY_CPU_INIT_SSE4(func) : CM_FAST_MEM_COPY_CPU_INIT_C(func))
+#endif
 
 void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes, CPU_INSTRUCTION_LEVEL cpuInstructionLevel )
 {
+#if defined(__loongarch64)
+    CmFastMemCopyFromWC_C(dst, src, bytes);
+#else
     static const bool is_SSE4_available = (cpuInstructionLevel >= CPU_INSTRUCTION_LEVEL_SSE4_1);
     static const t_CmFastMemCopyFromWC CmFastMemCopyFromWC_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopyFromWC);
 
     CmFastMemCopyFromWC_impl(dst, src, bytes);
+#endif
 }

--- a/media_driver/linux/common/cm/hal/osservice/cm_mem_os.h
+++ b/media_driver/linux/common/cm/hal/osservice/cm_mem_os.h
@@ -26,8 +26,13 @@
 #pragma once
 
 #include <iostream>
+#if defined(__loongarch64)
+#define SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse2.h>
+#else
 #include "cpuid.h"
 #include <smmintrin.h>
+#endif
 
 typedef uintptr_t           UINT_PTR;
 #define __fastcall
@@ -120,6 +125,9 @@ Output:
 \*****************************************************************************/
 inline void GetCPUID(int cpuInfo[4], int infoType)
 {
+#if defined(__loongarch64)
+    return;
+#else
 #ifndef NO_EXCEPTION_HANDLING
     __try
     {
@@ -135,6 +143,7 @@ inline void GetCPUID(int cpuInfo[4], int infoType)
         return;
     }
 #endif  //NO_EXCEPTION_HANDLING
+#endif //defined(__loongarch64)
 }
 
 void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes, CPU_INSTRUCTION_LEVEL cpuInstructionLevel );

--- a/media_softlet/cmake/linux/media_compile_flags_linux.cmake
+++ b/media_softlet/cmake/linux/media_compile_flags_linux.cmake
@@ -53,9 +53,6 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -ffunction-sections
     -Wl,--gc-sections
 
-    # -m32 or -m64
-    -m${ARCH}
-
     # Global defines
     -DLINUX=1
     -DLINUX
@@ -65,6 +62,12 @@ set(MEDIA_COMPILER_FLAGS_COMMON
     -g
 )
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^loongarch")
+    list(APPEND MEDIA_COMPILER_FLAGS_COMMON "-Wno-overloaded-virtual")
+else()
+    # -m32 or -m64
+    list(APPEND MEDIA_COMPILER_FLAGS_COMMON "-m${ARCH}")
+endif()
 
 if(${UFO_MARCH} STREQUAL "slm")
     set(MEDIA_COMPILER_FLAGS_COMMON


### PR DESCRIPTION
Initial work is done at https://github.com/FanFansfan/media-driver/tree/loongarch by @FanFansfan.

I use libsimde-dev on system for SIMDE headers.

This pr depends on https://github.com/intel/gmmlib/pull/133 for build dep.

Tested with Intel Arc B580 on Loongson 3A6000 desktop platform. Vaapi decoding/encoding is working fine.