### PR TITLE
[MHW] Fix GCC 16 dangling-pointer build error in AddSamplerStateData

### DIFF
--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_state_heap_xe_xpm.c
+++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_state_heap_xe_xpm.c
@@ -178,7 +178,18 @@ MOS_STATUS MHW_STATE_HEAP_INTERFACE_XE_XPM::AddSamplerStateData(
         mhw_state_heap_xe_xpm::SAMPLER_STATE_CMD          unormSampler;
         mhw_state_heap_xe_xpm::SAMPLER_INDIRECT_STATE_CMD indirectState;
 
+        // indirectState is scratch space consumed entirely within this block:
+        // SetSamplerState writes to it via pParam->Unorm.pIndirectState and the
+        // result is copied out below. The pointer never outlives indirectState,
+        // so suppress GCC's false-positive dangling-pointer warning (GCC 16+).
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
         pParam->Unorm.pIndirectState = &indirectState;
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
         MHW_MI_CHK_STATUS(SetSamplerState(&unormSampler, pParam));
 

--- a/media_driver/agnostic/gen11/hw/mhw_state_heap_g11.c
+++ b/media_driver/agnostic/gen11/hw/mhw_state_heap_g11.c
@@ -894,7 +894,18 @@ MOS_STATUS MHW_STATE_HEAP_INTERFACE_G11_X::AddSamplerStateData(
         mhw_state_heap_g11_X::SAMPLER_STATE_CMD          unormSampler;
         mhw_state_heap_g11_X::SAMPLER_INDIRECT_STATE_CMD indirectState;
 
+        // indirectState is scratch space consumed entirely within this block:
+        // SetSamplerState writes to it via pParam->Unorm.pIndirectState and the
+        // result is copied out below. The pointer never outlives indirectState,
+        // so suppress GCC's false-positive dangling-pointer warning (GCC 16+).
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
         pParam->Unorm.pIndirectState = &indirectState;
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
         MHW_MI_CHK_STATUS(SetSamplerState(&unormSampler, pParam));
 

--- a/media_driver/agnostic/gen12/hw/mhw_state_heap_g12.c
+++ b/media_driver/agnostic/gen12/hw/mhw_state_heap_g12.c
@@ -777,7 +777,18 @@ MOS_STATUS MHW_STATE_HEAP_INTERFACE_G12_X::AddSamplerStateData(
         mhw_state_heap_g12_X::SAMPLER_STATE_CMD          unormSampler;
         mhw_state_heap_g12_X::SAMPLER_INDIRECT_STATE_CMD indirectState;
 
+        // indirectState is scratch space consumed entirely within this block:
+        // SetSamplerState writes to it via pParam->Unorm.pIndirectState and the
+        // result is copied out below. The pointer never outlives indirectState,
+        // so suppress GCC's false-positive dangling-pointer warning (GCC 16+).
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
         pParam->Unorm.pIndirectState = &indirectState;
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
         MHW_MI_CHK_STATUS(SetSamplerState(&unormSampler, pParam));
 

--- a/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c
+++ b/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c
@@ -831,7 +831,18 @@ MOS_STATUS MHW_STATE_HEAP_INTERFACE_G8_X::AddSamplerStateData(
         mhw_state_heap_g8_X::SAMPLER_STATE_CMD          unormSampler;
         mhw_state_heap_g8_X::SAMPLER_INDIRECT_STATE_CMD indirectState;
 
+        // indirectState is scratch space consumed entirely within this block:
+        // SetSamplerState writes to it via pParam->Unorm.pIndirectState and the
+        // result is copied out below. The pointer never outlives indirectState,
+        // so suppress GCC's false-positive dangling-pointer warning (GCC 16+).
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
         pParam->Unorm.pIndirectState = &indirectState;
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
         MHW_MI_CHK_STATUS(SetSamplerState(&unormSampler, pParam));
 

--- a/media_driver/agnostic/gen9/hw/mhw_state_heap_g9.c
+++ b/media_driver/agnostic/gen9/hw/mhw_state_heap_g9.c
@@ -1035,7 +1035,18 @@ MOS_STATUS MHW_STATE_HEAP_INTERFACE_G9_X::AddSamplerStateData(
         mhw_state_heap_g9_X::SAMPLER_STATE_CMD          unormSampler;
         mhw_state_heap_g9_X::SAMPLER_INDIRECT_STATE_CMD indirectState;
 
+        // indirectState is scratch space consumed entirely within this block:
+        // SetSamplerState writes to it via pParam->Unorm.pIndirectState and the
+        // result is copied out below. The pointer never outlives indirectState,
+        // so suppress GCC's false-positive dangling-pointer warning (GCC 16+).
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
         pParam->Unorm.pIndirectState = &indirectState;
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
         MHW_MI_CHK_STATUS(SetSamplerState(&unormSampler, pParam));
 


### PR DESCRIPTION
GCC 16.1.0 fails the build with -Werror=dangling-pointer= because AddSamplerStateData stores the address of the local scratch buffer 'indirectState' into the caller-supplied pParam->Unorm.pIndirectState. The pointer is consumed entirely within indirectState's own scope (SetSamplerState writes through it, then the result is copied to the heap), so this is a false positive, but it breaks the build under -Werror.

Suppress the warning around the assignment in all affected state-heap implementations (gen8/gen9/gen11/gen12/Xe_XPM). The pragma is guarded to GCC >= 12 (where -Wdangling-pointer exists) and excluded for clang to avoid -Wpragmas / -Wunknown-warning-option errors on other toolchains.

Fixes #2008

