### PR TITLE
Fix pragma errors causing -Wpragma-pack-suspicious-include

### DIFF
--- a/cmrtlib/agnostic/share/cm_hw_vebox_cmd_g10.h
+++ b/cmrtlib/agnostic/share/cm_hw_vebox_cmd_g10.h
@@ -20,10 +20,11 @@
 * OTHER DEALINGS IN THE SOFTWARE.
 */
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class CmHwVeboxCmdG10
 {

--- a/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_hpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_hpm.h
@@ -41,10 +41,11 @@
 #endif
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_hpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_hpm.h
@@ -36,10 +36,11 @@
 #include "mhw_hwcmd.h"
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe_hpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe_hpm.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_XE_HPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_mi_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_mi_hwcmd_xe_xpm.h
@@ -35,10 +35,11 @@
 #define __MHW_MI_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_mi_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_sfc_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_sfc_hwcmd_xe_xpm.h
@@ -34,10 +34,11 @@
 #define __MHW_SFC_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_sfc_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_state_heap_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_state_heap_hwcmd_xe_xpm.h
@@ -35,10 +35,11 @@
 #define __MHW_STATE_HEAP_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_state_heap_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_vebox_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_vebox_hwcmd_xe_xpm.h
@@ -31,10 +31,11 @@
 #define __MHW_VEBOX_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vebox_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_xpm.h
@@ -35,10 +35,11 @@
 #define __MHW_VDBOX_AVP_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_avp_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_xpm.h
@@ -34,10 +34,11 @@
 #define __MHW_VDBOX_HCP_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe_xpm.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe_xpm.h
@@ -31,10 +31,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_XE_XPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_xe_xpm
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM_plus/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_xpm_plus.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM_plus/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_xpm_plus.h
@@ -36,10 +36,11 @@
 #include "mhw_hwcmd.h"
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_driver/agnostic/Xe_M/Xe_XPM_plus/hw/vdbox/mhw_vdbox_huc_hwcmd_xe_xpm_plus.h
+++ b/media_driver/agnostic/Xe_M/Xe_XPM_plus/hw/vdbox/mhw_vdbox_huc_hwcmd_xe_xpm_plus.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_XE_XPM_PLUS_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_driver/agnostic/Xe_R/Xe_HP_base/hw/render/mhw_render_hwcmd_xe_hp_base.h
+++ b/media_driver/agnostic/Xe_R/Xe_HP_base/hw/render/mhw_render_hwcmd_xe_hp_base.h
@@ -35,10 +35,11 @@
 #define __MHW_RENDER_HWCMD_XE_HP_BASE_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_render_xe_xpm_base
 {

--- a/media_driver/agnostic/common/hw/mhw_vebox_hwcmd_g9_X.h
+++ b/media_driver/agnostic/common/hw/mhw_vebox_hwcmd_g9_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VEBOX_HWCMD_G9_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vebox_g9_X
 {

--- a/media_driver/agnostic/g12/g12_base/hw/render/mhw_render_hwcmd_g12_X.h
+++ b/media_driver/agnostic/g12/g12_base/hw/render/mhw_render_hwcmd_g12_X.h
@@ -29,10 +29,11 @@
 #define __MHW_RENDER_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_render_g12_X
 {

--- a/media_driver/agnostic/gen11/hw/mhw_mi_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/mhw_mi_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_MI_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_mi_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/mhw_render_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/mhw_render_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_RENDER_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_render_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/mhw_sfc_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/mhw_sfc_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_SFC_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_sfc_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/mhw_state_heap_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/mhw_state_heap_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_STATE_HEAP_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_state_heap_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/mhw_vebox_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/mhw_vebox_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VEBOX_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vebox_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_hcp_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_hcp_hwcmd_g11_X.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HCP_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_huc_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_huc_hwcmd_g11_X.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_huc_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_mfx_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_mfx_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_g11_X
 {

--- a/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g11_X.h
+++ b/media_driver/agnostic/gen11/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g11_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_VDENC_HWCMD_G11_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_vdenc_g11_X
 {

--- a/media_driver/agnostic/gen12/hw/mhw_mi_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/mhw_mi_hwcmd_g12_X.h
@@ -23,10 +23,11 @@
 #define __MHW_MI_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_mi_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/mhw_sfc_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/mhw_sfc_hwcmd_g12_X.h
@@ -29,10 +29,11 @@
 #define __MHW_SFC_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_sfc_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/mhw_state_heap_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/mhw_state_heap_hwcmd_g12_X.h
@@ -32,10 +32,11 @@
 #define __MHW_STATE_HEAP_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_state_heap_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/mhw_vebox_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/mhw_vebox_hwcmd_g12_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VEBOX_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_vebox_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_avp_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_avp_hwcmd_g12_X.h
@@ -32,10 +32,11 @@
 #define __MHW_AVP_HWCMD_G12_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_avp_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_hcp_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_hcp_hwcmd_g12_X.h
@@ -34,10 +34,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define __MHW_VDBOX_HCP_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_huc_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_huc_hwcmd_g12_X.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_huc_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_mfx_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_mfx_hwcmd_g12_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_g12_X
 {

--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g12_X.h
+++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g12_X.h
@@ -31,10 +31,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define __MHW_VDBOX_VDENC_HWCMD_G12_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_vdenc_g12_X
 {

--- a/media_driver/agnostic/gen8/hw/mhw_mi_hwcmd_g8_X.h
+++ b/media_driver/agnostic/gen8/hw/mhw_mi_hwcmd_g8_X.h
@@ -29,10 +29,11 @@
 #define __MHW_MI_HWCMD_G8_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_mi_g8_X
 {

--- a/media_driver/agnostic/gen8/hw/mhw_render_hwcmd_g8_X.h
+++ b/media_driver/agnostic/gen8/hw/mhw_render_hwcmd_g8_X.h
@@ -29,10 +29,11 @@
 #define __MHW_RENDER_HWCMD_G8_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_render_g8_X
 {

--- a/media_driver/agnostic/gen8/hw/mhw_state_heap_hwcmd_g8_X.h
+++ b/media_driver/agnostic/gen8/hw/mhw_state_heap_hwcmd_g8_X.h
@@ -29,10 +29,11 @@
 #define __MHW_STATE_HEAP_HWCMD_G8_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_state_heap_g8_X
 {

--- a/media_driver/agnostic/gen8/hw/mhw_vebox_hwcmd_g8_X.h
+++ b/media_driver/agnostic/gen8/hw/mhw_vebox_hwcmd_g8_X.h
@@ -29,10 +29,11 @@
 #define __MHW_VEBOX_HWCMD_G8_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_vebox_g8_X
 {

--- a/media_driver/agnostic/gen8_bdw/hw/vdbox/mhw_vdbox_mfx_hwcmd_g8_bdw.h
+++ b/media_driver/agnostic/gen8_bdw/hw/vdbox/mhw_vdbox_mfx_hwcmd_g8_bdw.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_G8_BDW_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_g8_bdw
 {

--- a/media_driver/agnostic/gen9/hw/mhw_mi_hwcmd_g9_X.h
+++ b/media_driver/agnostic/gen9/hw/mhw_mi_hwcmd_g9_X.h
@@ -29,10 +29,11 @@
 #define __MHW_MI_HWCMD_G9_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_mi_g9_X
 {

--- a/media_driver/agnostic/gen9/hw/mhw_render_hwcmd_g9_X.h
+++ b/media_driver/agnostic/gen9/hw/mhw_render_hwcmd_g9_X.h
@@ -29,10 +29,11 @@
 #define __MHW_RENDER_HWCMD_G9_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_render_g9_X
 {

--- a/media_driver/agnostic/gen9/hw/mhw_sfc_hwcmd_g9_X.h
+++ b/media_driver/agnostic/gen9/hw/mhw_sfc_hwcmd_g9_X.h
@@ -29,10 +29,11 @@
 #define __MHW_SFC_HWCMD_G9_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_sfc_g9_X
 {

--- a/media_driver/agnostic/gen9/hw/mhw_state_heap_hwcmd_g9_X.h
+++ b/media_driver/agnostic/gen9/hw/mhw_state_heap_hwcmd_g9_X.h
@@ -29,10 +29,11 @@
 #define __MHW_STATE_HEAP_HWCMD_G9_X_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_state_heap_g9_X
 {

--- a/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_bxt.h
+++ b/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_bxt.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HCP_HWCMD_G9_BXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_g9_bxt
 {

--- a/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_bxt.h
+++ b/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_bxt.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_G9_BXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_huc_g9_bxt
 {

--- a/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_mfx_hwcmd_g9_bxt.h
+++ b/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_mfx_hwcmd_g9_bxt.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_G9_BXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_g9_bxt
 {

--- a/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g9_bxt.h
+++ b/media_driver/agnostic/gen9_bxt/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g9_bxt.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_VDENC_HWCMD_G9_BXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_vdenc_g9_bxt
 {

--- a/media_driver/agnostic/gen9_glk/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_glk.h
+++ b/media_driver/agnostic/gen9_glk/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_glk.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HCP_HWCMD_G9_GLK_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_g9_glk
 {

--- a/media_driver/agnostic/gen9_glk/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_glk.h
+++ b/media_driver/agnostic/gen9_glk/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_glk.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_G9_GLK_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
+
+#pragma pack(1)
 
 class mhw_vdbox_huc_g9_glk
 {

--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_kbl.h
+++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_kbl.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HCP_HWCMD_G9_KBL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_g9_kbl
 {

--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_kbl.h
+++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_kbl.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_G9_KBL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_huc_g9_kbl
 {

--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_mfx_hwcmd_g9_kbl.h
+++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_mfx_hwcmd_g9_kbl.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_G9_KBL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_g9_kbl
 {

--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g9_kbl.h
+++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g9_kbl.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_VDENC_HWCMD_G9_KBL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_vdenc_g9_kbl
 {

--- a/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_skl.h
+++ b/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_hcp_hwcmd_g9_skl.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HCP_HWCMD_G9_SKL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_hcp_g9_skl
 {

--- a/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_skl.h
+++ b/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_huc_hwcmd_g9_skl.h
@@ -32,10 +32,11 @@
 #define __MHW_VDBOX_HUC_HWCMD_G9_SKL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_huc_g9_skl
 {

--- a/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_mfx_hwcmd_g9_skl.h
+++ b/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_mfx_hwcmd_g9_skl.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_MFX_HWCMD_G9_SKL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_mfx_g9_skl
 {

--- a/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g9_skl.h
+++ b/media_driver/agnostic/gen9_skl/hw/vdbox/mhw_vdbox_vdenc_hwcmd_g9_skl.h
@@ -29,10 +29,11 @@
 #define __MHW_VDBOX_VDENC_HWCMD_G9_SKL_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 class mhw_vdbox_vdenc_g9_skl
 {

--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/mhw_vebox_hwcmd_xe_hpm.h
+++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/mhw_vebox_hwcmd_xe_hpm.h
@@ -31,12 +31,13 @@
 #define __MHW_VEBOX_HWCMD_XE_HPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "mhw_hwcmd.h"
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #pragma once
 #pragma pack(1)

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_aqm_hwcmd_xe2_lpm.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_aqm_hwcmd_xe2_lpm.h
@@ -34,12 +34,13 @@
 #define __MHW_VDBOX_AQM_HWCMD_XE2_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_aqm_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe2_lpm.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe2_lpm.h
@@ -35,12 +35,13 @@
 #define __MHW_VDBOX_AVP_HWCMD_XE2_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_avp_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe2_lpm.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe2_lpm.h
@@ -36,12 +36,13 @@
 #include "mhw_hwcmd.h"
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe2_lpm.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe2_lpm.h
@@ -32,12 +32,13 @@
 #define __MHW_VDBOX_HUC_HWCMD_XE2_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe2_lpm.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe2_lpm.h
@@ -35,12 +35,13 @@
 #define __MHW_VDBOX_MFX_HWCMD_XE2_LPM_H__
 
 #pragma once
-#pragma pack(1)
 
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_vvcp_hwcmd_xe2_lpm_X.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM/hw/vdbox/mhw_vdbox_vvcp_hwcmd_xe2_lpm_X.h
@@ -35,12 +35,13 @@
 #define __MHW_VDBOX_VVCP_HWCMD_XE2_LPM_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM_base/hw/mhw_blt_hwcmd_xe2_lpm.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM_base/hw/mhw_blt_hwcmd_xe2_lpm.h
@@ -32,11 +32,12 @@
 #define __MHW_BLT_HWCMD_XE2_LPM_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM_base/hw/mhw_sfc_hwcmd_xe2_lpm_base_next.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM_base/hw/mhw_sfc_hwcmd_xe2_lpm_base_next.h
@@ -34,11 +34,12 @@
 #define __MHW_SFC_HWCMD_XE2_LPM_BASE_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM_base/hw/mhw_vebox_hwcmd_xe2_lpm_base_next.h
+++ b/media_softlet/agnostic/Xe2_M_plus/Xe2_LPM_base/hw/mhw_vebox_hwcmd_xe2_lpm_base_next.h
@@ -34,11 +34,12 @@
 #define __MHW_VEBOX_HWCMD_XE2_LPM_BASE_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_aqm_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_aqm_hwcmd_xe3_lpm.h
@@ -32,12 +32,13 @@
 #define __MHW_VDBOX_AQM_HWCMD_XE3_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_aqm_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe3_lpm.h
@@ -32,12 +32,13 @@
 #define __MHW_VDBOX_AVP_HWCMD_XE3_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_avp_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe3_lpm.h
@@ -32,11 +32,12 @@
 #define __MHW_VDBOX_HCP_HWCMD_XE3_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe3_lpm.h
@@ -32,11 +32,12 @@
 #define __MHW_VDBOX_HUC_HWCMD_XE3_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe3_lpm.h
@@ -32,11 +32,12 @@
 #define __MHW_VDBOX_MFX_HWCMD_XE3_LPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_vvcp_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM/hw/vdbox/mhw_vdbox_vvcp_hwcmd_xe3_lpm.h
@@ -32,12 +32,13 @@
 #define __MHW_VDBOX_VVCP_HWCMD_XE3_LPM_X_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM_base/hw/mhw_blt_hwcmd_xe3_lpm.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM_base/hw/mhw_blt_hwcmd_xe3_lpm.h
@@ -32,11 +32,12 @@
 #define __MHW_BLT_HWCMD_XE3_LPM_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM_base/hw/mhw_sfc_hwcmd_xe3_lpm_base.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM_base/hw/mhw_sfc_hwcmd_xe3_lpm_base.h
@@ -32,11 +32,12 @@
 #define __MHW_SFC_HWCMD_XE3_LPM_BASE_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM_base/hw/mhw_vebox_hwcmd_xe3_lpm_base.h
+++ b/media_softlet/agnostic/Xe3_M_plus/Xe3_LPM_base/hw/mhw_vebox_hwcmd_xe3_lpm_base.h
@@ -32,11 +32,12 @@
 #define __MHW_VEBOX_HWCMD_XE3_LPM_BASE_H__
 
 #pragma once
-#pragma pack(1)
 
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/mhw_blt_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/mhw_blt_hwcmd_xe2_hpm.h
@@ -31,11 +31,12 @@
 #define __MHW_BLT_HWCMD_XE2_HPM_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/mhw_sfc_hwcmd_xe2_hpm_next.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/mhw_sfc_hwcmd_xe2_hpm_next.h
@@ -32,11 +32,12 @@
 #define __MHW_SFC_HWCMD_XE2_HPM_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/mhw_vebox_hwcmd_xe2_hpm_next.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/mhw_vebox_hwcmd_xe2_hpm_next.h
@@ -30,11 +30,12 @@
 #define __MHW_VEBOX_HWCMD_XE2_HPM_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_aqm_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_aqm_hwcmd_xe2_hpm.h
@@ -35,12 +35,13 @@
 #define __MHW_VDBOX_AQM_HWCMD_XE2_HPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_aqm_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_avp_hwcmd_xe2_hpm.h
@@ -33,12 +33,13 @@
 #define __MHW_VDBOX_AVP_HWCMD_XE2_HPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_avp_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe2_hpm.h
@@ -36,10 +36,11 @@
 #include "mhw_hwcmd.h"
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_huc_hwcmd_xe2_hpm.h
@@ -34,12 +34,13 @@
 #define __MHW_VDBOX_HUC_HWCMD_XE2_HPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe2_hpm.h
@@ -32,12 +32,13 @@
 #define __MHW_VDBOX_MFX_HWCMD_XE2_HPM_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_vdenc_hwcmd_xe2_hpm.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe2_HPM/hw/vdbox/mhw_vdbox_vdenc_hwcmd_xe2_hpm.h
@@ -33,9 +33,10 @@
 #define __MHW_VDBOX_VDENC_HWCMD_XE2_HPM_H__
 
 #pragma once
+#include "mhw_hwcmd.h"
+
 #pragma pack(1)
 
-#include "mhw_hwcmd.h"
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_vdenc_hwcmd_ext.h"
 #endif

--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_blt_hwcmd_xe_lpm_plus_next.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_blt_hwcmd_xe_lpm_plus_next.h
@@ -32,11 +32,12 @@
 #define __MHW_BLT_HWCMD_XE_LPM_PLUS_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_vebox_hwcmd_xe_lpm_plus_next.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_vebox_hwcmd_xe_lpm_plus_next.h
@@ -32,11 +32,12 @@
 #define __MHW_VEBOX_HWCMD_XE_LPM_PLUS_NEXT_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_lpm_plus.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_lpm_plus.h
@@ -34,12 +34,13 @@
 #define __MHW_VDBOX_AVP_HWCMD_XE_LPM_PLUS_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 #ifdef _MEDIA_RESERVED
 #include "mhw_vdbox_avp_hwcmd_ext.h"

--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_lpm_plus.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_hcp_hwcmd_xe_lpm_plus.h
@@ -36,10 +36,11 @@
 #include "mhw_hwcmd.h"
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_huc_hwcmd_xe_lpm_plus.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_huc_hwcmd_xe_lpm_plus.h
@@ -34,12 +34,13 @@
 #define __MHW_VDBOX_HUC_HWCMD_XE_LPM_PLUS_H__
 
 #pragma once
-#pragma pack(1)
-
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe_lpm_plus.h
+++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_mfx_hwcmd_xe_lpm_plus.h
@@ -34,12 +34,13 @@
 #define __MHW_VDBOX_MFX_HWCMD_XE_LPM_PLUS_H__
 
 #pragma once
-#pragma pack(1)
 
 #include "mhw_hwcmd.h"
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_R/Xe2_HPG/hw/mhw_render_hwcmd_xe2_hpg_next.h
+++ b/media_softlet/agnostic/Xe_R/Xe2_HPG/hw/mhw_render_hwcmd_xe2_hpg_next.h
@@ -36,10 +36,11 @@
 
 #include "mhw_hwcmd.h"
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
+
+
+#pragma pack(1)
 
 namespace mhw
 {

--- a/media_softlet/agnostic/Xe_R/Xe2_HPG/hw/mhw_state_heap_hwcmd_xe2_hpg.h
+++ b/media_softlet/agnostic/Xe_R/Xe2_HPG/hw/mhw_state_heap_hwcmd_xe2_hpg.h
@@ -32,11 +32,12 @@
 #define __MHW_STATE_HEAP_HWCMD_XE2_HPG_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 class mhw_state_heap_xe2_hpg
 {

--- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/mhw_state_heap_hwcmd_xe_hpg.h
+++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/mhw_state_heap_hwcmd_xe_hpg.h
@@ -35,11 +35,12 @@
 #define __MHW_STATE_HEAP_HWCMD_XE_HPG_H__
 
 #pragma once
-#pragma pack(1)
-
 #include <cstdint>
 #include <cstddef>
 #include "media_class_trace.h"
+
+
+#pragma pack(1)
 
 class mhw_state_heap_xe_hpg
 {


### PR DESCRIPTION
To build media driver in Android we need to add
-Wno-pragma-pack-suspicious-include.
Without above flag getting compile errors.
This change will fix pragma errors.