### PR TITLE
Reorder delete of OsInterface and MhwInterface

### DIFF
--- a/media_driver/media_interface/media_interfaces_dg2/media_interfaces_dg2.cpp
+++ b/media_driver/media_interface/media_interfaces_dg2/media_interfaces_dg2.cpp
@@ -353,6 +353,12 @@ MOS_STATUS McpyDeviceXe_Hpm::Initialize(
     MhwInterfaces* mhwInterfaces = nullptr;
 
     auto deleterOnFailure = [&](bool deleteOsInterface, bool deleteMhwInterface){
+        if (deleteMhwInterface && mhwInterfaces != nullptr)
+        {
+            mhwInterfaces->Destroy();
+            MOS_Delete(mhwInterfaces);
+        }
+
         if (deleteOsInterface && osInterface != nullptr)
         {
             if (osInterface->pfnDestroy)
@@ -360,12 +366,6 @@ MOS_STATUS McpyDeviceXe_Hpm::Initialize(
                 osInterface->pfnDestroy(osInterface, false);
             }
             MOS_FreeMemory(osInterface);
-        }
-
-        if (deleteMhwInterface && mhwInterfaces != nullptr)
-        {
-            mhwInterfaces->Destroy();
-            MOS_Delete(mhwInterfaces);
         }
 
         MOS_Delete(device);

--- a/media_driver/media_interface/media_interfaces_m12_tgllp/media_interfaces_g12_tgllp.cpp
+++ b/media_driver/media_interface/media_interfaces_m12_tgllp/media_interfaces_g12_tgllp.cpp
@@ -415,6 +415,12 @@ MOS_STATUS McpyDeviceG12Tgllp::Initialize(
     MhwInterfaces* mhwInterfaces = nullptr;
 
     auto deleterOnFailure = [&](bool deleteOsInterface, bool deleteMhwInterface){
+        if (deleteMhwInterface && mhwInterfaces != nullptr)
+        {
+            mhwInterfaces->Destroy();
+            MOS_Delete(mhwInterfaces);
+        }
+
         if (deleteOsInterface && osInterface != nullptr)
         {
             if (osInterface->pfnDestroy)
@@ -422,12 +428,6 @@ MOS_STATUS McpyDeviceG12Tgllp::Initialize(
                 osInterface->pfnDestroy(osInterface, false);
             }
             MOS_FreeMemory(osInterface);
-        }
-
-        if (deleteMhwInterface && mhwInterfaces != nullptr)
-        {
-            mhwInterfaces->Destroy();
-            MOS_Delete(mhwInterfaces);
         }
 
         MOS_Delete(device);

--- a/media_driver/media_interface/media_interfaces_pvc/media_interfaces_pvc.cpp
+++ b/media_driver/media_interface/media_interfaces_pvc/media_interfaces_pvc.cpp
@@ -333,6 +333,12 @@ MOS_STATUS McpyDeviceXe_Xpm_Plus::Initialize(
     MhwInterfaces* mhwInterfaces = nullptr;
 
     auto deleterOnFailure = [&](bool deleteOsInterface, bool deleteMhwInterface){
+        if (deleteMhwInterface && mhwInterfaces != nullptr)
+        {
+            mhwInterfaces->Destroy();
+            MOS_Delete(mhwInterfaces);
+        }
+
         if (deleteOsInterface && osInterface != nullptr)
         {
             if (osInterface->pfnDestroy)
@@ -340,12 +346,6 @@ MOS_STATUS McpyDeviceXe_Xpm_Plus::Initialize(
                 osInterface->pfnDestroy(osInterface, false);
             }
             MOS_FreeMemory(osInterface);
-        }
-
-        if (deleteMhwInterface && mhwInterfaces != nullptr)
-        {
-            mhwInterfaces->Destroy();
-            MOS_Delete(mhwInterfaces);
         }
 
         MOS_Delete(device);

--- a/media_driver/media_interface/media_interfaces_xehp_sdv/media_interfaces_xehp_sdv.cpp
+++ b/media_driver/media_interface/media_interfaces_xehp_sdv/media_interfaces_xehp_sdv.cpp
@@ -311,6 +311,12 @@ MOS_STATUS McpyDeviceXe_Xpm::Initialize(
     MhwInterfaces* mhwInterfaces = nullptr;
 
     auto deleterOnFailure = [&](bool deleteOsInterface, bool deleteMhwInterface){
+        if (deleteMhwInterface && mhwInterfaces != nullptr)
+        {
+            mhwInterfaces->Destroy();
+            MOS_Delete(mhwInterfaces);
+        }
+
         if (deleteOsInterface && osInterface != nullptr)
         {
             if (osInterface->pfnDestroy)
@@ -318,12 +324,6 @@ MOS_STATUS McpyDeviceXe_Xpm::Initialize(
                 osInterface->pfnDestroy(osInterface, false);
             }
             MOS_FreeMemory(osInterface);
-        }
-
-        if (deleteMhwInterface && mhwInterfaces != nullptr)
-        {
-            mhwInterfaces->Destroy();
-            MOS_Delete(mhwInterfaces);
         }
 
         MOS_Delete(device);

--- a/media_softlet/agnostic/common/media_interfaces/media_interfaces_mcpy_next.h
+++ b/media_softlet/agnostic/common/media_interfaces/media_interfaces_mcpy_next.h
@@ -90,6 +90,12 @@ public:
         Mhw  *mhwInterfaces = nullptr;
 
         auto deleterOnFailure = [&](bool deleteOsInterface, bool deleteMhwInterface) {
+            if (deleteMhwInterface && mhwInterfaces != nullptr)
+            {
+                mhwInterfaces->Destroy();
+                MOS_Delete(mhwInterfaces);
+            }
+
             if (deleteOsInterface && osInterface != nullptr)
             {
                 if (osInterface->pfnDestroy)
@@ -97,12 +103,6 @@ public:
                     osInterface->pfnDestroy(osInterface, false);
                 }
                 MOS_FreeMemory(osInterface);
-            }
-
-            if (deleteMhwInterface && mhwInterfaces != nullptr)
-            {
-                mhwInterfaces->Destroy();
-                MOS_Delete(mhwInterfaces);
             }
 
             MOS_Delete(device);


### PR DESCRIPTION
MhwInterface depends on OsInterface and can not be deleted afterwards as dereferences of OsInterface will happen.

Fixes: https://github.com/intel/media-driver/issues/2001