### PR TITLE
ddi: fix wrong sizeof when zeroing DecodeStatusReportData

### DIFF
--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
@@ -477,7 +477,7 @@ VAStatus DdiDecode_StatusReport(PDDI_MEDIA_CONTEXT mediaCtx, DecodePipelineAdapt
             for (uint32_t i = 0; i < uNumCompletedReport; i++)
             {
                 decode::DecodeStatusReportData tempNewReport;
-                MOS_ZeroMemory(&tempNewReport, sizeof(CodechalDecodeStatusReport));
+                MOS_ZeroMemory(&tempNewReport, sizeof(tempNewReport));
                 MOS_STATUS eStatus = decoder->GetStatusReport(&tempNewReport, 1);
                 DDI_CHK_CONDITION(MOS_STATUS_SUCCESS != eStatus, "Get status report fail", VA_STATUS_ERROR_OPERATION_FAILED);
 

--- a/media_softlet/linux/common/codec/ddi/dec/ddi_decode_functions.cpp
+++ b/media_softlet/linux/common/codec/ddi/dec/ddi_decode_functions.cpp
@@ -1054,7 +1054,8 @@ VAStatus DdiDecodeFunctions::StatusReport(
             for (uint32_t i = 0; i < uNumCompletedReport; i++)
             {
                 DecodeStatusReportData tempNewReport;
-                MOS_ZeroMemory(&tempNewReport, sizeof(CodechalDecodeStatusReport));
+                MOS_ZeroMemory(&tempNewReport, sizeof(tempNewReport));
+                //MOS_ZeroMemory(&tempNewReport, sizeof(CodechalDecodeStatusReport));
                 MOS_STATUS eStatus = decoder->GetStatusReport(&tempNewReport, 1);
                 DDI_CODEC_CHK_CONDITION(MOS_STATUS_SUCCESS != eStatus, "Get status report fail", VA_STATUS_ERROR_OPERATION_FAILED);
 


### PR DESCRIPTION
media_softlet/linux/common/codec/ddi/dec/ddi_decode_functions.cpp;media_driver/linux/common/codec/ddi/media_libva_decoder.cpp