### PR TITLE
[PTL] Add device ID 0xB084 for Arc Pro B390

### DIFF
--- a/media_softlet/linux/xe3_lpm/ddi/media_sysinfo_ptl.cpp
+++ b/media_softlet/linux/xe3_lpm/ddi/media_sysinfo_ptl.cpp
@@ -194,6 +194,9 @@ static bool ptlDeviceB082 = DeviceInfoFactory<GfxDeviceInfo>::
 static bool ptlDeviceB083 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0xB083, &ptlInfo);
 
+static bool ptlDeviceB084 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0xB084, &ptlInfo);
+
 static bool ptlDeviceB08F = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0xB08F, &ptlInfo);
 


### PR DESCRIPTION
Register PCI device ID 0xB084 (Intel Arc Pro B390) in the PTL device table so VAAPI initialization succeeds on this SKU.

Fixes: #2031