### PR TITLE
[DDI] Fix debug assert to check source surface bo in MediaSurfaceToMosResource

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_common.cpp
+++ b/media_driver/linux/common/ddi/media_libva_common.cpp
@@ -53,7 +53,7 @@ void DdiMedia_MediaSurfaceToMosResource(DDI_MEDIA_SURFACE *mediaSurface, MOS_RES
 {
     DDI_CHK_NULL(mediaSurface, "nullptr mediaSurface",);
     DDI_CHK_NULL(mosResource, "nullptr mosResource",);
-    DDI_ASSERT(mosResource->bo);
+    DDI_ASSERT(mediaSurface->bo);
 
     MosInterface::ConvertResourceFromDdi(mediaSurface, mosResource, OS_SPECIFIC_RESOURCE_SURFACE, 0);
 


### PR DESCRIPTION
## Summary
`DdiMedia_MediaSurfaceToMosResource` asserted on the destination
`mosResource->bo`, which is not yet populated at that point, instead of the
source `mediaSurface->bo`. With debug asserts enabled this fired on valid
usage. The assert now checks `mediaSurface->bo`, consistent with the sibling
`DdiMedia_MediaBufferToMosResource` which asserts `mediaBuffer->bo`.

## Issue
Fixes https://github.com/intel/media-driver/issues/1724