### PR TITLE
[VP] Fix VEBOX surface config crash in 60i->30p deinterlacing

### DIFF
--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
+++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
@@ -2561,7 +2561,11 @@ MOS_STATUS VpResourceManager::AssignVeboxResource(VP_EXECUTE_CAPS& caps, VP_SURF
     if (caps.bDI || caps.bDiProcess2ndField)
     {
         bool b60fpsDi = resHint.b60fpsDi || caps.bDiProcess2ndField;
-        VEBOX_SURFACES_CONFIG cfg(b60fpsDi, caps.bSFC, m_sameSamples, m_outOfBound, m_currentFrameIds.pastFrameAvailable,
+        // sameSample path is only meaningful for 60fps DI workflows.
+        // For 30i->30p (single-field) DI, forcing sameSample can select an invalid
+        // VEBOX surface config combination.
+        const bool sameSamplesForConfig = b60fpsDi ? m_sameSamples : false;
+        VEBOX_SURFACES_CONFIG cfg(b60fpsDi, caps.bSFC, sameSamplesForConfig, m_outOfBound, m_currentFrameIds.pastFrameAvailable,
             m_currentFrameIds.futureFrameAvailable, IsInterleaveFirstField(inputSurface->SampleType));
         auto it = m_veboxSurfaceConfigMap.find(cfg.value);
         if (m_veboxSurfaceConfigMap.end() == it)


### PR DESCRIPTION
## Summary

Fix a segfault (`SIGSEGV` / exit code 139) in `VpResourceManager::AssignVeboxResource()` that occurs when performing non-bob deinterlacing (normal/advanced mode, 60i->30p) on pure softlet platforms (Meteor Lake and later).

## Background

I originally encountered this crash while using [QSVEncC](https://github.com/rigaya/QSVEnc) (a hardware-accelerated video encoder leveraging Intel Quick Sync Video via libvpl) on an Intel Core Ultra 7 265K (ArrowLake-S) system running Ubuntu 22.04.5 LTS.
After discussions with @rigaya (the author of QSVEncC), we confirmed that the crash occurs in the Intel Media Driver, not in QSVEncC itself.

This is a significant regression for real-world use cases. In Japan, terrestrial TV broadcasts use MPEG-2 TS (1440x1080i, interlaced), and QSVEncC is widely used to transcode these recordings to H.264/H.265 with hardware-accelerated deinterlacing.
This workflow was working fine on older platforms (e.g., i5-9400 / Gen9, i5-12400 / ADL, Arc A310 / DG2), but is now completely broken on Meteor Lake and later platforms where the pure softlet VP adapter is used.

The bug also reproduces with FFmpeg's QSV VPP deinterlace filter (`vpp_qsv`), confirming this is not application-specific but a driver-level issue affecting any VA-API consumer that uses VEBOX-based 60i->30p deinterlacing.

We would appreciate prompt merging and backporting to distribution packages (e.g., `intel-media-va-driver-non-free` on Ubuntu), as this currently renders non-bob deinterlacing unusable on all MTL+ platforms.

## Root Cause

In `AssignVeboxResource()`, the `VEBOX_SURFACES_CONFIG` is constructed with `m_sameSamples` passed directly as the `sameSample` field. However, `InitSurfaceConfigMap()` only registers entries with `sameSample=true` for 60fps DI (`b64DI=true`) configurations. The 60i->30p section (lines 695-705, `b64DI=false`) has **no entries** with `sameSample=true`:

> note: the source code comments use "30i -> 30p" counting interlaced frames rather than fields, which is equivalent to "60i -> 30p" in broadcast terminology.

```
//30i -> 30p sfc Enable
AddSurfaceConfig(false, true,   false, ...);  // sameSample=false
AddSurfaceConfig(false, true,   false, ...);  // sameSample=false
...
//30i -> 30p sfc disable
AddSurfaceConfig(false, false,  false, ...);  // sameSample=false
...
```

When `b60fpsDi=false` (60i->30p) and `m_sameSamples=true`, the constructed config value has no matching entry in the map, causing `MOS_STATUS_INVALID_PARAMETER` to be returned and ultimately a segfault.

## Fix

Gate `m_sameSamples` by `b60fpsDi` so that `sameSample` is only set for 60fps DI (60i->60p) paths, where the surface config map does have matching entries:

```cpp
const bool sameSamplesForConfig = b60fpsDi ? m_sameSamples : false;
VEBOX_SURFACES_CONFIG cfg(b60fpsDi, caps.bSFC, sameSamplesForConfig, ...);
```

## Affected Platforms

This bug affects **all pure softlet VP adapter platforms** that go through `InitSurfaceConfigMap()`:

| Platform | Adapter | Affected |
|----------|---------|----------|
| TGL / ADL / RPL (Gen12) | `VpPipelineG12Adapter` (legacy hybrid) | No |
| DG2 / Arc (Xe HPM) | `VpPipelineAdapterXe_Hpm` (legacy hybrid) | No |
| **MTL** (Xe LPM+) | `VpPipelineAdapterXe_Lpm_Plus` (pure softlet) | **Yes** |
| **ARL** (Xe LPM+) | `VpPipelineAdapterXe_Lpm_Plus` (pure softlet) | **Yes** |
| **LNL** (Xe2 LPM) | `VpPipelineAdapterXe2_Lpm` (pure softlet) | **Yes** |
| **BMG** (Xe2 HPM) | `VpPipelineAdapterXe2_Hpm` (pure softlet) | **Yes** |
| **PTL** (Xe3 LPM) | `VpPipelineAdapterXe3_Lpm` (pure softlet) | **Yes** |
| **NVL** (Xe3P LPM) | `VpPipelineAdapterXe3P_Lpm` (pure softlet) | **Yes** |

Legacy hybrid adapters (TGL/ADL/RPL, DG2/Arc) inherit from both `VphalState*` and `VpPipelineAdapterLegacy`, using a different VEBOX resource management path that does not go through `InitSurfaceConfigMap()`. This is why the bug was not noticed on older platforms.

## Bug Origin

Introduced in commit f38f67cf6 (`[VP] 30pRefdi case Linux`, 2022-11-09), which added 60i->30p config entries to `InitSurfaceConfigMap()` but only with `sameSample=false` variants. The bug remained latent until the pure softlet VP adapter transition starting with Meteor Lake (late 2023).

The bug is **codec-agnostic**: `m_sameSamples` is computed from frame IDs and buffer object tracking in the VA-API layer, with no codec-specific logic. Any interlaced source (MPEG-2, H.264 interlaced, VC-1, etc.) can trigger it.

## Reproduction

**Hardware:** Intel Core Ultra 7 265K (ArrowLake-S, iGPU) — or any MTL+ platform
**OS:** Ubuntu 22.04.5 LTS, kernel 6.8.0-100-generic
**Driver:** intel-media-va-driver-non-free 25.2.4 (iHD 25.2.4)

**Input:** Any interlaced video file (e.g., MPEG-2 TS, 1440x1080i)

### QSVEncC 8.04

```bash
# Crashes (SIGSEGV / exit 139) — non-bob DI (60i->30p, b60fpsDi=false)
QSVEncC --avhw -i input.ts --vpp-deinterlace normal -o output.mp4

# Works fine — bob mode (60i->60p, b60fpsDi=true)
QSVEncC --avhw -i input.ts --vpp-deinterlace bob -o output.mp4
```

### FFmpeg 7.1

```bash
# Crashes (SIGSEGV / exit 139) — advanced DI at frame rate (60i->30p)
ffmpeg -hwaccel qsv -c:v mpeg2_qsv -i input.ts \
  -vf 'vpp_qsv=deinterlace=2:rate=frame' -c:v h264_qsv -an output.mp4

# Works fine — bob mode (60i->60p)
ffmpeg -hwaccel qsv -c:v mpeg2_qsv -i input.ts \
  -vf 'vpp_qsv=deinterlace=1' -c:v h264_qsv -an output.mp4

# Works fine — advanced DI at field rate (60i->60p, b60fpsDi=true)
ffmpeg -hwaccel qsv -c:v mpeg2_qsv -i input.ts \
  -vf 'deinterlace_qsv=mode=advanced' -c:v h264_qsv -an output.mp4
```

### Test Results

The "After Fix" column was tested by building `iHD_drv_video.so` from this branch and loading it via `LIBVA_DRIVERS_PATH` at runtime, on the same system listed above.

| Tool | DI Mode | Output | Before Fix (25.2.4) | After Fix (this branch) |
|------|---------|--------|---------------------|-------------------------|
| QSVEncC | normal | 30p | SIGSEGV (exit 139) | OK |
| QSVEncC | normal (avsw decode) | 30p | SIGSEGV (exit 139) | OK |
| QSVEncC | bob | 60p | OK | OK |
| FFmpeg | vpp_qsv advanced, rate=frame | 30p | SIGSEGV (exit 139) | OK |
| FFmpeg | vpp_qsv bob | 60p | OK | OK |
| FFmpeg | deinterlace_qsv advanced | 60p | OK | OK |

PS: This investigation and fix were performed using Codex (GPT-5.3-Codex) and Claude Code (Claude Opus 4.6).
However, it has been confirmed on an actual Core Ultra 7 265K machine that applying this patch to iHD_drv_video.so successfully avoids this error and enables deinterlacing.
Therefore, it is undeniable that this patch is effective, at the very least.