### PR TITLE
[Build] Add missing <stdlib.h> include for atoi

### DIFF
--- a/cmrtlib/agnostic/share/cm_printf_host.cpp
+++ b/cmrtlib/agnostic/share/cm_printf_host.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "cm_include.h"
+#include <stdlib.h>
 #include "cm_printf_host.h"
 #include "cm_debug.h"
 #include "cm_mem.h"


### PR DESCRIPTION
PFParser::getToken() calls atoi() but cm_printf_host.cpp includes only project headers. The declaration has been arriving transitively through the standard library headers those pull in.

libc++ has been removing such transitive includes release by release. Under LLVM 22 with -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES=1 the path is gone and the file no longer compiles:

  cmrtlib/agnostic/share/cm_printf_host.cpp:226:43: error: use of
      undeclared identifier 'atoi'

Include <stdlib.h> directly. The call site is unqualified atoi() rather than std::atoi(), and <stdlib.h> is what the rest of the tree uses, so it is preferred here over <cstdlib>.
Sorry for PR message being much longer than patch.