### PR TITLE
media_softlet: register PTL device ID 0xB086

### DIFF
--- a/media_softlet/linux/xe3_lpm/ddi/media_sysinfo_ptl.cpp
+++ b/media_softlet/linux/xe3_lpm/ddi/media_sysinfo_ptl.cpp
@@ -197,6 +197,9 @@ static bool ptlDeviceB083 = DeviceInfoFactory<GfxDeviceInfo>::
 static bool ptlDeviceB084 = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0xB084, &ptlInfo);
 
+static bool ptlDeviceB086 = DeviceInfoFactory<GfxDeviceInfo>::
+    RegisterDevice(0xB086, &ptlInfo);
+
 static bool ptlDeviceB08F = DeviceInfoFactory<GfxDeviceInfo>::
     RegisterDevice(0xB08F, &ptlInfo);
 


### PR DESCRIPTION
## Summary
`0xB086` (Arc Pro B390, Panther Lake) is missing from the Panther Lake device
table in `media_sysinfo_ptl.cpp`, even though it falls in the middle of the
already-registered ID range (`0xB080`-`0xB084`, `0xB08F`-`0xB092`,
`0xB0A0`-`0xB0A2`, `0xB0B0`, `0xB0FF`) and is the same silicon/media family as
its neighbors.

Without this entry, `DeviceInfoFactory` has no match for the PCI ID, so VAAPI
initialization fails outright (`vaInitialize failed with error code 1`) on
any hardware reporting this ID.

## Fix
Register `0xB086` against the existing `ptlInfo` struct, same as the
surrounding device IDs.

## Test plan
- Confirmed `lspci -nn` reports `8086:b086` on the affected hardware
  (Panther Lake iGPU, kernel `xe` driver, "Arc Pro B390").
- Built this driver locally with the one-line patch applied.
- `vainfo` now succeeds and reports full decode/encode profile support
  (H.264, HEVC 8/10/12-bit incl. 4:2:2/4:4:4, VP8, VP9, AV1, VVC) where it
  previously failed with `iHD_drv_video.so init failed`.