### PR TITLE
[cmrtlib] Update minimum required CMake version to 3.11

### DIFF
--- a/cmrtlib/linux/CMakeLists.txt
+++ b/cmrtlib/linux/CMakeLists.txt
@@ -18,7 +18,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.11)
 include (${CMAKE_CURRENT_LIST_DIR}/cmrt_utils.cmake)
 
 
@@ -90,9 +90,9 @@ set(CMRT_DEFINES ${CMRT_DEFINES} VPHAL ISTDLIB_UMD CM_RT_EXPORTS)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(CMRT_DEFINES ${CMRT_DEFINES} __CT__)
 endif()
-set_target_properties( igfxcmrt PROPERTIES 
-  FOLDER CM_RT 
-  COMPILE_DEFINITIONS "${CMRT_DEFINES}" 
+set_target_properties( igfxcmrt PROPERTIES
+  FOLDER CM_RT
+  COMPILE_DEFINITIONS "${CMRT_DEFINES}"
   )
 
 # set the version


### PR DESCRIPTION
Update the minimum required CMake version in
cmrtlib/linux/CMakeLists.txt from 2.8 to 3.11 to align with the project-wide CMake requirements established in the root and parent cmrtlib CMake configuration files.