### PR TITLE
[Encode] Fix ACM HEVC VDENC 422 CBR/VBR

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_caps.cpp
+++ b/media_driver/linux/common/ddi/media_libva_caps.cpp
@@ -2093,6 +2093,7 @@ VAStatus MediaLibvaCaps::CreateEncConfig(
         {
             case VAProfileHEVCMain:
             case VAProfileHEVCMain10:
+            case VAProfileHEVCMain422_10:
             case VAProfileHEVCMain444:
             case VAProfileHEVCMain444_10:
                 rc_mb_flag = true;


### PR DESCRIPTION
The patch is to fix ACM HEVC 422 CBR/VBR encode with gstreamer-va.

Tested with below:
`gst-launch-1.0 -v filesrc location=Duck_1920x1080_3mbps_25fps_Main_at_L4.0_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw, format=YUY2" ! vah265lpenc bitrate=6000 rate-control=cbr ! filesink location=output_Duck_1920x1080_3mbps_25fps_Main_at_L4.0_422_cbr_system_memory.h265`
`gst-launch-1.0 -v filesrc location=Duck_1920x1080_3mbps_25fps_Main_at_L4.0_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw, format=YUY2" ! vah265lpenc bitrate=6000 rate-control=vbr ! filesink location=output_Duck_1920x1080_3mbps_25fps_Main_at_L4.0_422_vbr_system_memory.h265`
`gst-launch-1.0 -v filesrc location=Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw, format=Y210" ! vah265lpenc bitrate=6000 rate-control=cbr ! filesink location=output_Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422_cbr_system_memory.h265`
`gst-launch-1.0 -v filesrc location=Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422.mkv ! matroskademux ! h265parse ! vah265dec ! "video/x-raw, format=Y210" ! vah265lpenc bitrate=6000 rate-control=vbr ! filesink location=output_Elecard2_1920x1080_4mbps_60fps_Main_at_L4.1_10bit_422_vbr_system_memory.h265`