### PR TITLE
[Docs] Correct build description for Fedora/RHEL/SUSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Media driver contains three components as below
 - **Video processing** supports several popular features by hardware-based video processor([VEBox/SFC](https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-kbl-vol09-media_vebox.pdf)) and shader(media kernel) based solution together.
 
 Media driver supports below two builds
-- **Full Feature Build** is ***default*** driver build, which supports all feature by hardware accelerator and close source shaders(media kernel binaries). Most of OSVs(like RHEL/SUSE/fedora) are using this build.
-- **Free Kernel Build**, enables fully open source shaders(media kernels) and hardware features but the features would be limited.
+- **Full Feature Build** is ***default*** driver build, which supports all feature by hardware accelerator and close source shaders(media kernel binaries).
+- **Free Kernel Build**, enables fully open source shaders(media kernels) and hardware features but the features would be limited. Some OSVs ship this build by default for legal reasons; for example Fedora and RHEL(EPEL) package it as `intel-media-driver-free`, and provide the Full Feature Build only through third-party repositories (such as RPM Fusion non-free) or Intel's own graphics repository.
 
 About Ubuntu/Debian OSV, they provide [intel-media-va-driver-non-free](https://packages.ubuntu.com/search?keywords=intel-media-driver-non-free&searchon=sourcenames) (Full feature build) and [intel-media-va-driver](https://packages.ubuntu.com/search?keywords=intel-media-driver&searchon=sourcenames) (Free kernel build) two packages. ***Free*** here means open source kernel but not related to fee need to pay. You could refer to [build options](https://github.com/intel/media-driver?tab=readme-ov-file#build-options) for more detail.
 


### PR DESCRIPTION
## Summary
The README claimed that most OSVs like RHEL/SUSE/fedora use the default
**Full Feature Build**. That is inaccurate: Fedora and RHEL (EPEL) ship the
**Free Kernel Build**, packaged as `intel-media-driver-free`, which excludes
the closed-source media kernels (and therefore H.26x codec support). The
Full Feature Build is only available there through third-party repositories
(e.g. RPM Fusion non-free) or Intel's own graphics repository.

This drops the incorrect claim from the Full Feature Build bullet and
describes the actual packaging on the Free Kernel Build bullet.

## Issue
Fixes https://github.com/intel/media-driver/issues/1858

## Notes
Documentation-only change. SUSE is intentionally not called out with a
specific claim since its default build configuration was not verified; the
Ubuntu/Debian package split (`intel-media-va-driver` /
`intel-media-va-driver-non-free`) is already documented in the following
paragraph and is left unchanged.