### PR TITLE
[DDI] Allow exporting 8-bit single-channel (Y8/400P) surfaces

### DIFF
--- a/media_driver/linux/common/ddi/media_libva.cpp
+++ b/media_driver/linux/common/ddi/media_libva.cpp
@@ -6995,6 +6995,8 @@ static uint32_t DdiMedia_GetDrmFormatOfSeparatePlane(uint32_t fourcc, int plane)
         case VA_FOURCC_422V:
         case VA_FOURCC_444P:
         case VA_FOURCC_Y800:
+        case VA_FOURCC_Y8:
+        case VA_FOURCC('4','0','0','P'):
         case VA_FOURCC_RGBP:
         case VA_FOURCC_BGRP:
             return DRM_FORMAT_R8;
@@ -7136,6 +7138,8 @@ static uint32_t DdiMedia_GetDrmFormatOfCompositeObject(uint32_t fourcc)
     case VA_FOURCC_Y416:
         return DRM_FORMAT_Y416;
     case VA_FOURCC_Y800:
+    case VA_FOURCC_Y8:
+    case VA_FOURCC('4','0','0','P'):
         return DRM_FORMAT_R8;
     case VA_FOURCC_P010:
         return DRM_FORMAT_P010;


### PR DESCRIPTION
## Summary
`DdiMedia_ExportSurfaceHandle` could not export 8-bit single-channel
(grayscale) surfaces because the DRM-format helpers only mapped
`VA_FOURCC_Y800`. This adds `VA_FOURCC_Y8` and `VA_FOURCC('4','0','0','P')`
as fallthroughs to the existing `Y800` case (all are 8-bit single channel →
`DRM_FORMAT_R8`) in both `DdiMedia_GetDrmFormatOfSeparatePlane` and
`DdiMedia_GetDrmFormatOfCompositeObject`.

`DdiMedia_MediaFormatToOsFormat` / `DdiMedia_OsFormatToMediaFormat` already
handle both fourccs, so only these two helpers needed updating.

## Issue
Fixes https://github.com/intel/media-driver/issues/1436