### PR TITLE
[Media Common] Fix alloc-dealloc mismatch in VAImageBufferType destru…

### DIFF
--- a/media_softlet/linux/common/codec/ddi/enc/ddi_encode_functions.cpp
+++ b/media_softlet/linux/common/codec/ddi/enc/ddi_encode_functions.cpp
@@ -653,7 +653,7 @@ VAStatus DdiEncodeFunctions::DestroyBuffer (
         case VAImageBufferType:
             if(buf->format == Media_Format_CPU)
             {
-                MOS_DeleteArray(buf->pData);
+                MOS_FreeMemory(buf->pData);
             }
             else
             {

--- a/media_softlet/linux/common/ddi/ddi_media_functions.cpp
+++ b/media_softlet/linux/common/ddi/ddi_media_functions.cpp
@@ -171,7 +171,7 @@ VAStatus DdiMediaFunctions::DestroyBuffer(
         case VAImageBufferType:
             if(buf->format == Media_Format_CPU)
             {
-                MOS_DeleteArray(buf->pData);
+                MOS_FreeMemory(buf->pData);
             }
             else
             {


### PR DESCRIPTION
…ction

buf->pData is allocated with MOS_AllocAndZeroMemory (malloc) in MediaLibvaUtilNext::CreateBuffer for Media_Format_CPU buffers, but freed with MOS_DeleteArray (operator delete[]) in DestroyBuffer. This is undefined behavior and flagged by AddressSanitizer as alloc-dealloc-mismatch. Use MOS_FreeMemory (free) to match.

Fixes #1985