### PR TITLE
accept cacheable setting from libva

### DIFF
--- a/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_interface_next.cpp
@@ -3299,7 +3299,8 @@ VAStatus MediaLibvaInterfaceNext::CreateSurfaces2 (
                     expectedFourcc  = externalBufDescripor.pixel_format;
                     width            = externalBufDescripor.width;
                     height           = externalBufDescripor.height;
-                    // the following code is for backward compatible and it will be removed in the future
+                    descFlag         = externalBufDescripor.flags;
+                    // the following code is for backward compatible problem caused by incorrect use of VA_SURFACE_ATTRIB_MEM_TYPE_XXX in application layer. and it will be removed in the future
                     // new implemention should use VASurfaceAttribMemoryType attrib and set its value to VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM
                     if ((externalBufDescripor.flags & VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM )||
                         (externalBufDescripor.flags & VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME)||

--- a/media_softlet/linux/common/ddi/media_libva_util_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
@@ -651,9 +651,13 @@ VAStatus MediaLibvaUtilNext::CreateExternalSurface(
 
     GMM_RESCREATE_CUSTOM_PARAMS_2 gmmCustomParams;
     MOS_ZeroMemory(&gmmCustomParams, sizeof(gmmCustomParams));
+    gmmCustomParams.Usage = GMM_RESOURCE_USAGE_STAGING;
+    if ((VA_SURFACE_EXTBUF_DESC_UNCACHED & mediaSurface->pSurfDesc->uiFlags) || (VA_SURFACE_EXTBUF_DESC_WC & mediaSurface->pSurfDesc->uiFlags))
+    {
+        gmmCustomParams.Usage = GMM_RESOURCE_USAGE_UNKNOWN;
+    }
     if (VA_SURFACE_ATTRIB_MEM_TYPE_USER_PTR == mediaSurface->pSurfDesc->uiVaMemType)
     {
-        gmmCustomParams.Usage = GMM_RESOURCE_USAGE_STAGING;
         gmmCustomParams.Type = RESOURCE_1D;
     }
 


### PR DESCRIPTION
set the default coherency to 1-way by setting the usage GMM_RESOURCE_USAGE_STAGING set the usage to GMM_RESOURCE_USAGE_UNKNOWN if it is WC or UC