### PR TITLE
[Media Decode] not reduce the slice number when destroy slice data buffer

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -280,11 +280,7 @@ static bool DdiMedia_ReleaseBsBuffer(
         }
         return false;
     }
-    else
-    {
-        if (bufMgr->dwNumSliceData)
-            bufMgr->dwNumSliceData--;
-    }
+
     return true;
 }
 

--- a/media_softlet/linux/common/codec/ddi/dec/ddi_decode_functions.cpp
+++ b/media_softlet/linux/common/codec/ddi/dec/ddi_decode_functions.cpp
@@ -1383,11 +1383,7 @@ bool DdiDecodeFunctions::ReleaseBsBuffer(DDI_CODEC_COM_BUFFER_MGR *bufMgr, DDI_M
         }
         return false;
     }
-    else
-    {
-        if (bufMgr->dwNumSliceData)
-            bufMgr->dwNumSliceData--;
-    }
+
     return true;
 }
 


### PR DESCRIPTION
…iceDataBuffer

sometimes, app call vaDestoryBuffer for VASliceDataBufferType in middle of one frame execution. for example: there are two VASliceDataBufferType for one frame. after first VASliceDataBufferType was created. then destroy one VASliceDataBufferType of last frame , then create second slice for current frame, it will cause problem.
the rootcause is :media driver try to optimize the bistream combination, so it allocate one buffer for mulitple slice data. then these slice data just get the offset and were filled into one bistream buffer. this method reduce one combination copy.